### PR TITLE
add local cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+_out/
 Gopkg.lock
+cluster/.kubeconfig
+cluster/.kubectl
 cmd/client/client
-cmd/state-controller/state-controller
 cmd/policy-controller/policy-controller
+cmd/state-controller/state-controller
 tools/manifest-generator/manifest-generator

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,15 @@ build:
 	cd cmd/state-controller && go fmt && go vet && go build
 	cd cmd/policy-controller && go fmt && go vet && go build
 
-DOCKER_REPO=yuvalif
+IMAGE_REGISTRY ?= yuvalif
 
 docker: build
-	cd cmd/client && docker build -t $(DOCKER_REPO)/k8s-node-net-conf-client .
-	cd cmd/state-controller && docker build -t $(DOCKER_REPO)/k8s-node-network-state-controller .
+	cd cmd/client && docker build -t $(IMAGE_REGISTRY)/k8s-node-net-conf-client .
+	cd cmd/state-controller && docker build -t $(IMAGE_REGISTRY)/k8s-node-network-state-controller .
+
+docker-push: build
+	docker push $(IMAGE_REGISTRY)/k8s-node-net-conf-client
+	docker push $(IMAGE_REGISTRY)/k8s-node-network-state-controller
 
 generate:
 	hack/update-codegen.sh
@@ -56,4 +60,16 @@ clean-generate:
 clean-manifests:
 	rm -rf $(MANIFESTS_DESTINATION)
 
-.PHONY: build docker generate manifests test dep clean-dep clean-generate clean-manifests
+cluster-up:
+	./cluster/up.sh
+
+cluster-sync:
+	./cluster/sync.sh
+
+cluster-clean:
+	./cluster/clean.sh
+
+cluster-down:
+	./cluster/down.sh
+
+.PHONY: build docker docker-push generate manifests test dep clean-dep clean-generate clean-manifests cluster-up cluster-sync cluster-clean cluster-down

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+echo 'Cleaning up ...'
+
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/namespace.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/rbac.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/state-crd.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/configuration-policy-crd.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/state-controller-ds.yaml
+./cluster/kubectl.sh delete --ignore-not-found -f _out/manifests/state-client-pod.yaml
+
+sleep 2
+
+echo 'Done'

--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+source ${SCRIPT_ROOT}/cluster/gocli.sh
+
+if [[ -t 1 ]]; then
+    $gocli_interactive "$@"
+else
+    $gocli "$@"
+fi

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+source ./cluster/gocli.sh
+
+echo 'Bringing down cluster and client ...'
+$gocli rm
+
+# clean up unused docker volumes
+dangling_volumes="$(docker volume ls -qf dangling=true)"
+if [[ $? == 0 && -n "$dangling_volumes" ]]; then
+    echo 'Cleaning up docker and dangling volumes ...'
+    docker volume rm $dangling_volumes
+fi

--- a/cluster/gocli.sh
+++ b/cluster/gocli.sh
@@ -1,0 +1,3 @@
+gocli_image="kubevirtci/gocli@sha256:2ff1e9cddfa2cfdf268301a52d1a5ec252ace6908196609e001844e5458b746a"
+gocli="docker run --net=host --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock $gocli_image"
+gocli_interactive="docker run --net=host --privileged --rm -it -v /var/run/docker.sock:/var/run/docker.sock $gocli_image"

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+function _kubectl() {
+    export KUBECONFIG=./cluster/.kubeconfig
+    ./cluster/.kubectl "$@"
+}
+
+_kubectl "$@"

