### PR TITLE
Refresh NodeNetworkState every 5 seconds

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	log         = logf.Log.WithName("controller_nodenetworkstate")
+	log         = logf.Log.WithName("controller_node")
 	nodeRefresh = 5 * time.Second
 )
 

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +21,10 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
 )
 
-var log = logf.Log.WithName("controller_node")
+var (
+	log         = logf.Log.WithName("controller_nodenetworkstate")
+	nodeRefresh = 5 * time.Second
+)
 
 // Add creates a new Node Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -112,5 +116,5 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 	}
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: nodeRefresh}, nil
 }

--- a/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
+++ b/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
@@ -56,14 +56,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			return false
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			eventIsForThisNode = nmstate.EventIsForThisNode(updateEvent.MetaNew)
+			eventIsForThisNode := nmstate.EventIsForThisNode(updateEvent.MetaNew)
 
 			// As described [1] if we want to ignore reconcile of status update we have
 			// to check generation since it does not change on status updates also force
 			// reconcile if finalizers have changes
 			// [1] https://blog.openshift.com/kubernetes-operators-best-practices/
-			generationIsDifferent = updateEvent.MetaNew.GetGeneration() != updateEvent.MetaOld.GetGeneration()
-			finalizersAreDifferent = !reflect.DeepEqual(updateEvent.MetaNew.GetFinalizers(), updateEvent.MetaOld.GetFinalizers())
+			generationIsDifferent := updateEvent.MetaNew.GetGeneration() != updateEvent.MetaOld.GetGeneration()
+			finalizersAreDifferent := !reflect.DeepEqual(updateEvent.MetaNew.GetFinalizers(), updateEvent.MetaOld.GetFinalizers())
 
 			return eventIsForThisNode && (generationIsDifferent || finalizersAreDifferent)
 		},

--- a/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
+++ b/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
@@ -3,6 +3,7 @@ package nodenetworkstate
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1"
@@ -55,7 +56,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			return false
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			return nmstate.EventIsForThisNode(updateEvent.MetaNew)
+			return nmstate.EventIsForThisNode(updateEvent.MetaNew) &&
+				(updateEvent.MetaNew.GetGeneration() != updateEvent.MetaOld.GetGeneration() ||
+					!reflect.DeepEqual(updateEvent.MetaNew.GetFinalizers(), updateEvent.MetaOld.GetFinalizers()))
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
 			return nmstate.EventIsForThisNode(genericEvent.Meta)

--- a/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
+++ b/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
@@ -3,6 +3,7 @@ package nodenetworkstate
 import (
 	"context"
 	"fmt"
+	"time"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +21,10 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
 )
 
-var log = logf.Log.WithName("controller_nodenetworkstate")
+var (
+	log                     = logf.Log.WithName("controller_nodenetworkstate")
+	nodenetworkstateRefresh = 5 * time.Second
+)
 
 // Add creates a new NodeNetworkState Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -106,5 +110,5 @@ func (r *ReconcileNodeNetworkState) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, fmt.Errorf("error reconciling nodenetworkstate: %v", err)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: nodenetworkstateRefresh}, nil
 }

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -64,7 +64,7 @@ func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1.NodeNe
 		CurrentState: nmstatev1.State(currentState),
 	}
 
-	err = client.Status().Update(context.TODO(), nodeNetworkState)
+	err = client.Status().Update(context.Background(), nodeNetworkState)
 	if err != nil {
 		return fmt.Errorf("error updating status of NodeNetworkState: %v", err)
 	}

