### PR TITLE
Set k8s-1.13.3 as the default provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ E2E_TEST_ARGS ?= $(strip -test.v -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 OPERATOR_SDK ?= go run ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
 LOCAL_REGISTRY ?= registry:5000
 
-export KUBEVIRT_PROVIDER ?= k8s-1.11.0
+export KUBEVIRT_PROVIDER ?= k8s-1.13.3
 export KUBEVIRT_NUM_NODES ?= 1
 
 CLUSTER_DIR ?= kubevirtci/cluster-up/

--- a/automation/check-patch.k8s-1.13.3.mounts
+++ b/automation/check-patch.k8s-1.13.3.mounts
@@ -1,0 +1,1 @@
+check-patch.mounts

--- a/automation/check-patch.k8s-1.13.3.packages
+++ b/automation/check-patch.k8s-1.13.3.packages
@@ -1,0 +1,1 @@
+check-patch.packages

--- a/automation/check-patch.k8s-1.13.3.sh
+++ b/automation/check-patch.k8s-1.13.3.sh
@@ -1,0 +1,1 @@
+check-patch.sh

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,5 +1,6 @@
 sub-stages:
   - k8s-1.11.0
+  - k8s-1.13.3
   - os-3.11.0
 
 runtime_requirements:


### PR DESCRIPTION
The kubevirtci uses k8s-1.13.3 as the default let's do the same
at this project so ./kubevirtci/cluster-up/kubectl.sh works
out of the box.

Signed-off-by: Quique Llorente <ellorent@redhat.com>