### PR TITLE
Fix state-controller-ds "-system-type"

### DIFF
--- a/manifests/examples/state-controller-ds.yaml
+++ b/manifests/examples/state-controller-ds.yaml
@@ -14,7 +14,7 @@ spec:
         - name: state-controller
           image: quay.io/nmstate/kubernetes-nmstate-state-handler:latest
           imagePullPolicy: Always
-          args: ["-execution-type", "client"]
+          args: ["-execution-type", "controller"]
           volumeMounts:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket

--- a/manifests/templates/state-controller-ds.yaml.in
+++ b/manifests/templates/state-controller-ds.yaml.in
@@ -14,7 +14,7 @@ spec:
         - name: state-controller
           image: {{ .ImageRegistry }}/{{ .StateHandlerImage }}:{{ .ImageTag }}
           imagePullPolicy: {{ .PullPolicy }}
-          args: ["-execution-type", "client"]
+          args: ["-execution-type", "controller"]
           volumeMounts:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket


### PR DESCRIPTION
The manifests to do a periodic report state were using the wrong
"-system-type" argument "client" used for one-shot, change this to
"controller allows it to run at a daemon set.