### PR TITLE
Use new version of kubevirtci with limit increased

### DIFF
--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="fec1b777f912ff0b7195cc76b452885e429a2203"
+commit="b185a724521961fb480a9c70d4470268c32e925d"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci


### PR DESCRIPTION
Max pod per core are now 110

Signed-off-by: Quique Llorente <ellorent@redhat.com>