--- a/cluster/openshift-ovs-vsctl.yaml
+++ b/cluster/openshift-ovs-vsctl.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: ovs-vsctl-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: ovs-cni
+spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: ovs-cni
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: ovs-cni
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: ovs-vsctl
+        command:
+        - /bin/bash
+        - -c
+        - |
+          cp /usr/bin/ovs-vsctl /host/usr/bin/_ovs-vsctl
+          echo '#!/usr/bin/bash
+          _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
+          ' > /host/usr/bin/ovs-vsctl
+          chmod +x /host/usr/bin/ovs-vsctl
+          sleep infinity
+        image: docker.io/openshift/origin-node:v3.11.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: usrbin
+          mountPath: /host/usr/bin
+      volumes:
+        - name: usrbin
+          hostPath:
+            path: /usr/bin

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+registry_port=$(./cluster/cli.sh ports registry | tr -d '\r')
+registry=localhost:$registry_port
+
+IMAGE_REGISTRY=${registry} make docker docker-push
+MANIFESTS_DESTINATION='_out/manifests' IMAGE_REGISTRY='registry:5000' make manifests
+
+for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" 'sudo docker pull registry:5000/k8s-node-net-conf-client'
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" 'sudo docker pull registry:5000/k8s-node-network-state-controller'
+    # Temporary until image is updated with provisioner that sets this field
+    # This field is required by buildah tool
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" 'sudo sysctl -w user.max_user_namespaces=1024'
+done
+
+./cluster/kubectl.sh apply -f _out/manifests/namespace.yaml
+./cluster/kubectl.sh apply -f _out/manifests/rbac.yaml
+./cluster/kubectl.sh apply -f _out/manifests/state-crd.yaml
+./cluster/kubectl.sh apply -f _out/manifests/configuration-policy-crd.yaml

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+
+KUBERNETES_IMAGE="k8s-1.11.0@sha256:3412f158ecad53543c9b0aa8468db84dd043f01832a66f0db90327b7dc36a8e8"
+OPENSHIFT_IMAGE="os-3.11.0-crio@sha256:3f11a6f437fcdf2d70de4fcc31e0383656f994d0d05f9a83face114ea7254bc0"
+
+KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.11.0}
+KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
+KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
+
+if ! [[ $KUBEVIRT_NUM_NODES =~ '^-?[0-9]+$' ]] || [[ $KUBEVIRT_NUM_NODES -lt 1 ]] ; then
+    KUBEVIRT_NUM_NODES=1
+fi
+
+case "${KUBEVIRT_PROVIDER}" in
+    'k8s-1.11.0')
+        image=$KUBERNETES_IMAGE
+        ;;
+    'os-3.11.0')
+        image=$OPENSHIFT_IMAGE
+        ;;
+esac
+
+echo "Install cluster from image: ${image}"
+if [[ $image == $KUBERNETES_IMAGE ]]; then
+    # Run Kubernetes cluster image
+    ./cluster/cli.sh run --random-ports --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background kubevirtci/${image}
+
+    # Copy kubectl tool and configuration file
+    ./cluster/cli.sh scp /usr/bin/kubectl - > ./cluster/.kubectl
+    chmod u+x ./cluster/.kubectl
+    ./cluster/cli.sh scp /etc/kubernetes/admin.conf - > ./cluster/.kubeconfig
+
+    # Configure insecure access to Kubernetes cluster
+    cluster_port=$(./cluster/cli.sh ports k8s | tr -d '\r')
+    ./cluster/kubectl.sh config set-cluster kubernetes --server=https://127.0.0.1:$cluster_port
+    ./cluster/kubectl.sh config set-cluster kubernetes --insecure-skip-tls-verify=true
+elif [[ $image == $OPENSHIFT_IMAGE ]]; then
+    # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
+    if [ -z "${JOB_NAME}" ]; then
+        KUBEVIRT_PROVIDER_EXTRA_ARGS="${KUBEVIRT_PROVIDER_EXTRA_ARGS} --ocp-port 8443"
+    fi
+
+    # Run OpenShift cluster image
+    ./cluster/cli.sh run --random-ports --reverse --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}
+    ./cluster/cli.sh scp /etc/origin/master/admin.kubeconfig - > ./cluster/.kubeconfig
+    ./cluster/cli.sh ssh node01 -- sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
+    ./cluster/cli.sh ssh node01 -- sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
+
+    # Copy oc tool and configuration file
+    ./cluster/cli.sh scp /usr/bin/oc - > ./cluster/.kubectl
+    chmod u+x ./cluster/.kubectl
+    ./cluster/cli.sh scp /etc/origin/master/admin.kubeconfig - > ./cluster/.kubeconfig
+
+    # Update Kube config to support unsecured connection
+    cluster_port=$(./cluster/cli.sh ports ocp | tr -d '\r')
+    ./cluster/kubectl.sh config set-cluster node01:8443 --server=https://127.0.0.1:$cluster_port
+    ./cluster/kubectl.sh config set-cluster node01:8443 --insecure-skip-tls-verify=true
+fi
+
+echo 'Wait until all nodes are ready'
+until [[ $(./cluster/kubectl.sh get nodes --no-headers | wc -l) -eq $(./cluster/kubectl.sh get nodes --no-headers | grep ' Ready' | wc -l) ]]; do
+    sleep 1
+done
+
+echo 'Install Open vSwitch on nodes'
+if [[ $image == $KUBERNETES_IMAGE ]]; then
+    for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
+        ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo yum install -y http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-devel-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/dpdk/17.11/3.el7/x86_64/dpdk-17.11-3.el7.x86_64.rpm
+        ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl daemon-reload
+        ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl restart openvswitch
+    done
+elif [[ $image == $OPENSHIFT_IMAGE ]]; then
+    ./cluster/kubectl.sh create -f cluster/openshift-ovs-vsctl.yaml
+    until [[ $(./cluster/kubectl.sh -n kube-system get daemonsets | grep ovs-vsctl-amd64 | awk '{ if ($3 == $4) print "0"; else print "1"}') -eq "0" ]]; do
+        sleep 1
+    done
+fi
+
+echo 'Install NetworkManager on nodes'
+for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo yum install -y NetworkManager NetworkManager-ovs
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl daemon-reload
+    ./cluster/cli.sh ssh "node$(printf "%02d" ${i})" -- sudo systemctl restart NetworkManager
+done

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -15,7 +15,12 @@ Some other ```make``` targets:
  - ```test``` - will execute integrations tests
  - ```docker``` - will build docker images for all binaries
  - ```docker-push``` will upload them into a repo (by default it would be ```docker.io/nmstate```, so proper permissions will be needed)
- # Project Directory Structure
+ - ```cluster-up``` will start a local cluster that can be used for testing of kubernetes-nmstate
+ - ```cluster-sync``` will install kubernetes-nmstate namespace, RBAC on local cluster, it will build and push there images of kubernetes-nmstate so they can be later used for testing
+ - ```cluster-clean``` removes all resources related to kubernetes-nmstate from local cluster
+ - ```cluster-down``` tears down local cluster
+ 
+# Project Directory Structure
  ```
 ├── cmd                   # location of binaries main functions  as well as Dockerfiles
 │   ├── policy-handler


### PR DESCRIPTION
This patch provides local kubernetes/openshift cluster based on
kubevirtci. This cluster can be used to try out kubernetes-nmstate and
it will be later used also for functinal tests.