### PR TITLE
Fix security configuration on OpenShift

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -18,3 +18,6 @@ done
 ./cluster/kubectl.sh apply -f _out/manifests/rbac.yaml
 ./cluster/kubectl.sh apply -f _out/manifests/state-crd.yaml
 ./cluster/kubectl.sh apply -f _out/manifests/configuration-policy-crd.yaml
+if [[ $KUBEVIRT_PROVIDER =~ ^os-.*$ ]]; then
+    ./cluster/kubectl.sh apply -f _out/manifests/openshift-scc.yaml
+fi

--- a/manifests/examples/openshift-scc.yaml
+++ b/manifests/examples/openshift-scc.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: scc-nmstate-state-controller
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+runAsUser:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- 'secret'
+users:
+- system:serviceaccount:nmstate-default:nmstate-state-controller

--- a/manifests/examples/rbac.yaml
+++ b/manifests/examples/rbac.yaml
@@ -39,6 +39,12 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ''
+    resources:
       - events
     verbs:
       - update

--- a/manifests/examples/state-client-pod.yaml
+++ b/manifests/examples/state-client-pod.yaml
@@ -22,6 +22,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    securityContext:
+      privileged: true
   volumes:
   - name: dbus-socket
     hostPath:

--- a/manifests/examples/state-controller-ds.yaml
+++ b/manifests/examples/state-controller-ds.yaml
@@ -27,6 +27,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          securityContext:
+            privileged: true
       volumes:
       - name: dbus-socket
         hostPath:

--- a/manifests/templates/openshift-scc.yaml.in
+++ b/manifests/templates/openshift-scc.yaml.in
@@ -1,0 +1,19 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: scc-nmstate-state-controller
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+runAsUser:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- 'secret'
+users:
+- system:serviceaccount:{{ .Namespace }}:nmstate-state-controller

--- a/manifests/templates/rbac.yaml.in
+++ b/manifests/templates/rbac.yaml.in
@@ -39,6 +39,12 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ''
+    resources:
       - events
     verbs:
       - update

--- a/manifests/templates/state-client-pod.yaml.in
+++ b/manifests/templates/state-client-pod.yaml.in
@@ -22,6 +22,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    securityContext:
+      privileged: true
   volumes:
   - name: dbus-socket
     hostPath:

--- a/manifests/templates/state-controller-ds.yaml.in
+++ b/manifests/templates/state-controller-ds.yaml.in
@@ -27,6 +27,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          securityContext:
+            privileged: true
       volumes:
       - name: dbus-socket
         hostPath:


### PR DESCRIPTION
Add additional security configuration in order to allow kubernetes-nmstate to run on OpenShift clusters. With these changes, kubernetes-nmstate successfully reports network configuration on local OpenShift cluster.