### PR TITLE
Add handler

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -2,7 +2,7 @@
 
 kubectl() { cluster/kubectl.sh "$@"; }
 
-export CLUSTER_PROVIDER=$TARGET
+export KUBEVIRT_PROVIDER=$TARGET
 
 # Make sure that the VM is properly shut down on exit
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP

--- a/build/handler/Dockerfile
+++ b/build/handler/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+
+RUN yum -y install epel-release && \
+    yum -y update && \
+    yum -y install \
+        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
+        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
+    yum clean all
+CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/deploy/handler.yaml
+++ b/deploy/handler.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nmstate-handler
+spec:
+  selector:
+    matchLabels:
+      nmstate.io: nmstate-handler
+  template:
+    metadata:
+      labels:
+        nmstate.io: nmstate-handler
+    spec:
+      serviceAccountName: kubernetes-nmstate
+      containers:
+        - name: nmstate-handler
+          image: REPLACE_IMAGE
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: dbus-socket
+            mountPath: /run/dbus/system_bus_socket
+          securityContext:
+            privileged: true
+      volumes:
+      - name: dbus-socket
+        hostPath:
+          path: /run/dbus/system_bus_socket
+          type: Socket

--- a/deploy/openshift-scc.yaml
+++ b/deploy/openshift-scc.yaml
@@ -1,0 +1,19 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: scc-nmstate-state-controller
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+runAsUser:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- 'secret'
+users:
+- system:serviceaccount:default:kubernetes-nmstate

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,7 +8,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
   - endpoints
   - persistentvolumeclaims
@@ -17,6 +16,19 @@ rules:
   - secrets
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION

    Add nmstate-handler as a proxy to nodes
    
    It's a privileged DaemonSet that will have nmstate library installed
    with this in place nmstate-manager can exec into nmstate-handler pods
    and run nmstatectl to retrieve and set network config.
    
    Added make target "make cluster-sync-handler" to just sync the handler
