### PR TITLE
Run automation/test.sh with no colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GINKGO_ARGS ?= -v -r --randomizeAllSpecs --randomizeSuites --race --trace $(GINK
 GINKGO?= go run ./vendor/github.com/onsi/ginkgo/ginkgo
 
 E2E_TEST_EXTRA_ARGS ?=
-E2E_TEST_ARGS ?= -test.v -ginkgo.v$(E2E_TEST_EXTRA_ARGS)
+E2E_TEST_ARGS ?= $(strip -test.v -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 
 KUBECONFIG ?= ./cluster/.kubeconfig
 # TODO: use operator-sdk from vendor/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ GINKGO_EXTRA_ARGS ?=
 GINKGO_ARGS ?= -v -r --randomizeAllSpecs --randomizeSuites --race --trace $(GINKGO_EXTRA_ARGS)
 GINKGO?= go run ./vendor/github.com/onsi/ginkgo/ginkgo
 
+E2E_TEST_EXTRA_ARGS ?=
+E2E_TEST_ARGS ?= -test.v -ginkgo.v$(E2E_TEST_EXTRA_ARGS)
+
 KUBECONFIG ?= ./cluster/.kubeconfig
 # TODO: use operator-sdk from vendor/
 OPERATOR_SDK ?= go run ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
@@ -66,14 +69,14 @@ test/local/e2e:
 			--namespace default \
 			--global-manifest deploy/crds/nmstate_v1_nodenetworkstate_crd.yaml \
 			--up-local \
-			--go-test-flags "-test.v -ginkgo.v"
+			--go-test-flags "$(E2E_TEST_ARGS)"
 
 test/cluster/e2e:
 	$(OPERATOR_SDK) test local ./test/e2e \
 		--kubeconfig $(KUBECONFIG) \
 		--namespace default \
 		--no-setup \
-		--go-test-flags "-test.v -ginkgo.v"
+		--go-test-flags "$(E2E_TEST_ARGS)"
 
 
 $(local_handler_manifest): deploy/handler.yaml

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -9,4 +9,5 @@ trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP
 
 make cluster-down
 make cluster-up
-make cluster-sync test/cluster/e2e
+make cluster-sync
+make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor" test/cluster/e2e


### PR DESCRIPTION
There is no color support at jenkins and the output is kind of messy,
with this patch we maintain color at local dev but remove it at
jenkins run.
