### PR TITLE
Pin nmstate to 0.0.5

### DIFF
--- a/cmd/state-handler/Dockerfile
+++ b/cmd/state-handler/Dockerfile
@@ -4,10 +4,11 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/state-handler github.com/nmstate/kubernetes-nmstate/cmd/state-handler
 
 FROM centos:7
-RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-el7/repo/epel-7/nmstate-nmstate-el7-epel-7.repo && \
-    yum -y install epel-release && \
+RUN yum -y install epel-release && \
     yum -y update && \
-    yum -y install nmstate && \
+    yum -y install \
+        https://kojipkgs.fedoraproject.org//packages/nmstate/0.0.5/1.el7/noarch/python2-libnmstate-0.0.5-1.el7.noarch.rpm \
+        https://kojipkgs.fedoraproject.org//packages/nmstate/0.0.5/1.el7/noarch/nmstate-0.0.5-1.el7.noarch.rpm && \
     yum clean all
 COPY --from=builder /bin/state-handler /
 ENTRYPOINT ["/state-handler"]


### PR DESCRIPTION
The 0.0.6 version was failing at pkg_resources.DistributionNotFound: dbus-python

Closes #69

Signed-off-by: Quique Llorente <quique.llorente@gmail.com>