--- a/test/e2e/nodes_test.go
+++ b/test/e2e/nodes_test.go
@@ -1,45 +1,24 @@
 package e2e
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	yaml "sigs.k8s.io/yaml"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1"
 )
 
 var _ = Describe("Nodes", func() {
 	Context("when are up", func() {
-		var (
-			timeout  = 10 * time.Second
-			interval = 1 * time.Second
-		)
 		It("should have NodeNetworkState with currentState for each node", func() {
 			for _, node := range nodes {
-				key := types.NamespacedName{Namespace: namespace, Name: node}
 				var currentStateYaml nmstatev1.State
-				Eventually(func() nmstatev1.State {
-					currentStateYaml = nodeNetworkState(key).Status.CurrentState
-					return currentStateYaml
-				}, timeout, interval).ShouldNot(BeEmpty(), "Node %s should have currentState", node)
+				currentState(namespace, node, &currentStateYaml).ShouldNot(BeEmpty())
 
-				By("unmarshal state yaml into unstructured golang")
-				var currentState map[string]interface{}
-				err := yaml.Unmarshal(currentStateYaml, &currentState)
-				Expect(err).ToNot(HaveOccurred(), "Should parse correctly yaml: %s", currentStateYaml)
-
-				interfaces := currentState["interfaces"].([]interface{})
+				interfaces := interfaces(currentStateYaml)
 				Expect(interfaces).ToNot(BeEmpty(), "Node %s should have network interfaces", node)
 
 				obtainedInterfaces := interfacesName(interfaces)
-				Expect(obtainedInterfaces).To(SatisfyAll(
-					ContainElement("eth0"),
-				))
+				Expect(obtainedInterfaces).To(ContainElement("eth0"))
 			}
 		})
 		Context("and node network state is deleted", func() {
@@ -48,12 +27,35 @@ var _ = Describe("Nodes", func() {
 			})
 			It("should recreate it with currentState", func() {
 				for _, node := range nodes {
-					key := types.NamespacedName{Namespace: namespace, Name: node}
 					var currentStateYaml nmstatev1.State
-					Eventually(func() nmstatev1.State {
-						currentStateYaml = nodeNetworkState(key).Status.CurrentState
-						return currentStateYaml
-					}, timeout, interval).ShouldNot(BeEmpty(), "Node %s should have currentState", node)
+					currentState(namespace, node, &currentStateYaml).ShouldNot(BeEmpty())
+
+					interfaces := interfaces(currentStateYaml)
+					Expect(interfaces).ToNot(BeEmpty(), "Node %s should have network interfaces", node)
+				}
+			})
+		})
+		Context("and new interface is configured", func() {
+			var (
+				expectedDummyName = "dummy0"
+			)
+			BeforeEach(func() {
+				createDummy(nodes, expectedDummyName)
+			})
+			AfterEach(func() {
+				deleteDummy(nodes, expectedDummyName)
+			})
+			It("should update node network state with it", func() {
+				for _, node := range nodes {
+					Eventually(func() []string {
+						var currentStateYaml nmstatev1.State
+						currentState(namespace, node, &currentStateYaml).ShouldNot(BeEmpty())
+
+						interfaces := interfaces(currentStateYaml)
+						Expect(interfaces).ToNot(BeEmpty(), "Node %s should have network interfaces", node)
+
+						return interfacesName(interfaces)
+					}, ReadTimeout, ReadInterval).Should(ContainElement(expectedDummyName))
 				}
 			})
 		})

--- a/test/e2e/nodes_test.go
+++ b/test/e2e/nodes_test.go
@@ -14,12 +14,9 @@ import (
 )
 
 var _ = Describe("Nodes", func() {
-	Context("when nodes are up", func() {
-		AfterEach(func() {
-			deleteNodeNeworkStates()
-		})
+	Context("when are up", func() {
 		var (
-			timeout  = 5 * time.Second
+			timeout  = 10 * time.Second
 			interval = 1 * time.Second
 		)
 		It("should have NodeNetworkState with currentState for each node", func() {
@@ -44,6 +41,21 @@ var _ = Describe("Nodes", func() {
 					ContainElement("eth0"),
 				))
 			}
+		})
+		Context("and node network state is deleted", func() {
+			BeforeEach(func() {
+				deleteNodeNeworkStates()
+			})
+			It("should recreate it with currentState", func() {
+				for _, node := range nodes {
+					key := types.NamespacedName{Namespace: namespace, Name: node}
+					var currentStateYaml nmstatev1.State
+					Eventually(func() nmstatev1.State {
+						currentStateYaml = nodeNetworkState(key).Status.CurrentState
+						return currentStateYaml
+					}, timeout, interval).ShouldNot(BeEmpty(), "Node %s should have currentState", node)
+				}
+			})
 		})
 	})
 })


### PR DESCRIPTION
This PR include the following functionalit:
- re-create NodeNetworkState in case it's deleted
- refresh currentState every 5 seconds from nmstatectl show
- filter NodeNetworkState updates by generation and finalizers so we don't reconcile on status updates.