### PR TITLE
Use spec.nodeName to resolve hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@ _out/
 Gopkg.lock
 cluster/.kubeconfig
 cluster/.kubectl
-cmd/client/client
-cmd/policy-handler/policy-handler
-cmd/state-handler/state-handler
+bin/
 tools/manifest-generator/manifest-generator

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ check:
 	./hack/verify-codegen.sh
 	./hack/verify-fmt.sh
 	./hack/verify-vet.sh
+	./hack/verify-manifests.sh
 
 dep:
 	dep ensure -v

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,14 @@ PULL_POLICY ?= Always
 STATE_HANDLER_IMAGE ?= kubernetes-nmstate-state-handler
 POLICY_HANDLER_IMAGE ?= kubernetes-nmstate-configuration-policy-handler
 
-build:
-	cd cmd/state-handler && go fmt && go vet && go build
-	cd cmd/policy-handler && go fmt && go vet && go build
+commands = state-handler policy-handler
+
+$(commands):
+	go fmt ./cmd/$@
+	go vet ./cmd/$@
+	go build -o ./bin/$@ ./cmd/$@ 
+
+build: policy-handler state-handler
 
 docker:
 	docker build -f cmd/state-handler/Dockerfile -t $(IMAGE_REGISTRY)/$(STATE_HANDLER_IMAGE):$(IMAGE_TAG) .
@@ -66,4 +71,4 @@ cluster-clean:
 cluster-down:
 	./cluster/down.sh
 
-.PHONY: build docker docker-push generate manifests check dep clean-dep clean-generate clean-manifests cluster-up cluster-sync cluster-clean cluster-down
+.PHONY: policy-handler state-handler build docker docker-push generate manifests check dep clean-dep clean-generate clean-manifests cluster-up cluster-sync cluster-clean cluster-down

--- a/cmd/policy-handler/main.go
+++ b/cmd/policy-handler/main.go
@@ -54,11 +54,6 @@ func main() {
 	// get name space even if not set as commandline parameter
 	namespaceName := utils.GetNamespace(*namespace)
 
-	hostName := utils.GetHostName(*hostname, kubeClient, namespaceName)
-	if hostName == "" {
-		klog.Fatalf("Failed to get host name\n")
-	}
-
 	switch *executionType {
 	case "":
 		panic("execution-type must be specified")

--- a/docs/user-guide-state-reporting.md
+++ b/docs/user-guide-state-reporting.md
@@ -67,6 +67,10 @@ spec:
     - name: dbus-socket
       mountPath: /run/dbus/system_bus_socket
     env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     - name: POD_NAME
       valueFrom:
         fieldRef:
@@ -104,6 +108,10 @@ spec:
     - name: dbus-socket
       mountPath: /run/dbus/system_bus_socket
     env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef: 
+          fieldPath: spec.nodeName
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The nmstate Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+DIFFROOT="${SCRIPT_ROOT}/manifests/examples"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/manifests/examples"
+_tmp="${SCRIPT_ROOT}/_tmp"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+
+MANIFESTS_DESTINATIO=${_tmp}/manifests/examples make -C ${SCRIPT_ROOT} manifests
+echo "diffing ${DIFFROOT} against freshly generated manifests"
+ret=0
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run make manifests"
+  exit 1
+fi

--- a/manifests/examples/state-client-pod.yaml
+++ b/manifests/examples/state-client-pod.yaml
@@ -14,6 +14,10 @@ spec:
     - name: dbus-socket
       mountPath: /run/dbus/system_bus_socket
     env:
+     name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/manifests/examples/state-controller-ds.yaml
+++ b/manifests/examples/state-controller-ds.yaml
@@ -19,6 +19,10 @@ spec:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket
           env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/manifests/templates/state-client-pod.yaml.in
+++ b/manifests/templates/state-client-pod.yaml.in
@@ -14,6 +14,10 @@ spec:
     - name: dbus-socket
       mountPath: /run/dbus/system_bus_socket
     env:
+     name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/manifests/templates/state-controller-ds.yaml.in
+++ b/manifests/templates/state-controller-ds.yaml.in
@@ -19,6 +19,10 @@ spec:
           - name: dbus-socket
             mountPath: /run/dbus/system_bus_socket
           env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,34 +41,6 @@ func IsStateApplicable(kubeClient k8sclient.Interface, state *v1.NodeNetworkStat
 	return false
 }
 
-// GetHostName return the host name from the input
-// if not set, it tries to read from an k8s based on
-// env variable holding the pod's name, and if not possible either
-// tries to read it from the OS
-func GetHostName(hostname string, kubeClient k8sclient.Interface, ns string) string {
-	if hostname != "" {
-		return hostname
-	}
-
-	cause := "missing POD_NAME env variable"
-	podName := os.Getenv("POD_NAME")
-	if podName != "" {
-		pod, err := kubeClient.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
-		if err == nil {
-			return pod.Status.HostIP
-		}
-		cause = err.Error()
-	}
-
-	name, err := os.Hostname()
-	if err != nil {
-		fmt.Printf("Error: failed to get hostname from OS: %v\n", err)
-	}
-
-	fmt.Printf("Warning: hostname is taken from OS, this may be incorrect when running inside a container/pod: %s\n", cause)
-	return name
-}
-
 // GetNamespace trying to read the namespace from the input
 // if not set, it tries to read from an environment variable, and if not set there either
 // it returns "default"


### PR DESCRIPTION
To be able to do operations like "get nodenetworkstate node01" you need the
controller hostName to be the PODs nodeName not the HostIP, also keep
the previous used options (HostIP and os.Hostname()) as fallbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/kubernetes-nmstate/34)
<!-- Reviewable:end -->
