### PR TITLE
Filter e2e tests k8s logs by time

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 
@@ -17,6 +18,7 @@ var (
 	t         *testing.T
 	namespace string
 	nodes     = []string{"node01"} // TODO: Get it from cluster
+	startTime time.Time
 )
 
 var _ = BeforeSuite(func() {
@@ -38,8 +40,9 @@ func TestE2E(tapi *testing.T) {
 
 var _ = BeforeEach(func() {
 	_, namespace = prepare(t)
+	startTime = time.Now()
 })
 
 var _ = AfterEach(func() {
-	writePodsLogs(namespace, GinkgoWriter)
+	writePodsLogs(namespace, startTime, GinkgoWriter)
 })

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -30,11 +30,13 @@ import (
 const ReadTimeout = 15 * time.Second
 const ReadInterval = 1 * time.Second
 
-func writePodsLogs(namespace string, writer io.Writer) error {
+func writePodsLogs(namespace string, sinceTime time.Time, writer io.Writer) error {
 	if framework.Global.LocalOperator {
 		return nil
 	}
+
 	podLogOpts := corev1.PodLogOptions{}
+	podLogOpts.SinceTime = &metav1.Time{sinceTime}
 	podList := &corev1.PodList{}
 	err := framework.Global.Client.List(context.TODO(), &dynclient.ListOptions{}, podList)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Right now it shows the logs from cluster-up until end of test,
this does not make sense, let's just show the logs produced
between first BeforeEach until last AfterEach.

closes #100