### PR TITLE
Rename test/cluster/e2e to test/e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,7 @@ push-handler: handler
 unit-test:
 	$(GINKGO) $(GINKGO_ARGS) ./pkg/
 
-test/local/e2e:
-	OPERATOR_NAME=nmstate-handler\
-		$(OPERATOR_SDK) test local ./test/e2e \
-			--kubeconfig $(KUBECONFIG) \
-			--namespace default \
-			--global-manifest deploy/crds/nmstate_v1_nodenetworkstate_crd.yaml \
-			--up-local \
-			--go-test-flags "$(E2E_TEST_ARGS)"
-
-test/cluster/e2e:
+test/e2e:
 	$(OPERATOR_SDK) test local ./test/e2e \
 		--kubeconfig $(KUBECONFIG) \
 		--namespace default \
@@ -127,8 +118,7 @@ cluster-sync: cluster-sync-handler
 	handler \
 	push-handler \
 	test-unit \
-	test/local/e2e \
-	test/cluster/e2e \
+	test/e2e \
 	cluster-up \
 	cluster-down \
 	cluster-sync-resources \

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -16,4 +16,4 @@ trap teardown EXIT SIGINT SIGTERM SIGSTOP
 make cluster-down
 make cluster-up
 make cluster-sync
-make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor" test/cluster/e2e
+make E2E_TEST_EXTRA_ARGS="-ginkgo.noColor" test/e2e


### PR DESCRIPTION
Also remove test/local/e2e we cannot run locally the operator
now that it's calling nmstate directly.

Signed-off-by: Quique Llorente <ellorent@redhat.com>