### PR TITLE
Run a nmstatectl health check daemonset start

### DIFF
--- a/cmd/state-handler/main.go
+++ b/cmd/state-handler/main.go
@@ -54,7 +54,10 @@ func main() {
 			*hostname = envHostname
 		}
 	}
-
+	if err := nmstatectl.Check(); err != nil {
+		klog.Errorf("Error running nmstatectl: %v,  check that NetworkManager is running at nodes\n", err)
+		os.Exit(1)
+	}
 	switch *executionType {
 	case "":
 		panic("execution-type must be specified")

--- a/pkg/nmstatectl/converter.go
+++ b/pkg/nmstatectl/converter.go
@@ -11,6 +11,14 @@ import (
 
 const nmstateCommand = "nmstatectl"
 
+func Check() error {
+	cmd := exec.Command(nmstateCommand, "show")
+	if buff, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s\n%v", string(buff), err)
+	}
+	return nil
+}
+
 // Show is populating the passed ConfAndOperationalState object from the output of "nmstatectl show"
 func Show(currentState *v1.ConfAndOperationalState) (err error) {
 	cmd := exec.Command(nmstateCommand, "show", "--json")


### PR DESCRIPTION
To be sure that k8s host nodes has installed and running the needed
pre-requisites.

Closes #50

Error output:

```
Traceback (most recent call last):
  File "/usr/bin/nmstatectl", line 9, in <module>
    load_entry_point('nmstate==0.0.4', 'console_scripts', 'nmstatectl')()
  File "/usr/lib/python2.7/site-packages/nmstatectl/nmstatectl.py", line 54, in main
    return args.func(args)
  File "/usr/lib/python2.7/site-packages/nmstatectl/nmstatectl.py", line 125, in show
    state = _filter_state(netinfo.show(), args.only)
  File "/usr/lib/python2.7/site-packages/libnmstate/netinfo.py", line 35, in show
    report = {Constants.INTERFACES: interfaces()}
  File "/usr/lib/python2.7/site-packages/libnmstate/netinfo.py", line 56, in interfaces
    for dev in nm.device.list_devices()]
  File "/usr/lib/python2.7/site-packages/libnmstate/nm/device.py", line 345, in list_devices
    client = nmclient.client(refresh=True)
  File "/usr/lib/python2.7/site-packages/libnmstate/nm/nmclient.py", line 48, in client
    _nmclient = NM.Client.new(None)
GLib.Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Rejected send message, 1 matched rules; type="method_call", sender=":1.543" (uid=0 pid=17904 comm="/usr/bin/python2 /usr/bin/nmstatectl show ") interface="org.freedesktop.DBus.ObjectManager" member="GetManagedObjects" error name="(unset)" requested_reply="0" destination=":1.76" (uid=0 pid=3209 comm="/usr/sbin/NetworkManager --no-daemon ") (9)
E0528 05:56:20.012171       1 main.go:58] 
Error running nmstatectl: exit status 1,  check that NetworkManager is running at nodes

```
