### PR TITLE
Redirect nmcli device show to null

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -72,4 +72,4 @@ docker exec $node01_id ssh.sh sudo yum install -y NetworkManager
 docker exec $node01_id ssh.sh sudo systemctl daemon-reload
 docker exec $node01_id ssh.sh sudo systemctl restart NetworkManager
 echo 'Check NetworkManager is working fine'
-docker exec $node01_id ssh.sh nmcli device show
+docker exec $node01_id ssh.sh nmcli device show > /dev/null


### PR DESCRIPTION
The cluster/up.sh script was showing the whole list of
network devices from node, we just one to run the command
to ensure that NetworkManager is working fine.