### PR TITLE
create secondary NIC on local cluster nodes

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -7,6 +7,8 @@ KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.11.0}
 KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 
+SECONDARY_NICS_NUM=${SECONDARY_NICS_NUM:-1}
+
 if ! [[ $KUBEVIRT_NUM_NODES =~ '^-?[0-9]+$' ]] || [[ $KUBEVIRT_NUM_NODES -lt 1 ]] ; then
     KUBEVIRT_NUM_NODES=1
 fi
@@ -20,10 +22,15 @@ case "${KUBEVIRT_PROVIDER}" in
         ;;
 esac
 
+CREATE_SECONDARY_NICS=""
+for i in $(seq 1 ${SECONDARY_NICS_NUM}); do
+    CREATE_SECONDARY_NICS+=" -device virtio-net-pci,netdev=secondarynet$i -netdev tap,id=secondarynet$i,ifname=stap$i,script=no,downscript=no"
+done
+
 echo "Install cluster from image: ${image}"
 if [[ $image == $KUBERNETES_IMAGE ]]; then
     # Run Kubernetes cluster image
-    ./cluster/cli.sh run --random-ports --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background kubevirtci/${image}
+    ./cluster/cli.sh run --random-ports --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background --qemu-args "'${CREATE_SECONDARY_NICS}'" kubevirtci/${image}
 
     # Copy kubectl tool and configuration file
     ./cluster/cli.sh scp /usr/bin/kubectl - > ./cluster/.kubectl
@@ -41,7 +48,7 @@ elif [[ $image == $OPENSHIFT_IMAGE ]]; then
     fi
 
     # Run OpenShift cluster image
-    ./cluster/cli.sh run --random-ports --reverse --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}
+    ./cluster/cli.sh run --random-ports --reverse --nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --background --qemu-args "'${CREATE_SECONDARY_NICS}'" kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}
     ./cluster/cli.sh scp /etc/origin/master/admin.kubeconfig - > ./cluster/.kubeconfig
     ./cluster/cli.sh ssh node01 -- sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
     ./cluster/cli.sh ssh node01 -- sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,4 +1,5 @@
 # Prerequisites
+
 - git
 - golang
 - make
@@ -6,21 +7,25 @@
 - docker - if you want to build docker images, or run the dockerized tests
 - Should be able to communicate with a Kubernetes cluster for testing. Even if tests are run locally, it is needed, since the client needs to connect to Kubernetes in order to get/set the CRDs. Simple solution for that would be to run with a local [minikube](https://kubernetes.io/docs/setup/minikube/) cluster
 - [nmstate](https://nmstate.github.io/) - should be installed on the host to run any tests locally
+
 # Build
+
 First step is to clone this repo: ```git clone https://github.com/nmstate/kubernetes-nmstate.git```
 Then run ```make``` to build all binaries. 
 Some other ```make``` targets:
+
  - ```generate``` - call this after changes to the CRDs (```pkg/apis/nmstate.io/v1/types.go```). It will generate yaml files under ```manifests/generated```; generate client/controller code under ```pkg/client```; and generate deep-copy code for the CRD objects. ```clean-generate``` will delete the above files
  - ```dep``` - will update the ```vendors``` directory and ```Gopkg.lock``` file. ```clean-dep``` will delete them
  - ```test``` - will execute integrations tests
  - ```docker``` - will build docker images for all binaries
  - ```docker-push``` will upload them into a repo (by default it would be ```docker.io/nmstate```, so proper permissions will be needed)
- - ```cluster-up``` will start a local cluster that can be used for testing of kubernetes-nmstate
+ - ```cluster-up``` will start a local cluster that can be used for testing of kubernetes-nmstate. This target accepts several environment variables to adjust the cluster, some of them are `KUBEVIRT_NUM_NODES` (1 by default) to control number of cluster nodes, `KUBEVIRT_PROVIDER` (`k8s-1.11.0` by default, could also be `os-3.11.0`) to select type and version of the cluster, or `SECONDARY_NICS_NUM` (1 by default) to request secondary unused nics on cluster nodes
  - ```cluster-sync``` will install kubernetes-nmstate namespace, RBAC on local cluster, it will build and push there images of kubernetes-nmstate so they can be later used for testing
  - ```cluster-clean``` removes all resources related to kubernetes-nmstate from local cluster
  - ```cluster-down``` tears down local cluster
  
 # Project Directory Structure
+
  ```
 ├── cmd                   # location of binaries main functions  as well as Dockerfiles
 │   ├── policy-handler


### PR DESCRIPTION
In order to make testing and demoing easier, create secondary NIC
on local cluster nodes. This NIC is currently not connected to any
network. It can be used as a downlink of a bridge without affecting
node connectivity.