### PR TITLE
Increase to 5 seconds update timeout

### DIFF
--- a/test/e2e/nodes_test.go
+++ b/test/e2e/nodes_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/test/e2e/nodes_test.go
+++ b/test/e2e/nodes_test.go
@@ -13,6 +13,10 @@ import (
 
 var _ = Describe("Nodes", func() {
 	Context("when nodes are up", func() {
+		var (
+			timeout  = 5 * time.Second
+			interval = 1 * time.Second
+		)
 		It("should have NodeNetworkState with currentState for each node", func() {
 			for _, node := range nodes {
 				key := types.NamespacedName{Namespace: namespace, Name: node}
@@ -20,7 +24,7 @@ var _ = Describe("Nodes", func() {
 				Eventually(func() nmstatev1.State {
 					currentStateYaml = nodeNetworkState(key).Status.CurrentState
 					return currentStateYaml
-				}).ShouldNot(BeEmpty(), "Node %s should have currentState", node)
+				}, timeout, interval).ShouldNot(BeEmpty(), "Node %s should have currentState", node)
 
 				By("unmarshal state yaml into unstructured golang")
 				var currentState map[string]interface{}


### PR DESCRIPTION
Between node controller creation and nodenetworkstate controller update
there are some time, we should wait for more.

Signed-off-by: Quique Llorente <quique.llorente@gmail.com>