### PR TITLE
Use fedora RPMs to install nmstate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ build:
 	cd cmd/state-handler && go fmt && go vet && go build
 	cd cmd/policy-handler && go fmt && go vet && go build
 
-docker:
+docker-state-handler:
 	docker build -f cmd/state-handler/Dockerfile -t $(IMAGE_REGISTRY)/$(STATE_HANDLER_IMAGE):$(IMAGE_TAG) .
+
+docker-policy-handler:
 	docker build -f cmd/policy-handler/Dockerfile -t $(IMAGE_REGISTRY)/$(POLICY_HANDLER_IMAGE):$(IMAGE_TAG) .
+
+docker: docker-state-handler docker-policy-handler
 
 docker-push:
 	docker push $(IMAGE_REGISTRY)/$(STATE_HANDLER_IMAGE):$(IMAGE_TAG)

--- a/cmd/state-handler/Dockerfile
+++ b/cmd/state-handler/Dockerfile
@@ -4,19 +4,10 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/state-handler github.com/nmstate/kubernetes-nmstate/cmd/state-handler
 
 FROM centos:7
-RUN yum -y install epel-release && \
+RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-el7/repo/epel-7/nmstate-nmstate-el7-epel-7.repo && \
+    yum -y install epel-release && \
     yum -y update && \
-    yum -y install \
-        python2-pip \
-        git \
-        python2-pyyaml \
-        python2-six \
-        python-gobject-base \
-        python-jsonschema \
-        python-setuptools \
-        NetworkManager-libnm \
-        && \
+    yum -y install nmstate && \
     yum clean all
-RUN pip install git+https://github.com/nmstate/nmstate@d2afe631c39de5b007815789e12a2e6dab447efb
 COPY --from=builder /bin/state-handler /
 ENTRYPOINT ["/state-handler"]


### PR DESCRIPTION
Maybe we can use fedora RPMs instead of pip and github, right now is nmstate v0.0.4

Related to #41