### PR TITLE
Configure linux bridge vlan-filtering manually

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1012,6 +1012,30 @@
   version = "0.2.0"
 
 [[projects]]
+  digest = "1:cf43b1118f4690d1dbc85392c89a926a89b694d94a9d87a6e6d7f762ba4b8a14"
+  name = "github.com/tidwall/gjson"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "c5e72cdf74dff23857243dd662c465b810891c21"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:20d232e544cf67770287960b1a5e8bee6a58a86fd71f77dfad60a9d903b9f2ed"
+  name = "github.com/tidwall/match"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "33827db735fff6510490d69a8622612558a557ed"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:280f705ff03437a764cd7ceed59f2bb1e8adbe380e70e1e225f6a38dac9040fa"
+  name = "github.com/tidwall/pretty"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "1166b9ac2b65e46a43d8618d30d1554f4652d49b"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:5cf4eb1ceaa1b2c96fd9779fef101def21e68932b33809913563a312e2f88275"
   name = "github.com/tomnomnom/linkheader"
   packages = ["."]
@@ -1944,6 +1968,7 @@
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/spf13/pflag",
+    "github.com/tidwall/gjson",
     "golang.org/x/tools/cmd/goimports",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LOCAL_REGISTRY ?= registry:5000
 
 export KUBEVIRT_PROVIDER ?= k8s-1.13.3
 export KUBEVIRT_NUM_NODES ?= 1
-export KUBEVIRT_NUM_SECONDARY_NICS ?= 1
+export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 
 CLUSTER_DIR ?= kubevirtci/cluster-up/
 KUBECONFIG ?= kubevirtci/_ci-configs/$(KUBEVIRT_PROVIDER)/.kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ HANDLER_IMAGE_SUFFIX ?=
 HANDLER_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(HANDLER_IMAGE_NAME)$(HANDLER_IMAGE_SUFFIX)
 HANDLER_IMAGE ?= $(IMAGE_REGISTRY)/$(HANDLER_IMAGE_FULL_NAME)
 
-UNIT_TEST_ARGS ?= -v -r --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_EXTRA_ARGS)
+UNIT_TEST_ARGS ?=  -r --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_EXTRA_ARGS)
 ifdef UNIT_TEST_FOCUS
 	UNIT_TEST_ARGS += --focus $(UNIT_TEST_FOCUS)
 endif
@@ -17,7 +17,7 @@ ifdef UNIT_TEST_EXTRA_ARGS
 	UNIT_TEST_ARGS += $(UNIT_TEST_ARGS)
 endif
 
-E2E_TEST_ARGS ?= -test.v -ginkgo.v
+E2E_TEST_ARGS ?= -test.v
 ifdef E2E_TEST_FOCUS
 	E2E_TEST_ARGS +=  -ginkgo.focus $(E2E_TEST_FOCUS)
 endif

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ RUN yum -y install epel-release && \
     yum -y install \
         https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
         https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
-        iproute \
+        iproute && \
     yum clean all
 
 # Cannot change the binary to nmstate-handler since the name

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install epel-release && \
     yum -y install \
         https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
         https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
+        iproute \
     yum clean all
 
 # Cannot change the binary to nmstate-handler since the name

--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -13,4 +13,4 @@ for bridge in $@; do
    done
 
 done
-bridge vlan show
+bridge -j vlan show

--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -13,4 +13,3 @@ for bridge in $@; do
    done
 
 done
-bridge -j vlan show

--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -1,23 +1,16 @@
 #!/bin/bash -e
-IFS=$'\n'
-sed_expression="^.*: (.*) state .* : .*master (.*) state.*$"
-vlan_range=1-4094
-for port in $(bridge link show | grep -v @ | grep "state forwarding"); do
-   outbound_name=$(echo $port | sed -r "s/$sed_expression/\1/")
-   bridge_name=$(echo $port | sed -r "s/$sed_expression/\2/")
-   bridges=$(printf $bridge_name\\n$bridges | uniq)
-   outbounds=$(printf $outbound_name\\n$outbounds)
-done
 
-# We need activate vlan_filtering first to be able
-# to set vlans on outbound ports
-for bridge in $bridges; do
+vlan_range=1-4094
+
+for bridge in $@; do
    ip link set dev $bridge type bridge vlan_filtering 1
    bridge vlan add dev $bridge vid $vlan_range self
-done
 
-for outbound in $outbounds; do
-   bridge vlan add dev $outbound vid $vlan_range
-done
+   IFS=$'\n'
+   for port in $(bridge link show $bridge | grep -v @ | grep "state forwarding"); do
+      outbound=$(echo $port | sed -r "s/^.*: (.*) state .* :.*$/\1/")
+      bridge vlan add dev $outbound vid $vlan_range
+   done
 
+done
 bridge vlan show

--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+IFS=$'\n'
+sed_expression="^.*: (.*) state .* : .*master (.*) state.*$"
+vlan_range=1-4094
+for port in $(bridge link show | grep -v @ | grep "state forwarding"); do
+   outbound_name=$(echo $port | sed -r "s/$sed_expression/\1/")
+   bridge_name=$(echo $port | sed -r "s/$sed_expression/\2/")
+   bridges=$(printf $bridge_name\\n$bridges | uniq)
+   outbounds=$(printf $outbound_name\\n$outbounds)
+done
+
+# We need activate vlan_filtering first to be able
+# to set vlans on outbound ports
+for bridge in $bridges; do
+   ip link set dev $bridge type bridge vlan_filtering 1
+   bridge vlan add dev $bridge vid $vlan_range self
+done
+
+for outbound in $outbounds; do
+   bridge vlan add dev $outbound vid $vlan_range
+done
+
+bridge vlan show

--- a/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
+++ b/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
@@ -11,7 +11,7 @@ spec:
     - name: eth2
       type: ethernet
       state: up
-    - name: mynet0
+    - name: br0
       type: linux-bridge
       state: up
       bridge:
@@ -23,7 +23,7 @@ spec:
             stp-hairpin-mode: false
             stp-path-cost: 100
             stp-priority: 32
-    - name: mynet1
+    - name: br1
       type: linux-bridge
       state: up
       bridge:

--- a/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
+++ b/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
@@ -3,14 +3,15 @@ kind: NodeNetworkConfigurationPolicy
 metadata:
   name: example-nodenetworkconfigurationpolicy
 spec:
-  priority: 99
-  nodeSelector:
-    kubernetes.io/hostname: node01
   desiredState:
+    interfaces:
     - name: eth1
       type: ethernet
       state: up
-    - name: br1
+    - name: eth2
+      type: ethernet
+      state: up
+    - name: mynet0
       type: linux-bridge
       state: up
       bridge:
@@ -19,6 +20,18 @@ spec:
             enabled: false
         port:
           - name: eth1
+            stp-hairpin-mode: false
+            stp-path-cost: 100
+            stp-priority: 32
+    - name: mynet1
+      type: linux-bridge
+      state: up
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: eth2
             stp-hairpin-mode: false
             stp-path-cost: 100
             stp-priority: 32

--- a/deploy/openshift/scc.yaml
+++ b/deploy/openshift/scc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: nmstate
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+allowHostNetwork: true
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,9 @@ spec:
         app: kubernetes-nmstate
         name: nmstate-handler
     spec:
+      # Needed to force vlan filtering config with iproute commands until
+      # future nmstate/NM is in place.
+      # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
       serviceAccountName: nmstate-handler
       nodeSelector:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,7 @@ spec:
         app: kubernetes-nmstate
         name: nmstate-handler
     spec:
+      hostNetwork: true
       serviceAccountName: nmstate-handler
       nodeSelector:
         beta.kubernetes.io/arch: amd64

--- a/pkg/helper/bridges.go
+++ b/pkg/helper/bridges.go
@@ -1,0 +1,31 @@
+package helper
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+
+	yaml "sigs.k8s.io/yaml"
+
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+)
+
+func getBridgesUp(desiredState nmstatev1alpha1.State) ([]string, error) {
+	foundBridges := []string{}
+
+	desiredStateYaml, err := yaml.YAMLToJSON([]byte(desiredState))
+	if err != nil {
+		return foundBridges, fmt.Errorf("error converting desiredState to JSON: %v", err)
+	}
+
+	queryResults := gjson.ParseBytes(desiredStateYaml).
+		Get("interfaces.#(type==linux-bridge)#").
+		Get("#(state==up)#.name").
+		Array()
+
+	for _, queryResult := range queryResults {
+		foundBridges = append(foundBridges, queryResult.String())
+	}
+
+	return foundBridges, nil
+}

--- a/pkg/helper/bridges_test.go
+++ b/pkg/helper/bridges_test.go
@@ -1,0 +1,132 @@
+package helper
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+)
+
+var (
+	badYaml = nmstatev1alpha1.State("}")
+	empty   = nmstatev1alpha1.State("")
+
+	noBridges = nmstatev1alpha1.State(`interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: bond1
+    type: bond
+    state: up
+    link-aggregation:
+      mode: active-backup
+      slaves:
+        - eth1
+      options:
+        miimon: '120'
+`)
+	noBridgesUp = nmstatev1alpha1.State(`interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: br1
+    type: linux-bridge
+    state: down
+  - name: br2
+    type: linux-bridge
+    state: absent
+`)
+	someBridgesUp = nmstatev1alpha1.State(`interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+  - name: br1
+    type: linux-bridge
+    state: up
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth1
+          stp-hairpin-mode: false
+          stp-path-cost: 100
+          stp-priority: 32
+  - name: br2
+    type: linux-bridge
+    state: up
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth2
+          stp-hairpin-mode: false
+          stp-path-cost: 100
+          stp-priority: 32
+  - name: br3
+    type: linux-bridge
+    state: down
+  - name: br4
+    type: linux-bridge
+    state: absent
+`)
+)
+
+var _ = Describe("Network desired state bridge parser", func() {
+	var (
+		obtainedBridges []string
+		desiredState    nmstatev1alpha1.State
+		err             error
+	)
+	JustBeforeEach(func() {
+		obtainedBridges, err = getBridgesUp(desiredState)
+	})
+	Context("when desired state is not a yaml", func() {
+		BeforeEach(func() {
+			desiredState = badYaml
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("when desired state is empty", func() {
+		BeforeEach(func() {
+			desiredState = empty
+		})
+		It("should return empty slice", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obtainedBridges).To(BeEmpty())
+		})
+	})
+	Context("when there is no bridges", func() {
+		BeforeEach(func() {
+			desiredState = noBridges
+		})
+		It("should return empty slice", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obtainedBridges).To(BeEmpty())
+		})
+	})
+	Context("when there are no bridges up", func() {
+		BeforeEach(func() {
+			desiredState = noBridgesUp
+		})
+		It("should return empty slice", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obtainedBridges).To(BeEmpty())
+		})
+	})
+	Context("when there are bridges up", func() {
+		BeforeEach(func() {
+			desiredState = someBridgesUp
+		})
+		It("should return the slice with the bridges", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obtainedBridges).To(ConsistOf("br1", "br2"))
+		})
+	})
+})

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -123,6 +123,8 @@ func ApplyDesiredState(nodeNetworkState *nmstatev1alpha1.NodeNetworkState) (stri
 	// we have to enforce it at the desiredState bridges and outbound ports
 	// they will be configured with vlan_filtering 1 and all the vlan id range
 	// set
+	// TODO: After implementing commit/rollack from nmstate we have to
+	//       rollback if vlanfiltering fails
 	bridgesUp, err := getBridgesUp(nodeNetworkState.Spec.DesiredState)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving up bridges from desired state: %v", err)

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -27,8 +27,8 @@ func show(arguments ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-func applyVlanFiltering() (string, error) {
-	cmd := exec.Command("vlan-filtering")
+func applyVlanFiltering(bridgesUp []string) (string, error) {
+	cmd := exec.Command("vlan-filtering", bridgesUp...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -117,7 +117,11 @@ func ApplyDesiredState(nodeNetworkState *nmstatev1alpha1.NodeNetworkState) (stri
 	if err != nil {
 		return outputSet, err
 	}
-	outputVlanFiltering, err := applyVlanFiltering()
+	bridgesUp, err := getBridgesUp(nodeNetworkState.Spec.DesiredState)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving up bridges from desired state: %v", err)
+	}
+	outputVlanFiltering, err := applyVlanFiltering(bridgesUp)
 	if err != nil {
 		return outputVlanFiltering, err
 	}

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -113,10 +113,16 @@ func ApplyDesiredState(nodeNetworkState *nmstatev1alpha1.NodeNetworkState) (stri
 	if len(desiredState) == 0 {
 		return "Ignoring empty desired state", nil
 	}
-	outputSet, err := set(string(nodeNetworkState.Spec.DesiredState))
+
+	setOutput, err := set(string(nodeNetworkState.Spec.DesiredState))
 	if err != nil {
-		return outputSet, err
+		return setOutput, err
 	}
+
+	// Future versions of nmstate/NM will support vlan-filtering meanwhile
+	// we have to enforce it at the desiredState bridges and outbound ports
+	// they will be configured with vlan_filtering 1 and all the vlan id range
+	// set
 	bridgesUp, err := getBridgesUp(nodeNetworkState.Spec.DesiredState)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving up bridges from desired state: %v", err)
@@ -125,5 +131,6 @@ func ApplyDesiredState(nodeNetworkState *nmstatev1alpha1.NodeNetworkState) (stri
 	if err != nil {
 		return outputVlanFiltering, err
 	}
-	return outputSet + outputVlanFiltering, nil
+
+	return setOutput + outputVlanFiltering, nil
 }

--- a/pkg/helper/helper_suite_test.go
+++ b/pkg/helper/helper_suite_test.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helpers Test Suite")
+}

--- a/test/e2e/nodenetworkstate_test.go
+++ b/test/e2e/nodenetworkstate_test.go
@@ -96,6 +96,7 @@ var _ = Describe("NodeNetworkState", func() {
 
 				// Let's clean the bridge directly in the node
 				// bypassing nmstate
+				deleteConnectionAtNodes("eth1")
 				deleteConnectionAtNodes("br1")
 			})
 			It("should have the linux bridge at currentState", func() {
@@ -133,6 +134,7 @@ var _ = Describe("NodeNetworkState", func() {
 				time.Sleep(1 * time.Second)
 
 				deleteConnectionAtNodes("bond1")
+				deleteConnectionAtNodes("eth1")
 			})
 			It("should have the bond interface at currentState", func() {
 				var (
@@ -162,6 +164,7 @@ var _ = Describe("NodeNetworkState", func() {
 				//       remove this ugly sleep
 				time.Sleep(1 * time.Second)
 
+				deleteConnectionAtNodes("eth1")
 				deleteConnectionAtNodes("br1")
 				deleteConnectionAtNodes("bond1")
 			})

--- a/test/e2e/nodenetworkstate_test.go
+++ b/test/e2e/nodenetworkstate_test.go
@@ -96,7 +96,6 @@ var _ = Describe("NodeNetworkState", func() {
 
 				// Let's clean the bridge directly in the node
 				// bypassing nmstate
-				deleteConnectionAtNodes("eth1")
 				deleteConnectionAtNodes("br1")
 			})
 			It("should have the linux bridge at currentState", func() {
@@ -134,7 +133,6 @@ var _ = Describe("NodeNetworkState", func() {
 				time.Sleep(1 * time.Second)
 
 				deleteConnectionAtNodes("bond1")
-				deleteConnectionAtNodes("eth1")
 			})
 			It("should have the bond interface at currentState", func() {
 				var (
@@ -164,7 +162,6 @@ var _ = Describe("NodeNetworkState", func() {
 				//       remove this ugly sleep
 				time.Sleep(1 * time.Second)
 
-				deleteConnectionAtNodes("eth1")
 				deleteConnectionAtNodes("br1")
 				deleteConnectionAtNodes("bond1")
 			})

--- a/vendor/github.com/tidwall/gjson/LICENSE
+++ b/vendor/github.com/tidwall/gjson/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Josh Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tidwall/gjson/gjson.go
+++ b/vendor/github.com/tidwall/gjson/gjson.go
@@ -1,0 +1,2799 @@
+// Package gjson provides searching for json strings.
+package gjson
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/tidwall/match"
+	"github.com/tidwall/pretty"
+)
+
+// Type is Result type
+type Type int
+
+const (
+	// Null is a null json value
+	Null Type = iota
+	// False is a json false boolean
+	False
+	// Number is json number
+	Number
+	// String is a json string
+	String
+	// True is a json true boolean
+	True
+	// JSON is a raw block of JSON
+	JSON
+)
+
+// String returns a string representation of the type.
+func (t Type) String() string {
+	switch t {
+	default:
+		return ""
+	case Null:
+		return "Null"
+	case False:
+		return "False"
+	case Number:
+		return "Number"
+	case String:
+		return "String"
+	case True:
+		return "True"
+	case JSON:
+		return "JSON"
+	}
+}
+
+// Result represents a json value that is returned from Get().
+type Result struct {
+	// Type is the json type
+	Type Type
+	// Raw is the raw json
+	Raw string
+	// Str is the json string
+	Str string
+	// Num is the json number
+	Num float64
+	// Index of raw value in original json, zero means index unknown
+	Index int
+}
+
+// String returns a string representation of the value.
+func (t Result) String() string {
+	switch t.Type {
+	default:
+		return ""
+	case False:
+		return "false"
+	case Number:
+		if len(t.Raw) == 0 {
+			// calculated result
+			return strconv.FormatFloat(t.Num, 'f', -1, 64)
+		}
+		var i int
+		if t.Raw[0] == '-' {
+			i++
+		}
+		for ; i < len(t.Raw); i++ {
+			if t.Raw[i] < '0' || t.Raw[i] > '9' {
+				return strconv.FormatFloat(t.Num, 'f', -1, 64)
+			}
+		}
+		return t.Raw
+	case String:
+		return t.Str
+	case JSON:
+		return t.Raw
+	case True:
+		return "true"
+	}
+}
+
+// Bool returns an boolean representation.
+func (t Result) Bool() bool {
+	switch t.Type {
+	default:
+		return false
+	case True:
+		return true
+	case String:
+		return t.Str != "" && t.Str != "0" && t.Str != "false"
+	case Number:
+		return t.Num != 0
+	}
+}
+
+// Int returns an integer representation.
+func (t Result) Int() int64 {
+	switch t.Type {
+	default:
+		return 0
+	case True:
+		return 1
+	case String:
+		n, _ := parseInt(t.Str)
+		return n
+	case Number:
+		// try to directly convert the float64 to int64
+		n, ok := floatToInt(t.Num)
+		if !ok {
+			// now try to parse the raw string
+			n, ok = parseInt(t.Raw)
+			if !ok {
+				// fallback to a standard conversion
+				return int64(t.Num)
+			}
+		}
+		return n
+	}
+}
+
+// Uint returns an unsigned integer representation.
+func (t Result) Uint() uint64 {
+	switch t.Type {
+	default:
+		return 0
+	case True:
+		return 1
+	case String:
+		n, _ := parseUint(t.Str)
+		return n
+	case Number:
+		// try to directly convert the float64 to uint64
+		n, ok := floatToUint(t.Num)
+		if !ok {
+			// now try to parse the raw string
+			n, ok = parseUint(t.Raw)
+			if !ok {
+				// fallback to a standard conversion
+				return uint64(t.Num)
+			}
+		}
+		return n
+	}
+}
+
+// Float returns an float64 representation.
+func (t Result) Float() float64 {
+	switch t.Type {
+	default:
+		return 0
+	case True:
+		return 1
+	case String:
+		n, _ := strconv.ParseFloat(t.Str, 64)
+		return n
+	case Number:
+		return t.Num
+	}
+}
+
+// Time returns a time.Time representation.
+func (t Result) Time() time.Time {
+	res, _ := time.Parse(time.RFC3339, t.String())
+	return res
+}
+
+// Array returns back an array of values.
+// If the result represents a non-existent value, then an empty array will be
+// returned. If the result is not a JSON array, the return value will be an
+// array containing one result.
+func (t Result) Array() []Result {
+	if t.Type == Null {
+		return []Result{}
+	}
+	if t.Type != JSON {
+		return []Result{t}
+	}
+	r := t.arrayOrMap('[', false)
+	return r.a
+}
+
+// IsObject returns true if the result value is a JSON object.
+func (t Result) IsObject() bool {
+	return t.Type == JSON && len(t.Raw) > 0 && t.Raw[0] == '{'
+}
+
+// IsArray returns true if the result value is a JSON array.
+func (t Result) IsArray() bool {
+	return t.Type == JSON && len(t.Raw) > 0 && t.Raw[0] == '['
+}
+
+// ForEach iterates through values.
+// If the result represents a non-existent value, then no values will be
+// iterated. If the result is an Object, the iterator will pass the key and
+// value of each item. If the result is an Array, the iterator will only pass
+// the value of each item. If the result is not a JSON array or object, the
+// iterator will pass back one value equal to the result.
+func (t Result) ForEach(iterator func(key, value Result) bool) {
+	if !t.Exists() {
+		return
+	}
+	if t.Type != JSON {
+		iterator(Result{}, t)
+		return
+	}
+	json := t.Raw
+	var keys bool
+	var i int
+	var key, value Result
+	for ; i < len(json); i++ {
+		if json[i] == '{' {
+			i++
+			key.Type = String
+			keys = true
+			break
+		} else if json[i] == '[' {
+			i++
+			break
+		}
+		if json[i] > ' ' {
+			return
+		}
+	}
+	var str string
+	var vesc bool
+	var ok bool
+	for ; i < len(json); i++ {
+		if keys {
+			if json[i] != '"' {
+				continue
+			}
+			s := i
+			i, str, vesc, ok = parseString(json, i+1)
+			if !ok {
+				return
+			}
+			if vesc {
+				key.Str = unescape(str[1 : len(str)-1])
+			} else {
+				key.Str = str[1 : len(str)-1]
+			}
+			key.Raw = str
+			key.Index = s
+		}
+		for ; i < len(json); i++ {
+			if json[i] <= ' ' || json[i] == ',' || json[i] == ':' {
+				continue
+			}
+			break
+		}
+		s := i
+		i, value, ok = parseAny(json, i, true)
+		if !ok {
+			return
+		}
+		value.Index = s
+		if !iterator(key, value) {
+			return
+		}
+	}
+}
+
+// Map returns back an map of values. The result should be a JSON array.
+func (t Result) Map() map[string]Result {
+	if t.Type != JSON {
+		return map[string]Result{}
+	}
+	r := t.arrayOrMap('{', false)
+	return r.o
+}
+
+// Get searches result for the specified path.
+// The result should be a JSON array or object.
+func (t Result) Get(path string) Result {
+	return Get(t.Raw, path)
+}
+
+type arrayOrMapResult struct {
+	a  []Result
+	ai []interface{}
+	o  map[string]Result
+	oi map[string]interface{}
+	vc byte
+}
+
+func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
+	var json = t.Raw
+	var i int
+	var value Result
+	var count int
+	var key Result
+	if vc == 0 {
+		for ; i < len(json); i++ {
+			if json[i] == '{' || json[i] == '[' {
+				r.vc = json[i]
+				i++
+				break
+			}
+			if json[i] > ' ' {
+				goto end
+			}
+		}
+	} else {
+		for ; i < len(json); i++ {
+			if json[i] == vc {
+				i++
+				break
+			}
+			if json[i] > ' ' {
+				goto end
+			}
+		}
+		r.vc = vc
+	}
+	if r.vc == '{' {
+		if valueize {
+			r.oi = make(map[string]interface{})
+		} else {
+			r.o = make(map[string]Result)
+		}
+	} else {
+		if valueize {
+			r.ai = make([]interface{}, 0)
+		} else {
+			r.a = make([]Result, 0)
+		}
+	}
+	for ; i < len(json); i++ {
+		if json[i] <= ' ' {
+			continue
+		}
+		// get next value
+		if json[i] == ']' || json[i] == '}' {
+			break
+		}
+		switch json[i] {
+		default:
+			if (json[i] >= '0' && json[i] <= '9') || json[i] == '-' {
+				value.Type = Number
+				value.Raw, value.Num = tonum(json[i:])
+				value.Str = ""
+			} else {
+				continue
+			}
+		case '{', '[':
+			value.Type = JSON
+			value.Raw = squash(json[i:])
+			value.Str, value.Num = "", 0
+		case 'n':
+			value.Type = Null
+			value.Raw = tolit(json[i:])
+			value.Str, value.Num = "", 0
+		case 't':
+			value.Type = True
+			value.Raw = tolit(json[i:])
+			value.Str, value.Num = "", 0
+		case 'f':
+			value.Type = False
+			value.Raw = tolit(json[i:])
+			value.Str, value.Num = "", 0
+		case '"':
+			value.Type = String
+			value.Raw, value.Str = tostr(json[i:])
+			value.Num = 0
+		}
+		i += len(value.Raw) - 1
+
+		if r.vc == '{' {
+			if count%2 == 0 {
+				key = value
+			} else {
+				if valueize {
+					if _, ok := r.oi[key.Str]; !ok {
+						r.oi[key.Str] = value.Value()
+					}
+				} else {
+					if _, ok := r.o[key.Str]; !ok {
+						r.o[key.Str] = value
+					}
+				}
+			}
+			count++
+		} else {
+			if valueize {
+				r.ai = append(r.ai, value.Value())
+			} else {
+				r.a = append(r.a, value)
+			}
+		}
+	}
+end:
+	return
+}
+
+// Parse parses the json and returns a result.
+//
+// This function expects that the json is well-formed, and does not validate.
+// Invalid json will not panic, but it may return back unexpected results.
+// If you are consuming JSON from an unpredictable source then you may want to
+// use the Valid function first.
+func Parse(json string) Result {
+	var value Result
+	for i := 0; i < len(json); i++ {
+		if json[i] == '{' || json[i] == '[' {
+			value.Type = JSON
+			value.Raw = json[i:] // just take the entire raw
+			break
+		}
+		if json[i] <= ' ' {
+			continue
+		}
+		switch json[i] {
+		default:
+			if (json[i] >= '0' && json[i] <= '9') || json[i] == '-' {
+				value.Type = Number
+				value.Raw, value.Num = tonum(json[i:])
+			} else {
+				return Result{}
+			}
+		case 'n':
+			value.Type = Null
+			value.Raw = tolit(json[i:])
+		case 't':
+			value.Type = True
+			value.Raw = tolit(json[i:])
+		case 'f':
+			value.Type = False
+			value.Raw = tolit(json[i:])
+		case '"':
+			value.Type = String
+			value.Raw, value.Str = tostr(json[i:])
+		}
+		break
+	}
+	return value
+}
+
+// ParseBytes parses the json and returns a result.
+// If working with bytes, this method preferred over Parse(string(data))
+func ParseBytes(json []byte) Result {
+	return Parse(string(json))
+}
+
+func squash(json string) string {
+	// expects that the lead character is a '[' or '{'
+	// squash the value, ignoring all nested arrays and objects.
+	// the first '[' or '{' has already been read
+	depth := 1
+	for i := 1; i < len(json); i++ {
+		if json[i] >= '"' && json[i] <= '}' {
+			switch json[i] {
+			case '"':
+				i++
+				s2 := i
+				for ; i < len(json); i++ {
+					if json[i] > '\\' {
+						continue
+					}
+					if json[i] == '"' {
+						// look for an escaped slash
+						if json[i-1] == '\\' {
+							n := 0
+							for j := i - 2; j > s2-1; j-- {
+								if json[j] != '\\' {
+									break
+								}
+								n++
+							}
+							if n%2 == 0 {
+								continue
+							}
+						}
+						break
+					}
+				}
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+				if depth == 0 {
+					return json[:i+1]
+				}
+			}
+		}
+	}
+	return json
+}
+
+func tonum(json string) (raw string, num float64) {
+	for i := 1; i < len(json); i++ {
+		// less than dash might have valid characters
+		if json[i] <= '-' {
+			if json[i] <= ' ' || json[i] == ',' {
+				// break on whitespace and comma
+				raw = json[:i]
+				num, _ = strconv.ParseFloat(raw, 64)
+				return
+			}
+			// could be a '+' or '-'. let's assume so.
+			continue
+		}
+		if json[i] < ']' {
+			// probably a valid number
+			continue
+		}
+		if json[i] == 'e' || json[i] == 'E' {
+			// allow for exponential numbers
+			continue
+		}
+		// likely a ']' or '}'
+		raw = json[:i]
+		num, _ = strconv.ParseFloat(raw, 64)
+		return
+	}
+	raw = json
+	num, _ = strconv.ParseFloat(raw, 64)
+	return
+}
+
+func tolit(json string) (raw string) {
+	for i := 1; i < len(json); i++ {
+		if json[i] < 'a' || json[i] > 'z' {
+			return json[:i]
+		}
+	}
+	return json
+}
+
+func tostr(json string) (raw string, str string) {
+	// expects that the lead character is a '"'
+	for i := 1; i < len(json); i++ {
+		if json[i] > '\\' {
+			continue
+		}
+		if json[i] == '"' {
+			return json[:i+1], json[1:i]
+		}
+		if json[i] == '\\' {
+			i++
+			for ; i < len(json); i++ {
+				if json[i] > '\\' {
+					continue
+				}
+				if json[i] == '"' {
+					// look for an escaped slash
+					if json[i-1] == '\\' {
+						n := 0
+						for j := i - 2; j > 0; j-- {
+							if json[j] != '\\' {
+								break
+							}
+							n++
+						}
+						if n%2 == 0 {
+							continue
+						}
+					}
+					break
+				}
+			}
+			var ret string
+			if i+1 < len(json) {
+				ret = json[:i+1]
+			} else {
+				ret = json[:i]
+			}
+			return ret, unescape(json[1:i])
+		}
+	}
+	return json, json[1:]
+}
+
+// Exists returns true if value exists.
+//
+//  if gjson.Get(json, "name.last").Exists(){
+//		println("value exists")
+//  }
+func (t Result) Exists() bool {
+	return t.Type != Null || len(t.Raw) != 0
+}
+
+// Value returns one of these types:
+//
+//	bool, for JSON booleans
+//	float64, for JSON numbers
+//	Number, for JSON numbers
+//	string, for JSON string literals
+//	nil, for JSON null
+//	map[string]interface{}, for JSON objects
+//	[]interface{}, for JSON arrays
+//
+func (t Result) Value() interface{} {
+	if t.Type == String {
+		return t.Str
+	}
+	switch t.Type {
+	default:
+		return nil
+	case False:
+		return false
+	case Number:
+		return t.Num
+	case JSON:
+		r := t.arrayOrMap(0, true)
+		if r.vc == '{' {
+			return r.oi
+		} else if r.vc == '[' {
+			return r.ai
+		}
+		return nil
+	case True:
+		return true
+	}
+}
+
+func parseString(json string, i int) (int, string, bool, bool) {
+	var s = i
+	for ; i < len(json); i++ {
+		if json[i] > '\\' {
+			continue
+		}
+		if json[i] == '"' {
+			return i + 1, json[s-1 : i+1], false, true
+		}
+		if json[i] == '\\' {
+			i++
+			for ; i < len(json); i++ {
+				if json[i] > '\\' {
+					continue
+				}
+				if json[i] == '"' {
+					// look for an escaped slash
+					if json[i-1] == '\\' {
+						n := 0
+						for j := i - 2; j > 0; j-- {
+							if json[j] != '\\' {
+								break
+							}
+							n++
+						}
+						if n%2 == 0 {
+							continue
+						}
+					}
+					return i + 1, json[s-1 : i+1], true, true
+				}
+			}
+			break
+		}
+	}
+	return i, json[s-1:], false, false
+}
+
+func parseNumber(json string, i int) (int, string) {
+	var s = i
+	i++
+	for ; i < len(json); i++ {
+		if json[i] <= ' ' || json[i] == ',' || json[i] == ']' ||
+			json[i] == '}' {
+			return i, json[s:i]
+		}
+	}
+	return i, json[s:]
+}
+
+func parseLiteral(json string, i int) (int, string) {
+	var s = i
+	i++
+	for ; i < len(json); i++ {
+		if json[i] < 'a' || json[i] > 'z' {
+			return i, json[s:i]
+		}
+	}
+	return i, json[s:]
+}
+
+type arrayPathResult struct {
+	part    string
+	path    string
+	pipe    string
+	piped   bool
+	more    bool
+	alogok  bool
+	arrch   bool
+	alogkey string
+	query   struct {
+		on    bool
+		path  string
+		op    string
+		value string
+		all   bool
+	}
+}
+
+func parseArrayPath(path string) (r arrayPathResult) {
+	for i := 0; i < len(path); i++ {
+		if path[i] == '|' {
+			r.part = path[:i]
+			r.pipe = path[i+1:]
+			r.piped = true
+			return
+		}
+		if path[i] == '.' {
+			r.part = path[:i]
+			r.path = path[i+1:]
+			r.more = true
+			return
+		}
+		if path[i] == '#' {
+			r.arrch = true
+			if i == 0 && len(path) > 1 {
+				if path[1] == '.' {
+					r.alogok = true
+					r.alogkey = path[2:]
+					r.path = path[:1]
+				} else if path[1] == '[' || path[1] == '(' {
+					// query
+					r.query.on = true
+					if true {
+						qpath, op, value, _, fi, ok := parseQuery(path[i:])
+						if !ok {
+							// bad query, end now
+							break
+						}
+						r.query.path = qpath
+						r.query.op = op
+						r.query.value = value
+						i = fi - 1
+						if i+1 < len(path) && path[i+1] == '#' {
+							r.query.all = true
+						}
+					} else {
+						var end byte
+						if path[1] == '[' {
+							end = ']'
+						} else {
+							end = ')'
+						}
+						i += 2
+						// whitespace
+						for ; i < len(path); i++ {
+							if path[i] > ' ' {
+								break
+							}
+						}
+						s := i
+						for ; i < len(path); i++ {
+							if path[i] <= ' ' ||
+								path[i] == '!' ||
+								path[i] == '=' ||
+								path[i] == '<' ||
+								path[i] == '>' ||
+								path[i] == '%' ||
+								path[i] == end {
+								break
+							}
+						}
+						r.query.path = path[s:i]
+						// whitespace
+						for ; i < len(path); i++ {
+							if path[i] > ' ' {
+								break
+							}
+						}
+						if i < len(path) {
+							s = i
+							if path[i] == '!' {
+								if i < len(path)-1 && (path[i+1] == '=' ||
+									path[i+1] == '%') {
+									i++
+								}
+							} else if path[i] == '<' || path[i] == '>' {
+								if i < len(path)-1 && path[i+1] == '=' {
+									i++
+								}
+							} else if path[i] == '=' {
+								if i < len(path)-1 && path[i+1] == '=' {
+									s++
+									i++
+								}
+							}
+							i++
+							r.query.op = path[s:i]
+							// whitespace
+							for ; i < len(path); i++ {
+								if path[i] > ' ' {
+									break
+								}
+							}
+							s = i
+							for ; i < len(path); i++ {
+								if path[i] == '"' {
+									i++
+									s2 := i
+									for ; i < len(path); i++ {
+										if path[i] > '\\' {
+											continue
+										}
+										if path[i] == '"' {
+											// look for an escaped slash
+											if path[i-1] == '\\' {
+												n := 0
+												for j := i - 2; j > s2-1; j-- {
+													if path[j] != '\\' {
+														break
+													}
+													n++
+												}
+												if n%2 == 0 {
+													continue
+												}
+											}
+											break
+										}
+									}
+								} else if path[i] == end {
+									if i+1 < len(path) && path[i+1] == '#' {
+										r.query.all = true
+									}
+									break
+								}
+							}
+							if i > len(path) {
+								i = len(path)
+							}
+							v := path[s:i]
+							for len(v) > 0 && v[len(v)-1] <= ' ' {
+								v = v[:len(v)-1]
+							}
+							r.query.value = v
+						}
+					}
+				}
+			}
+			continue
+		}
+	}
+	r.part = path
+	r.path = ""
+	return
+}
+
+// splitQuery takes a query and splits it into three parts:
+//   path, op, middle, and right.
+// So for this query:
+//   #(first_name=="Murphy").last
+// Becomes
+//   first_name   # path
+//   =="Murphy"   # middle
+//   .last        # right
+// Or,
+//   #(service_roles.#(=="one")).cap
+// Becomes
+//   service_roles.#(=="one")   # path
+//                              # middle
+//   .cap                       # right
+func parseQuery(query string) (
+	path, op, value, remain string, i int, ok bool,
+) {
+	if len(query) < 2 || query[0] != '#' ||
+		(query[1] != '(' && query[1] != '[') {
+		return "", "", "", "", i, false
+	}
+	i = 2
+	j := 0 // start of value part
+	depth := 1
+	for ; i < len(query); i++ {
+		if depth == 1 && j == 0 {
+			switch query[i] {
+			case '!', '=', '<', '>', '%':
+				// start of the value part
+				j = i
+				continue
+			}
+		}
+		if query[i] == '\\' {
+			i++
+		} else if query[i] == '[' || query[i] == '(' {
+			depth++
+		} else if query[i] == ']' || query[i] == ')' {
+			depth--
+			if depth == 0 {
+				break
+			}
+		} else if query[i] == '"' {
+			// inside selector string, balance quotes
+			i++
+			for ; i < len(query); i++ {
+				if query[i] == '\\' {
+					i++
+				} else if query[i] == '"' {
+					break
+				}
+			}
+		}
+	}
+	if depth > 0 {
+		return "", "", "", "", i, false
+	}
+	if j > 0 {
+		path = trim(query[2:j])
+		value = trim(query[j:i])
+		remain = query[i+1:]
+		// parse the compare op from the value
+		var opsz int
+		switch {
+		case len(value) == 1:
+			opsz = 1
+		case value[0] == '!' && value[1] == '=':
+			opsz = 2
+		case value[0] == '!' && value[1] == '%':
+			opsz = 2
+		case value[0] == '<' && value[1] == '=':
+			opsz = 2
+		case value[0] == '>' && value[1] == '=':
+			opsz = 2
+		case value[0] == '=' && value[1] == '=':
+			value = value[1:]
+			opsz = 1
+		case value[0] == '<':
+			opsz = 1
+		case value[0] == '>':
+			opsz = 1
+		case value[0] == '=':
+			opsz = 1
+		case value[0] == '%':
+			opsz = 1
+		}
+		op = value[:opsz]
+		value = trim(value[opsz:])
+	} else {
+		path = trim(query[2:i])
+		remain = query[i+1:]
+	}
+	return path, op, value, remain, i + 1, true
+}
+
+func trim(s string) string {
+left:
+	if len(s) > 0 && s[0] <= ' ' {
+		s = s[1:]
+		goto left
+	}
+right:
+	if len(s) > 0 && s[len(s)-1] <= ' ' {
+		s = s[:len(s)-1]
+		goto right
+	}
+	return s
+}
+
+type objectPathResult struct {
+	part  string
+	path  string
+	pipe  string
+	piped bool
+	wild  bool
+	more  bool
+}
+
+func parseObjectPath(path string) (r objectPathResult) {
+	for i := 0; i < len(path); i++ {
+		if path[i] == '|' {
+			r.part = path[:i]
+			r.pipe = path[i+1:]
+			r.piped = true
+			return
+		}
+		if path[i] == '.' {
+			// peek at the next byte and see if it's a '@', '[', or '{'.
+			r.part = path[:i]
+			if !DisableModifiers &&
+				i < len(path)-1 &&
+				(path[i+1] == '@' ||
+					path[i+1] == '[' || path[i+1] == '{') {
+				r.pipe = path[i+1:]
+				r.piped = true
+			} else {
+				r.path = path[i+1:]
+				r.more = true
+			}
+			return
+		}
+		if path[i] == '*' || path[i] == '?' {
+			r.wild = true
+			continue
+		}
+		if path[i] == '\\' {
+			// go into escape mode. this is a slower path that
+			// strips off the escape character from the part.
+			epart := []byte(path[:i])
+			i++
+			if i < len(path) {
+				epart = append(epart, path[i])
+				i++
+				for ; i < len(path); i++ {
+					if path[i] == '\\' {
+						i++
+						if i < len(path) {
+							epart = append(epart, path[i])
+						}
+						continue
+					} else if path[i] == '.' {
+						r.part = string(epart)
+						// peek at the next byte and see if it's a '@' modifier
+						if !DisableModifiers &&
+							i < len(path)-1 && path[i+1] == '@' {
+							r.pipe = path[i+1:]
+							r.piped = true
+						} else {
+							r.path = path[i+1:]
+							r.more = true
+						}
+						r.more = true
+						return
+					} else if path[i] == '|' {
+						r.part = string(epart)
+						r.pipe = path[i+1:]
+						r.piped = true
+						return
+					} else if path[i] == '*' || path[i] == '?' {
+						r.wild = true
+					}
+					epart = append(epart, path[i])
+				}
+			}
+			// append the last part
+			r.part = string(epart)
+			return
+		}
+	}
+	r.part = path
+	return
+}
+
+func parseSquash(json string, i int) (int, string) {
+	// expects that the lead character is a '[' or '{'
+	// squash the value, ignoring all nested arrays and objects.
+	// the first '[' or '{' has already been read
+	s := i
+	i++
+	depth := 1
+	for ; i < len(json); i++ {
+		if json[i] >= '"' && json[i] <= '}' {
+			switch json[i] {
+			case '"':
+				i++
+				s2 := i
+				for ; i < len(json); i++ {
+					if json[i] > '\\' {
+						continue
+					}
+					if json[i] == '"' {
+						// look for an escaped slash
+						if json[i-1] == '\\' {
+							n := 0
+							for j := i - 2; j > s2-1; j-- {
+								if json[j] != '\\' {
+									break
+								}
+								n++
+							}
+							if n%2 == 0 {
+								continue
+							}
+						}
+						break
+					}
+				}
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+				if depth == 0 {
+					i++
+					return i, json[s:i]
+				}
+			}
+		}
+	}
+	return i, json[s:]
+}
+
+func parseObject(c *parseContext, i int, path string) (int, bool) {
+	var pmatch, kesc, vesc, ok, hit bool
+	var key, val string
+	rp := parseObjectPath(path)
+	if !rp.more && rp.piped {
+		c.pipe = rp.pipe
+		c.piped = true
+	}
+	for i < len(c.json) {
+		for ; i < len(c.json); i++ {
+			if c.json[i] == '"' {
+				// parse_key_string
+				// this is slightly different from getting s string value
+				// because we don't need the outer quotes.
+				i++
+				var s = i
+				for ; i < len(c.json); i++ {
+					if c.json[i] > '\\' {
+						continue
+					}
+					if c.json[i] == '"' {
+						i, key, kesc, ok = i+1, c.json[s:i], false, true
+						goto parse_key_string_done
+					}
+					if c.json[i] == '\\' {
+						i++
+						for ; i < len(c.json); i++ {
+							if c.json[i] > '\\' {
+								continue
+							}
+							if c.json[i] == '"' {
+								// look for an escaped slash
+								if c.json[i-1] == '\\' {
+									n := 0
+									for j := i - 2; j > 0; j-- {
+										if c.json[j] != '\\' {
+											break
+										}
+										n++
+									}
+									if n%2 == 0 {
+										continue
+									}
+								}
+								i, key, kesc, ok = i+1, c.json[s:i], true, true
+								goto parse_key_string_done
+							}
+						}
+						break
+					}
+				}
+				key, kesc, ok = c.json[s:], false, false
+			parse_key_string_done:
+				break
+			}
+			if c.json[i] == '}' {
+				return i + 1, false
+			}
+		}
+		if !ok {
+			return i, false
+		}
+		if rp.wild {
+			if kesc {
+				pmatch = match.Match(unescape(key), rp.part)
+			} else {
+				pmatch = match.Match(key, rp.part)
+			}
+		} else {
+			if kesc {
+				pmatch = rp.part == unescape(key)
+			} else {
+				pmatch = rp.part == key
+			}
+		}
+		hit = pmatch && !rp.more
+		for ; i < len(c.json); i++ {
+			switch c.json[i] {
+			default:
+				continue
+			case '"':
+				i++
+				i, val, vesc, ok = parseString(c.json, i)
+				if !ok {
+					return i, false
+				}
+				if hit {
+					if vesc {
+						c.value.Str = unescape(val[1 : len(val)-1])
+					} else {
+						c.value.Str = val[1 : len(val)-1]
+					}
+					c.value.Raw = val
+					c.value.Type = String
+					return i, true
+				}
+			case '{':
+				if pmatch && !hit {
+					i, hit = parseObject(c, i+1, rp.path)
+					if hit {
+						return i, true
+					}
+				} else {
+					i, val = parseSquash(c.json, i)
+					if hit {
+						c.value.Raw = val
+						c.value.Type = JSON
+						return i, true
+					}
+				}
+			case '[':
+				if pmatch && !hit {
+					i, hit = parseArray(c, i+1, rp.path)
+					if hit {
+						return i, true
+					}
+				} else {
+					i, val = parseSquash(c.json, i)
+					if hit {
+						c.value.Raw = val
+						c.value.Type = JSON
+						return i, true
+					}
+				}
+			case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				i, val = parseNumber(c.json, i)
+				if hit {
+					c.value.Raw = val
+					c.value.Type = Number
+					c.value.Num, _ = strconv.ParseFloat(val, 64)
+					return i, true
+				}
+			case 't', 'f', 'n':
+				vc := c.json[i]
+				i, val = parseLiteral(c.json, i)
+				if hit {
+					c.value.Raw = val
+					switch vc {
+					case 't':
+						c.value.Type = True
+					case 'f':
+						c.value.Type = False
+					}
+					return i, true
+				}
+			}
+			break
+		}
+	}
+	return i, false
+}
+func queryMatches(rp *arrayPathResult, value Result) bool {
+	rpv := rp.query.value
+	if len(rpv) > 2 && rpv[0] == '"' && rpv[len(rpv)-1] == '"' {
+		rpv = rpv[1 : len(rpv)-1]
+	}
+	if !value.Exists() {
+		return false
+	}
+	if rp.query.op == "" {
+		// the query is only looking for existence, such as:
+		//   friends.#(name)
+		// which makes sure that the array "friends" has an element of
+		// "name" that exists
+		return true
+	}
+	switch value.Type {
+	case String:
+		switch rp.query.op {
+		case "=":
+			return value.Str == rpv
+		case "!=":
+			return value.Str != rpv
+		case "<":
+			return value.Str < rpv
+		case "<=":
+			return value.Str <= rpv
+		case ">":
+			return value.Str > rpv
+		case ">=":
+			return value.Str >= rpv
+		case "%":
+			return match.Match(value.Str, rpv)
+		case "!%":
+			return !match.Match(value.Str, rpv)
+		}
+	case Number:
+		rpvn, _ := strconv.ParseFloat(rpv, 64)
+		switch rp.query.op {
+		case "=":
+			return value.Num == rpvn
+		case "!=":
+			return value.Num != rpvn
+		case "<":
+			return value.Num < rpvn
+		case "<=":
+			return value.Num <= rpvn
+		case ">":
+			return value.Num > rpvn
+		case ">=":
+			return value.Num >= rpvn
+		}
+	case True:
+		switch rp.query.op {
+		case "=":
+			return rpv == "true"
+		case "!=":
+			return rpv != "true"
+		case ">":
+			return rpv == "false"
+		case ">=":
+			return true
+		}
+	case False:
+		switch rp.query.op {
+		case "=":
+			return rpv == "false"
+		case "!=":
+			return rpv != "false"
+		case "<":
+			return rpv == "true"
+		case "<=":
+			return true
+		}
+	}
+	return false
+}
+func parseArray(c *parseContext, i int, path string) (int, bool) {
+	var pmatch, vesc, ok, hit bool
+	var val string
+	var h int
+	var alog []int
+	var partidx int
+	var multires []byte
+	rp := parseArrayPath(path)
+	if !rp.arrch {
+		n, ok := parseUint(rp.part)
+		if !ok {
+			partidx = -1
+		} else {
+			partidx = int(n)
+		}
+	}
+	if !rp.more && rp.piped {
+		c.pipe = rp.pipe
+		c.piped = true
+	}
+
+	procQuery := func(qval Result) bool {
+		if rp.query.all {
+			if len(multires) == 0 {
+				multires = append(multires, '[')
+			}
+		}
+		var res Result
+		if qval.Type == JSON {
+			res = qval.Get(rp.query.path)
+		} else {
+			if rp.query.path != "" {
+				return false
+			}
+			res = qval
+		}
+		if queryMatches(&rp, res) {
+			if rp.more {
+				left, right, ok := splitPossiblePipe(rp.path)
+				if ok {
+					rp.path = left
+					c.pipe = right
+					c.piped = true
+				}
+				res = qval.Get(rp.path)
+			} else {
+				res = qval
+			}
+			if rp.query.all {
+				raw := res.Raw
+				if len(raw) == 0 {
+					raw = res.String()
+				}
+				if raw != "" {
+					if len(multires) > 1 {
+						multires = append(multires, ',')
+					}
+					multires = append(multires, raw...)
+				}
+			} else {
+				c.value = res
+				return true
+			}
+		}
+		return false
+	}
+
+	for i < len(c.json)+1 {
+		if !rp.arrch {
+			pmatch = partidx == h
+			hit = pmatch && !rp.more
+		}
+		h++
+		if rp.alogok {
+			alog = append(alog, i)
+		}
+		for ; ; i++ {
+			var ch byte
+			if i > len(c.json) {
+				break
+			} else if i == len(c.json) {
+				ch = ']'
+			} else {
+				ch = c.json[i]
+			}
+			switch ch {
+			default:
+				continue
+			case '"':
+				i++
+				i, val, vesc, ok = parseString(c.json, i)
+				if !ok {
+					return i, false
+				}
+				if rp.query.on {
+					var qval Result
+					if vesc {
+						qval.Str = unescape(val[1 : len(val)-1])
+					} else {
+						qval.Str = val[1 : len(val)-1]
+					}
+					qval.Raw = val
+					qval.Type = String
+					if procQuery(qval) {
+						return i, true
+					}
+				} else if hit {
+					if rp.alogok {
+						break
+					}
+					if vesc {
+						c.value.Str = unescape(val[1 : len(val)-1])
+					} else {
+						c.value.Str = val[1 : len(val)-1]
+					}
+					c.value.Raw = val
+					c.value.Type = String
+					return i, true
+				}
+			case '{':
+				if pmatch && !hit {
+					i, hit = parseObject(c, i+1, rp.path)
+					if hit {
+						if rp.alogok {
+							break
+						}
+						return i, true
+					}
+				} else {
+					i, val = parseSquash(c.json, i)
+					if rp.query.on {
+						if procQuery(Result{Raw: val, Type: JSON}) {
+							return i, true
+						}
+					} else if hit {
+						if rp.alogok {
+							break
+						}
+						c.value.Raw = val
+						c.value.Type = JSON
+						return i, true
+					}
+				}
+			case '[':
+				if pmatch && !hit {
+					i, hit = parseArray(c, i+1, rp.path)
+					if hit {
+						if rp.alogok {
+							break
+						}
+						return i, true
+					}
+				} else {
+					i, val = parseSquash(c.json, i)
+					if rp.query.on {
+						if procQuery(Result{Raw: val, Type: JSON}) {
+							return i, true
+						}
+					} else if hit {
+						if rp.alogok {
+							break
+						}
+						c.value.Raw = val
+						c.value.Type = JSON
+						return i, true
+					}
+				}
+			case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				i, val = parseNumber(c.json, i)
+				if rp.query.on {
+					var qval Result
+					qval.Raw = val
+					qval.Type = Number
+					qval.Num, _ = strconv.ParseFloat(val, 64)
+					if procQuery(qval) {
+						return i, true
+					}
+				} else if hit {
+					if rp.alogok {
+						break
+					}
+					c.value.Raw = val
+					c.value.Type = Number
+					c.value.Num, _ = strconv.ParseFloat(val, 64)
+					return i, true
+				}
+			case 't', 'f', 'n':
+				vc := c.json[i]
+				i, val = parseLiteral(c.json, i)
+				if rp.query.on {
+					var qval Result
+					qval.Raw = val
+					switch vc {
+					case 't':
+						qval.Type = True
+					case 'f':
+						qval.Type = False
+					}
+					if procQuery(qval) {
+						return i, true
+					}
+				} else if hit {
+					if rp.alogok {
+						break
+					}
+					c.value.Raw = val
+					switch vc {
+					case 't':
+						c.value.Type = True
+					case 'f':
+						c.value.Type = False
+					}
+					return i, true
+				}
+			case ']':
+				if rp.arrch && rp.part == "#" {
+					if rp.alogok {
+						left, right, ok := splitPossiblePipe(rp.alogkey)
+						if ok {
+							rp.alogkey = left
+							c.pipe = right
+							c.piped = true
+						}
+						var jsons = make([]byte, 0, 64)
+						jsons = append(jsons, '[')
+						for j, k := 0, 0; j < len(alog); j++ {
+							_, res, ok := parseAny(c.json, alog[j], true)
+							if ok {
+								res := res.Get(rp.alogkey)
+								if res.Exists() {
+									if k > 0 {
+										jsons = append(jsons, ',')
+									}
+									raw := res.Raw
+									if len(raw) == 0 {
+										raw = res.String()
+									}
+									jsons = append(jsons, []byte(raw)...)
+									k++
+								}
+							}
+						}
+						jsons = append(jsons, ']')
+						c.value.Type = JSON
+						c.value.Raw = string(jsons)
+						return i + 1, true
+					}
+					if rp.alogok {
+						break
+					}
+
+					c.value.Type = Number
+					c.value.Num = float64(h - 1)
+					c.value.Raw = strconv.Itoa(h - 1)
+					c.calcd = true
+					return i + 1, true
+				}
+				if len(multires) > 0 && !c.value.Exists() {
+					c.value = Result{
+						Raw:  string(append(multires, ']')),
+						Type: JSON,
+					}
+				}
+				return i + 1, false
+			}
+			break
+		}
+	}
+	return i, false
+}
+
+func splitPossiblePipe(path string) (left, right string, ok bool) {
+	// take a quick peek for the pipe character. If found we'll split the piped
+	// part of the path into the c.pipe field and shorten the rp.
+	var possible bool
+	for i := 0; i < len(path); i++ {
+		if path[i] == '|' {
+			possible = true
+			break
+		}
+	}
+	if !possible {
+		return
+	}
+
+	// split the left and right side of the path with the pipe character as
+	// the delimiter. This is a little tricky because we'll need to basically
+	// parse the entire path.
+
+	for i := 0; i < len(path); i++ {
+		if path[i] == '\\' {
+			i++
+		} else if path[i] == '.' {
+			if i == len(path)-1 {
+				return
+			}
+			if path[i+1] == '#' {
+				i += 2
+				if i == len(path) {
+					return
+				}
+				if path[i] == '[' || path[i] == '(' {
+					var start, end byte
+					if path[i] == '[' {
+						start, end = '[', ']'
+					} else {
+						start, end = '(', ')'
+					}
+					// inside selector, balance brackets
+					i++
+					depth := 1
+					for ; i < len(path); i++ {
+						if path[i] == '\\' {
+							i++
+						} else if path[i] == start {
+							depth++
+						} else if path[i] == end {
+							depth--
+							if depth == 0 {
+								break
+							}
+						} else if path[i] == '"' {
+							// inside selector string, balance quotes
+							i++
+							for ; i < len(path); i++ {
+								if path[i] == '\\' {
+									i++
+								} else if path[i] == '"' {
+									break
+								}
+							}
+						}
+					}
+				}
+			}
+		} else if path[i] == '|' {
+			return path[:i], path[i+1:], true
+		}
+	}
+	return
+}
+
+// ForEachLine iterates through lines of JSON as specified by the JSON Lines
+// format (http://jsonlines.org/).
+// Each line is returned as a GJSON Result.
+func ForEachLine(json string, iterator func(line Result) bool) {
+	var res Result
+	var i int
+	for {
+		i, res, _ = parseAny(json, i, true)
+		if !res.Exists() {
+			break
+		}
+		if !iterator(res) {
+			return
+		}
+	}
+}
+
+type subSelector struct {
+	name string
+	path string
+}
+
+// parseSubSelectors returns the subselectors belonging to a '[path1,path2]' or
+// '{"field1":path1,"field2":path2}' type subSelection. It's expected that the
+// first character in path is either '[' or '{', and has already been checked
+// prior to calling this function.
+func parseSubSelectors(path string) (sels []subSelector, out string, ok bool) {
+	depth := 1
+	colon := 0
+	start := 1
+	i := 1
+	pushSel := func() {
+		var sel subSelector
+		if colon == 0 {
+			sel.path = path[start:i]
+		} else {
+			sel.name = path[start:colon]
+			sel.path = path[colon+1 : i]
+		}
+		sels = append(sels, sel)
+		colon = 0
+		start = i + 1
+	}
+	for ; i < len(path); i++ {
+		switch path[i] {
+		case '\\':
+			i++
+		case ':':
+			if depth == 1 {
+				colon = i
+			}
+		case ',':
+			if depth == 1 {
+				pushSel()
+			}
+		case '"':
+			i++
+		loop:
+			for ; i < len(path); i++ {
+				switch path[i] {
+				case '\\':
+					i++
+				case '"':
+					break loop
+				}
+			}
+		case '[', '(', '{':
+			depth++
+		case ']', ')', '}':
+			depth--
+			if depth == 0 {
+				pushSel()
+				path = path[i+1:]
+				return sels, path, true
+			}
+		}
+	}
+	return
+}
+
+// nameOfLast returns the name of the last component
+func nameOfLast(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '|' || path[i] == '.' {
+			if i > 0 {
+				if path[i-1] == '\\' {
+					continue
+				}
+			}
+			return path[i+1:]
+		}
+	}
+	return path
+}
+
+func isSimpleName(component string) bool {
+	for i := 0; i < len(component); i++ {
+		if component[i] < ' ' {
+			return false
+		}
+		switch component[i] {
+		case '[', ']', '{', '}', '(', ')', '#', '|':
+			return false
+		}
+	}
+	return true
+}
+
+func appendJSONString(dst []byte, s string) []byte {
+	for i := 0; i < len(s); i++ {
+		if s[i] < ' ' || s[i] == '\\' || s[i] == '"' || s[i] > 126 {
+			d, _ := json.Marshal(s)
+			return append(dst, string(d)...)
+		}
+	}
+	dst = append(dst, '"')
+	dst = append(dst, s...)
+	dst = append(dst, '"')
+	return dst
+}
+
+type parseContext struct {
+	json  string
+	value Result
+	pipe  string
+	piped bool
+	calcd bool
+	lines bool
+}
+
+// Get searches json for the specified path.
+// A path is in dot syntax, such as "name.last" or "age".
+// When the value is found it's returned immediately.
+//
+// A path is a series of keys searated by a dot.
+// A key may contain special wildcard characters '*' and '?'.
+// To access an array value use the index as the key.
+// To get the number of elements in an array or to access a child path, use
+// the '#' character.
+// The dot and wildcard character can be escaped with '\'.
+//
+//  {
+//    "name": {"first": "Tom", "last": "Anderson"},
+//    "age":37,
+//    "children": ["Sara","Alex","Jack"],
+//    "friends": [
+//      {"first": "James", "last": "Murphy"},
+//      {"first": "Roger", "last": "Craig"}
+//    ]
+//  }
+//  "name.last"          >> "Anderson"
+//  "age"                >> 37
+//  "children"           >> ["Sara","Alex","Jack"]
+//  "children.#"         >> 3
+//  "children.1"         >> "Alex"
+//  "child*.2"           >> "Jack"
+//  "c?ildren.0"         >> "Sara"
+//  "friends.#.first"    >> ["James","Roger"]
+//
+// This function expects that the json is well-formed, and does not validate.
+// Invalid json will not panic, but it may return back unexpected results.
+// If you are consuming JSON from an unpredictable source then you may want to
+// use the Valid function first.
+func Get(json, path string) Result {
+	if len(path) > 1 {
+		if !DisableModifiers {
+			if path[0] == '@' {
+				// possible modifier
+				var ok bool
+				var npath string
+				var rjson string
+				npath, rjson, ok = execModifier(json, path)
+				if ok {
+					path = npath
+					if len(path) > 0 && (path[0] == '|' || path[0] == '.') {
+						res := Get(rjson, path[1:])
+						res.Index = 0
+						return res
+					}
+					return Parse(rjson)
+				}
+			}
+		}
+		if path[0] == '[' || path[0] == '{' {
+			// using a subselector path
+			kind := path[0]
+			var ok bool
+			var subs []subSelector
+			subs, path, ok = parseSubSelectors(path)
+			if ok {
+				if len(path) == 0 || (path[0] == '|' || path[0] == '.') {
+					var b []byte
+					b = append(b, kind)
+					var i int
+					for _, sub := range subs {
+						res := Get(json, sub.path)
+						if res.Exists() {
+							if i > 0 {
+								b = append(b, ',')
+							}
+							if kind == '{' {
+								if len(sub.name) > 0 {
+									if sub.name[0] == '"' && Valid(sub.name) {
+										b = append(b, sub.name...)
+									} else {
+										b = appendJSONString(b, sub.name)
+									}
+								} else {
+									last := nameOfLast(sub.path)
+									if isSimpleName(last) {
+										b = appendJSONString(b, last)
+									} else {
+										b = appendJSONString(b, "_")
+									}
+								}
+								b = append(b, ':')
+							}
+							var raw string
+							if len(res.Raw) == 0 {
+								raw = res.String()
+								if len(raw) == 0 {
+									raw = "null"
+								}
+							} else {
+								raw = res.Raw
+							}
+							b = append(b, raw...)
+							i++
+						}
+					}
+					b = append(b, kind+2)
+					var res Result
+					res.Raw = string(b)
+					res.Type = JSON
+					if len(path) > 0 {
+						res = res.Get(path[1:])
+					}
+					res.Index = 0
+					return res
+				}
+			}
+		}
+	}
+
+	var i int
+	var c = &parseContext{json: json}
+	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
+		c.lines = true
+		parseArray(c, 0, path[2:])
+	} else {
+		for ; i < len(c.json); i++ {
+			if c.json[i] == '{' {
+				i++
+				parseObject(c, i, path)
+				break
+			}
+			if c.json[i] == '[' {
+				i++
+				parseArray(c, i, path)
+				break
+			}
+		}
+	}
+	if c.piped {
+		res := c.value.Get(c.pipe)
+		res.Index = 0
+		return res
+	}
+	fillIndex(json, c)
+	return c.value
+}
+
+// GetBytes searches json for the specified path.
+// If working with bytes, this method preferred over Get(string(data), path)
+func GetBytes(json []byte, path string) Result {
+	return getBytes(json, path)
+}
+
+// runeit returns the rune from the the \uXXXX
+func runeit(json string) rune {
+	n, _ := strconv.ParseUint(json[:4], 16, 64)
+	return rune(n)
+}
+
+// unescape unescapes a string
+func unescape(json string) string { //, error) {
+	var str = make([]byte, 0, len(json))
+	for i := 0; i < len(json); i++ {
+		switch {
+		default:
+			str = append(str, json[i])
+		case json[i] < ' ':
+			return string(str)
+		case json[i] == '\\':
+			i++
+			if i >= len(json) {
+				return string(str)
+			}
+			switch json[i] {
+			default:
+				return string(str)
+			case '\\':
+				str = append(str, '\\')
+			case '/':
+				str = append(str, '/')
+			case 'b':
+				str = append(str, '\b')
+			case 'f':
+				str = append(str, '\f')
+			case 'n':
+				str = append(str, '\n')
+			case 'r':
+				str = append(str, '\r')
+			case 't':
+				str = append(str, '\t')
+			case '"':
+				str = append(str, '"')
+			case 'u':
+				if i+5 > len(json) {
+					return string(str)
+				}
+				r := runeit(json[i+1:])
+				i += 5
+				if utf16.IsSurrogate(r) {
+					// need another code
+					if len(json[i:]) >= 6 && json[i] == '\\' &&
+						json[i+1] == 'u' {
+						// we expect it to be correct so just consume it
+						r = utf16.DecodeRune(r, runeit(json[i+2:]))
+						i += 6
+					}
+				}
+				// provide enough space to encode the largest utf8 possible
+				str = append(str, 0, 0, 0, 0, 0, 0, 0, 0)
+				n := utf8.EncodeRune(str[len(str)-8:], r)
+				str = str[:len(str)-8+n]
+				i-- // backtrack index by one
+			}
+		}
+	}
+	return string(str)
+}
+
+// Less return true if a token is less than another token.
+// The caseSensitive paramater is used when the tokens are Strings.
+// The order when comparing two different type is:
+//
+//  Null < False < Number < String < True < JSON
+//
+func (t Result) Less(token Result, caseSensitive bool) bool {
+	if t.Type < token.Type {
+		return true
+	}
+	if t.Type > token.Type {
+		return false
+	}
+	if t.Type == String {
+		if caseSensitive {
+			return t.Str < token.Str
+		}
+		return stringLessInsensitive(t.Str, token.Str)
+	}
+	if t.Type == Number {
+		return t.Num < token.Num
+	}
+	return t.Raw < token.Raw
+}
+
+func stringLessInsensitive(a, b string) bool {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] >= 'A' && a[i] <= 'Z' {
+			if b[i] >= 'A' && b[i] <= 'Z' {
+				// both are uppercase, do nothing
+				if a[i] < b[i] {
+					return true
+				} else if a[i] > b[i] {
+					return false
+				}
+			} else {
+				// a is uppercase, convert a to lowercase
+				if a[i]+32 < b[i] {
+					return true
+				} else if a[i]+32 > b[i] {
+					return false
+				}
+			}
+		} else if b[i] >= 'A' && b[i] <= 'Z' {
+			// b is uppercase, convert b to lowercase
+			if a[i] < b[i]+32 {
+				return true
+			} else if a[i] > b[i]+32 {
+				return false
+			}
+		} else {
+			// neither are uppercase
+			if a[i] < b[i] {
+				return true
+			} else if a[i] > b[i] {
+				return false
+			}
+		}
+	}
+	return len(a) < len(b)
+}
+
+// parseAny parses the next value from a json string.
+// A Result is returned when the hit param is set.
+// The return values are (i int, res Result, ok bool)
+func parseAny(json string, i int, hit bool) (int, Result, bool) {
+	var res Result
+	var val string
+	for ; i < len(json); i++ {
+		if json[i] == '{' || json[i] == '[' {
+			i, val = parseSquash(json, i)
+			if hit {
+				res.Raw = val
+				res.Type = JSON
+			}
+			return i, res, true
+		}
+		if json[i] <= ' ' {
+			continue
+		}
+		switch json[i] {
+		case '"':
+			i++
+			var vesc bool
+			var ok bool
+			i, val, vesc, ok = parseString(json, i)
+			if !ok {
+				return i, res, false
+			}
+			if hit {
+				res.Type = String
+				res.Raw = val
+				if vesc {
+					res.Str = unescape(val[1 : len(val)-1])
+				} else {
+					res.Str = val[1 : len(val)-1]
+				}
+			}
+			return i, res, true
+		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			i, val = parseNumber(json, i)
+			if hit {
+				res.Raw = val
+				res.Type = Number
+				res.Num, _ = strconv.ParseFloat(val, 64)
+			}
+			return i, res, true
+		case 't', 'f', 'n':
+			vc := json[i]
+			i, val = parseLiteral(json, i)
+			if hit {
+				res.Raw = val
+				switch vc {
+				case 't':
+					res.Type = True
+				case 'f':
+					res.Type = False
+				}
+				return i, res, true
+			}
+		}
+	}
+	return i, res, false
+}
+
+var ( // used for testing
+	testWatchForFallback bool
+	testLastWasFallback  bool
+)
+
+// GetMany searches json for the multiple paths.
+// The return value is a Result array where the number of items
+// will be equal to the number of input paths.
+func GetMany(json string, path ...string) []Result {
+	res := make([]Result, len(path))
+	for i, path := range path {
+		res[i] = Get(json, path)
+	}
+	return res
+}
+
+// GetManyBytes searches json for the multiple paths.
+// The return value is a Result array where the number of items
+// will be equal to the number of input paths.
+func GetManyBytes(json []byte, path ...string) []Result {
+	res := make([]Result, len(path))
+	for i, path := range path {
+		res[i] = GetBytes(json, path)
+	}
+	return res
+}
+
+var fieldsmu sync.RWMutex
+var fields = make(map[string]map[string]int)
+
+func assign(jsval Result, goval reflect.Value) {
+	if jsval.Type == Null {
+		return
+	}
+	switch goval.Kind() {
+	default:
+	case reflect.Ptr:
+		if !goval.IsNil() {
+			newval := reflect.New(goval.Elem().Type())
+			assign(jsval, newval.Elem())
+			goval.Elem().Set(newval.Elem())
+		} else {
+			newval := reflect.New(goval.Type().Elem())
+			assign(jsval, newval.Elem())
+			goval.Set(newval)
+		}
+	case reflect.Struct:
+		fieldsmu.RLock()
+		sf := fields[goval.Type().String()]
+		fieldsmu.RUnlock()
+		if sf == nil {
+			fieldsmu.Lock()
+			sf = make(map[string]int)
+			for i := 0; i < goval.Type().NumField(); i++ {
+				f := goval.Type().Field(i)
+				tag := strings.Split(f.Tag.Get("json"), ",")[0]
+				if tag != "-" {
+					if tag != "" {
+						sf[tag] = i
+						sf[f.Name] = i
+					} else {
+						sf[f.Name] = i
+					}
+				}
+			}
+			fields[goval.Type().String()] = sf
+			fieldsmu.Unlock()
+		}
+		jsval.ForEach(func(key, value Result) bool {
+			if idx, ok := sf[key.Str]; ok {
+				f := goval.Field(idx)
+				if f.CanSet() {
+					assign(value, f)
+				}
+			}
+			return true
+		})
+	case reflect.Slice:
+		if goval.Type().Elem().Kind() == reflect.Uint8 &&
+			jsval.Type == String {
+			data, _ := base64.StdEncoding.DecodeString(jsval.String())
+			goval.Set(reflect.ValueOf(data))
+		} else {
+			jsvals := jsval.Array()
+			slice := reflect.MakeSlice(goval.Type(), len(jsvals), len(jsvals))
+			for i := 0; i < len(jsvals); i++ {
+				assign(jsvals[i], slice.Index(i))
+			}
+			goval.Set(slice)
+		}
+	case reflect.Array:
+		i, n := 0, goval.Len()
+		jsval.ForEach(func(_, value Result) bool {
+			if i == n {
+				return false
+			}
+			assign(value, goval.Index(i))
+			i++
+			return true
+		})
+	case reflect.Map:
+		if goval.Type().Key().Kind() == reflect.String &&
+			goval.Type().Elem().Kind() == reflect.Interface {
+			goval.Set(reflect.ValueOf(jsval.Value()))
+		}
+	case reflect.Interface:
+		goval.Set(reflect.ValueOf(jsval.Value()))
+	case reflect.Bool:
+		goval.SetBool(jsval.Bool())
+	case reflect.Float32, reflect.Float64:
+		goval.SetFloat(jsval.Float())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64:
+		goval.SetInt(jsval.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64:
+		goval.SetUint(jsval.Uint())
+	case reflect.String:
+		goval.SetString(jsval.String())
+	}
+	if len(goval.Type().PkgPath()) > 0 {
+		v := goval.Addr()
+		if v.Type().NumMethod() > 0 {
+			if u, ok := v.Interface().(json.Unmarshaler); ok {
+				u.UnmarshalJSON([]byte(jsval.Raw))
+			}
+		}
+	}
+}
+
+var validate uintptr = 1
+
+// UnmarshalValidationEnabled provides the option to disable JSON validation
+// during the Unmarshal routine. Validation is enabled by default.
+//
+// Deprecated: Use encoder/json.Unmarshal instead
+func UnmarshalValidationEnabled(enabled bool) {
+	if enabled {
+		atomic.StoreUintptr(&validate, 1)
+	} else {
+		atomic.StoreUintptr(&validate, 0)
+	}
+}
+
+// Unmarshal loads the JSON data into the value pointed to by v.
+//
+// This function works almost identically to json.Unmarshal except  that
+// gjson.Unmarshal will automatically attempt to convert JSON values to any Go
+// type. For example, the JSON string "100" or the JSON number 100 can be
+// equally assigned to Go string, int, byte, uint64, etc. This rule applies to
+// all types.
+//
+// Deprecated: Use encoder/json.Unmarshal instead
+func Unmarshal(data []byte, v interface{}) error {
+	if atomic.LoadUintptr(&validate) == 1 {
+		_, ok := validpayload(data, 0)
+		if !ok {
+			return errors.New("invalid json")
+		}
+	}
+	if v := reflect.ValueOf(v); v.Kind() == reflect.Ptr {
+		assign(ParseBytes(data), v)
+	}
+	return nil
+}
+
+func validpayload(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			i, ok = validany(data, i)
+			if !ok {
+				return i, false
+			}
+			for ; i < len(data); i++ {
+				switch data[i] {
+				default:
+					return i, false
+				case ' ', '\t', '\n', '\r':
+					continue
+				}
+			}
+			return i, true
+		case ' ', '\t', '\n', '\r':
+			continue
+		}
+	}
+	return i, false
+}
+func validany(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			return i, false
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '{':
+			return validobject(data, i+1)
+		case '[':
+			return validarray(data, i+1)
+		case '"':
+			return validstring(data, i+1)
+		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			return validnumber(data, i+1)
+		case 't':
+			return validtrue(data, i+1)
+		case 'f':
+			return validfalse(data, i+1)
+		case 'n':
+			return validnull(data, i+1)
+		}
+	}
+	return i, false
+}
+func validobject(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			return i, false
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '}':
+			return i + 1, true
+		case '"':
+		key:
+			if i, ok = validstring(data, i+1); !ok {
+				return i, false
+			}
+			if i, ok = validcolon(data, i); !ok {
+				return i, false
+			}
+			if i, ok = validany(data, i); !ok {
+				return i, false
+			}
+			if i, ok = validcomma(data, i, '}'); !ok {
+				return i, false
+			}
+			if data[i] == '}' {
+				return i + 1, true
+			}
+			i++
+			for ; i < len(data); i++ {
+				switch data[i] {
+				default:
+					return i, false
+				case ' ', '\t', '\n', '\r':
+					continue
+				case '"':
+					goto key
+				}
+			}
+			return i, false
+		}
+	}
+	return i, false
+}
+func validcolon(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			return i, false
+		case ' ', '\t', '\n', '\r':
+			continue
+		case ':':
+			return i + 1, true
+		}
+	}
+	return i, false
+}
+func validcomma(data []byte, i int, end byte) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			return i, false
+		case ' ', '\t', '\n', '\r':
+			continue
+		case ',':
+			return i, true
+		case end:
+			return i, true
+		}
+	}
+	return i, false
+}
+func validarray(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		switch data[i] {
+		default:
+			for ; i < len(data); i++ {
+				if i, ok = validany(data, i); !ok {
+					return i, false
+				}
+				if i, ok = validcomma(data, i, ']'); !ok {
+					return i, false
+				}
+				if data[i] == ']' {
+					return i + 1, true
+				}
+			}
+		case ' ', '\t', '\n', '\r':
+			continue
+		case ']':
+			return i + 1, true
+		}
+	}
+	return i, false
+}
+func validstring(data []byte, i int) (outi int, ok bool) {
+	for ; i < len(data); i++ {
+		if data[i] < ' ' {
+			return i, false
+		} else if data[i] == '\\' {
+			i++
+			if i == len(data) {
+				return i, false
+			}
+			switch data[i] {
+			default:
+				return i, false
+			case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+			case 'u':
+				for j := 0; j < 4; j++ {
+					i++
+					if i >= len(data) {
+						return i, false
+					}
+					if !((data[i] >= '0' && data[i] <= '9') ||
+						(data[i] >= 'a' && data[i] <= 'f') ||
+						(data[i] >= 'A' && data[i] <= 'F')) {
+						return i, false
+					}
+				}
+			}
+		} else if data[i] == '"' {
+			return i + 1, true
+		}
+	}
+	return i, false
+}
+func validnumber(data []byte, i int) (outi int, ok bool) {
+	i--
+	// sign
+	if data[i] == '-' {
+		i++
+	}
+	// int
+	if i == len(data) {
+		return i, false
+	}
+	if data[i] == '0' {
+		i++
+	} else {
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
+			}
+			break
+		}
+	}
+	// frac
+	if i == len(data) {
+		return i, true
+	}
+	if data[i] == '.' {
+		i++
+		if i == len(data) {
+			return i, false
+		}
+		if data[i] < '0' || data[i] > '9' {
+			return i, false
+		}
+		i++
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
+			}
+			break
+		}
+	}
+	// exp
+	if i == len(data) {
+		return i, true
+	}
+	if data[i] == 'e' || data[i] == 'E' {
+		i++
+		if i == len(data) {
+			return i, false
+		}
+		if data[i] == '+' || data[i] == '-' {
+			i++
+		}
+		if i == len(data) {
+			return i, false
+		}
+		if data[i] < '0' || data[i] > '9' {
+			return i, false
+		}
+		i++
+		for ; i < len(data); i++ {
+			if data[i] >= '0' && data[i] <= '9' {
+				continue
+			}
+			break
+		}
+	}
+	return i, true
+}
+
+func validtrue(data []byte, i int) (outi int, ok bool) {
+	if i+3 <= len(data) && data[i] == 'r' && data[i+1] == 'u' &&
+		data[i+2] == 'e' {
+		return i + 3, true
+	}
+	return i, false
+}
+func validfalse(data []byte, i int) (outi int, ok bool) {
+	if i+4 <= len(data) && data[i] == 'a' && data[i+1] == 'l' &&
+		data[i+2] == 's' && data[i+3] == 'e' {
+		return i + 4, true
+	}
+	return i, false
+}
+func validnull(data []byte, i int) (outi int, ok bool) {
+	if i+3 <= len(data) && data[i] == 'u' && data[i+1] == 'l' &&
+		data[i+2] == 'l' {
+		return i + 3, true
+	}
+	return i, false
+}
+
+// Valid returns true if the input is valid json.
+//
+//  if !gjson.Valid(json) {
+//  	return errors.New("invalid json")
+//  }
+//  value := gjson.Get(json, "name.last")
+//
+func Valid(json string) bool {
+	_, ok := validpayload(stringBytes(json), 0)
+	return ok
+}
+
+// ValidBytes returns true if the input is valid json.
+//
+//  if !gjson.Valid(json) {
+//  	return errors.New("invalid json")
+//  }
+//  value := gjson.Get(json, "name.last")
+//
+// If working with bytes, this method preferred over ValidBytes(string(data))
+//
+func ValidBytes(json []byte) bool {
+	_, ok := validpayload(json, 0)
+	return ok
+}
+
+func parseUint(s string) (n uint64, ok bool) {
+	var i int
+	if i == len(s) {
+		return 0, false
+	}
+	for ; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			n = n*10 + uint64(s[i]-'0')
+		} else {
+			return 0, false
+		}
+	}
+	return n, true
+}
+
+func parseInt(s string) (n int64, ok bool) {
+	var i int
+	var sign bool
+	if len(s) > 0 && s[0] == '-' {
+		sign = true
+		i++
+	}
+	if i == len(s) {
+		return 0, false
+	}
+	for ; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			n = n*10 + int64(s[i]-'0')
+		} else {
+			return 0, false
+		}
+	}
+	if sign {
+		return n * -1, true
+	}
+	return n, true
+}
+
+const minUint53 = 0
+const maxUint53 = 4503599627370495
+const minInt53 = -2251799813685248
+const maxInt53 = 2251799813685247
+
+func floatToUint(f float64) (n uint64, ok bool) {
+	n = uint64(f)
+	if float64(n) == f && n >= minUint53 && n <= maxUint53 {
+		return n, true
+	}
+	return 0, false
+}
+
+func floatToInt(f float64) (n int64, ok bool) {
+	n = int64(f)
+	if float64(n) == f && n >= minInt53 && n <= maxInt53 {
+		return n, true
+	}
+	return 0, false
+}
+
+// execModifier parses the path to find a matching modifier function.
+// then input expects that the path already starts with a '@'
+func execModifier(json, path string) (pathOut, res string, ok bool) {
+	name := path[1:]
+	var hasArgs bool
+	for i := 1; i < len(path); i++ {
+		if path[i] == ':' {
+			pathOut = path[i+1:]
+			name = path[1:i]
+			hasArgs = len(pathOut) > 0
+			break
+		}
+		if path[i] == '|' {
+			pathOut = path[i:]
+			name = path[1:i]
+			break
+		}
+		if path[i] == '.' {
+			pathOut = path[i:]
+			name = path[1:i]
+			break
+		}
+	}
+	if fn, ok := modifiers[name]; ok {
+		var args string
+		if hasArgs {
+			var parsedArgs bool
+			switch pathOut[0] {
+			case '{', '[', '"':
+				res := Parse(pathOut)
+				if res.Exists() {
+					_, args = parseSquash(pathOut, 0)
+					pathOut = pathOut[len(args):]
+					parsedArgs = true
+				}
+			}
+			if !parsedArgs {
+				idx := strings.IndexByte(pathOut, '|')
+				if idx == -1 {
+					args = pathOut
+					pathOut = ""
+				} else {
+					args = pathOut[:idx]
+					pathOut = pathOut[idx:]
+				}
+			}
+		}
+		return pathOut, fn(json, args), true
+	}
+	return pathOut, res, false
+}
+
+// DisableModifiers will disable the modifier syntax
+var DisableModifiers = false
+
+var modifiers = map[string]func(json, arg string) string{
+	"pretty":  modPretty,
+	"ugly":    modUgly,
+	"reverse": modReverse,
+}
+
+// AddModifier binds a custom modifier command to the GJSON syntax.
+// This operation is not thread safe and should be executed prior to
+// using all other gjson function.
+func AddModifier(name string, fn func(json, arg string) string) {
+	modifiers[name] = fn
+}
+
+// ModifierExists returns true when the specified modifier exists.
+func ModifierExists(name string, fn func(json, arg string) string) bool {
+	_, ok := modifiers[name]
+	return ok
+}
+
+// @pretty modifier makes the json look nice.
+func modPretty(json, arg string) string {
+	if len(arg) > 0 {
+		opts := *pretty.DefaultOptions
+		Parse(arg).ForEach(func(key, value Result) bool {
+			switch key.String() {
+			case "sortKeys":
+				opts.SortKeys = value.Bool()
+			case "indent":
+				opts.Indent = value.String()
+			case "prefix":
+				opts.Prefix = value.String()
+			case "width":
+				opts.Width = int(value.Int())
+			}
+			return true
+		})
+		return bytesString(pretty.PrettyOptions(stringBytes(json), &opts))
+	}
+	return bytesString(pretty.Pretty(stringBytes(json)))
+}
+
+// @ugly modifier removes all whitespace.
+func modUgly(json, arg string) string {
+	return bytesString(pretty.Ugly(stringBytes(json)))
+}
+
+// @reverse reverses array elements or root object members.
+func modReverse(json, arg string) string {
+	res := Parse(json)
+	if res.IsArray() {
+		var values []Result
+		res.ForEach(func(_, value Result) bool {
+			values = append(values, value)
+			return true
+		})
+		out := make([]byte, 0, len(json))
+		out = append(out, '[')
+		for i, j := len(values)-1, 0; i >= 0; i, j = i-1, j+1 {
+			if j > 0 {
+				out = append(out, ',')
+			}
+			out = append(out, values[i].Raw...)
+		}
+		out = append(out, ']')
+		return bytesString(out)
+	}
+	if res.IsObject() {
+		var keyValues []Result
+		res.ForEach(func(key, value Result) bool {
+			keyValues = append(keyValues, key, value)
+			return true
+		})
+		out := make([]byte, 0, len(json))
+		out = append(out, '{')
+		for i, j := len(keyValues)-2, 0; i >= 0; i, j = i-2, j+1 {
+			if j > 0 {
+				out = append(out, ',')
+			}
+			out = append(out, keyValues[i+0].Raw...)
+			out = append(out, ':')
+			out = append(out, keyValues[i+1].Raw...)
+		}
+		out = append(out, '}')
+		return bytesString(out)
+	}
+	return json
+}

--- a/vendor/github.com/tidwall/gjson/gjson_gae.go
+++ b/vendor/github.com/tidwall/gjson/gjson_gae.go
@@ -1,0 +1,18 @@
+//+build appengine js
+
+package gjson
+
+func getBytes(json []byte, path string) Result {
+	return Get(string(json), path)
+}
+func fillIndex(json string, c *parseContext) {
+	// noop. Use zero for the Index value.
+}
+
+func stringBytes(s string) []byte {
+	return []byte(s)
+}
+
+func bytesString(b []byte) string {
+	return string(b)
+}

--- a/vendor/github.com/tidwall/gjson/gjson_ngae.go
+++ b/vendor/github.com/tidwall/gjson/gjson_ngae.go
@@ -1,0 +1,81 @@
+//+build !appengine
+//+build !js
+
+package gjson
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// getBytes casts the input json bytes to a string and safely returns the
+// results as uniquely allocated data. This operation is intended to minimize
+// copies and allocations for the large json string->[]byte.
+func getBytes(json []byte, path string) Result {
+	var result Result
+	if json != nil {
+		// unsafe cast to string
+		result = Get(*(*string)(unsafe.Pointer(&json)), path)
+		// safely get the string headers
+		rawhi := *(*reflect.StringHeader)(unsafe.Pointer(&result.Raw))
+		strhi := *(*reflect.StringHeader)(unsafe.Pointer(&result.Str))
+		// create byte slice headers
+		rawh := reflect.SliceHeader{Data: rawhi.Data, Len: rawhi.Len}
+		strh := reflect.SliceHeader{Data: strhi.Data, Len: strhi.Len}
+		if strh.Data == 0 {
+			// str is nil
+			if rawh.Data == 0 {
+				// raw is nil
+				result.Raw = ""
+			} else {
+				// raw has data, safely copy the slice header to a string
+				result.Raw = string(*(*[]byte)(unsafe.Pointer(&rawh)))
+			}
+			result.Str = ""
+		} else if rawh.Data == 0 {
+			// raw is nil
+			result.Raw = ""
+			// str has data, safely copy the slice header to a string
+			result.Str = string(*(*[]byte)(unsafe.Pointer(&strh)))
+		} else if strh.Data >= rawh.Data &&
+			int(strh.Data)+strh.Len <= int(rawh.Data)+rawh.Len {
+			// Str is a substring of Raw.
+			start := int(strh.Data - rawh.Data)
+			// safely copy the raw slice header
+			result.Raw = string(*(*[]byte)(unsafe.Pointer(&rawh)))
+			// substring the raw
+			result.Str = result.Raw[start : start+strh.Len]
+		} else {
+			// safely copy both the raw and str slice headers to strings
+			result.Raw = string(*(*[]byte)(unsafe.Pointer(&rawh)))
+			result.Str = string(*(*[]byte)(unsafe.Pointer(&strh)))
+		}
+	}
+	return result
+}
+
+// fillIndex finds the position of Raw data and assigns it to the Index field
+// of the resulting value. If the position cannot be found then Index zero is
+// used instead.
+func fillIndex(json string, c *parseContext) {
+	if len(c.value.Raw) > 0 && !c.calcd {
+		jhdr := *(*reflect.StringHeader)(unsafe.Pointer(&json))
+		rhdr := *(*reflect.StringHeader)(unsafe.Pointer(&(c.value.Raw)))
+		c.value.Index = int(rhdr.Data - jhdr.Data)
+		if c.value.Index < 0 || c.value.Index >= len(json) {
+			c.value.Index = 0
+		}
+	}
+}
+
+func stringBytes(s string) []byte {
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: (*reflect.StringHeader)(unsafe.Pointer(&s)).Data,
+		Len:  len(s),
+		Cap:  len(s),
+	}))
+}
+
+func bytesString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/vendor/github.com/tidwall/match/LICENSE
+++ b/vendor/github.com/tidwall/match/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Josh Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tidwall/match/match.go
+++ b/vendor/github.com/tidwall/match/match.go
@@ -1,0 +1,181 @@
+// Match provides a simple pattern matcher with unicode support.
+package match
+
+import "unicode/utf8"
+
+// Match returns true if str matches pattern. This is a very
+// simple wildcard match where '*' matches on any number characters
+// and '?' matches on any one character.
+
+// pattern:
+// 	{ term }
+// term:
+// 	'*'         matches any sequence of non-Separator characters
+// 	'?'         matches any single non-Separator character
+// 	c           matches character c (c != '*', '?', '\\')
+// 	'\\' c      matches character c
+//
+func Match(str, pattern string) bool {
+	if pattern == "*" {
+		return true
+	}
+	return deepMatch(str, pattern)
+}
+func deepMatch(str, pattern string) bool {
+	for len(pattern) > 0 {
+		if pattern[0] > 0x7f {
+			return deepMatchRune(str, pattern)
+		}
+		switch pattern[0] {
+		default:
+			if len(str) == 0 {
+				return false
+			}
+			if str[0] > 0x7f {
+				return deepMatchRune(str, pattern)
+			}
+			if str[0] != pattern[0] {
+				return false
+			}
+		case '?':
+			if len(str) == 0 {
+				return false
+			}
+		case '*':
+			return deepMatch(str, pattern[1:]) ||
+				(len(str) > 0 && deepMatch(str[1:], pattern))
+		}
+		str = str[1:]
+		pattern = pattern[1:]
+	}
+	return len(str) == 0 && len(pattern) == 0
+}
+
+func deepMatchRune(str, pattern string) bool {
+	var sr, pr rune
+	var srsz, prsz int
+
+	// read the first rune ahead of time
+	if len(str) > 0 {
+		if str[0] > 0x7f {
+			sr, srsz = utf8.DecodeRuneInString(str)
+		} else {
+			sr, srsz = rune(str[0]), 1
+		}
+	} else {
+		sr, srsz = utf8.RuneError, 0
+	}
+	if len(pattern) > 0 {
+		if pattern[0] > 0x7f {
+			pr, prsz = utf8.DecodeRuneInString(pattern)
+		} else {
+			pr, prsz = rune(pattern[0]), 1
+		}
+	} else {
+		pr, prsz = utf8.RuneError, 0
+	}
+	// done reading
+	for pr != utf8.RuneError {
+		switch pr {
+		default:
+			if srsz == utf8.RuneError {
+				return false
+			}
+			if sr != pr {
+				return false
+			}
+		case '?':
+			if srsz == utf8.RuneError {
+				return false
+			}
+		case '*':
+			return deepMatchRune(str, pattern[prsz:]) ||
+				(srsz > 0 && deepMatchRune(str[srsz:], pattern))
+		}
+		str = str[srsz:]
+		pattern = pattern[prsz:]
+		// read the next runes
+		if len(str) > 0 {
+			if str[0] > 0x7f {
+				sr, srsz = utf8.DecodeRuneInString(str)
+			} else {
+				sr, srsz = rune(str[0]), 1
+			}
+		} else {
+			sr, srsz = utf8.RuneError, 0
+		}
+		if len(pattern) > 0 {
+			if pattern[0] > 0x7f {
+				pr, prsz = utf8.DecodeRuneInString(pattern)
+			} else {
+				pr, prsz = rune(pattern[0]), 1
+			}
+		} else {
+			pr, prsz = utf8.RuneError, 0
+		}
+		// done reading
+	}
+
+	return srsz == 0 && prsz == 0
+}
+
+var maxRuneBytes = func() []byte {
+	b := make([]byte, 4)
+	if utf8.EncodeRune(b, '\U0010FFFF') != 4 {
+		panic("invalid rune encoding")
+	}
+	return b
+}()
+
+// Allowable parses the pattern and determines the minimum and maximum allowable
+// values that the pattern can represent.
+// When the max cannot be determined, 'true' will be returned
+// for infinite.
+func Allowable(pattern string) (min, max string) {
+	if pattern == "" || pattern[0] == '*' {
+		return "", ""
+	}
+
+	minb := make([]byte, 0, len(pattern))
+	maxb := make([]byte, 0, len(pattern))
+	var wild bool
+	for i := 0; i < len(pattern); i++ {
+		if pattern[i] == '*' {
+			wild = true
+			break
+		}
+		if pattern[i] == '?' {
+			minb = append(minb, 0)
+			maxb = append(maxb, maxRuneBytes...)
+		} else {
+			minb = append(minb, pattern[i])
+			maxb = append(maxb, pattern[i])
+		}
+	}
+	if wild {
+		r, n := utf8.DecodeLastRune(maxb)
+		if r != utf8.RuneError {
+			if r < utf8.MaxRune {
+				r++
+				if r > 0x7f {
+					b := make([]byte, 4)
+					nn := utf8.EncodeRune(b, r)
+					maxb = append(maxb[:len(maxb)-n], b[:nn]...)
+				} else {
+					maxb = append(maxb[:len(maxb)-n], byte(r))
+				}
+			}
+		}
+	}
+	return string(minb), string(maxb)
+}
+
+// IsPattern returns true if the string is a pattern.
+func IsPattern(str string) bool {
+	for i := 0; i < len(str); i++ {
+		if str[i] == '*' || str[i] == '?' {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/tidwall/pretty/LICENSE
+++ b/vendor/github.com/tidwall/pretty/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Josh Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/tidwall/pretty/pretty.go
+++ b/vendor/github.com/tidwall/pretty/pretty.go
@@ -1,0 +1,432 @@
+package pretty
+
+import (
+	"sort"
+)
+
+// Options is Pretty options
+type Options struct {
+	// Width is an max column width for single line arrays
+	// Default is 80
+	Width int
+	// Prefix is a prefix for all lines
+	// Default is an empty string
+	Prefix string
+	// Indent is the nested indentation
+	// Default is two spaces
+	Indent string
+	// SortKeys will sort the keys alphabetically
+	// Default is false
+	SortKeys bool
+}
+
+// DefaultOptions is the default options for pretty formats.
+var DefaultOptions = &Options{Width: 80, Prefix: "", Indent: "  ", SortKeys: false}
+
+// Pretty converts the input json into a more human readable format where each
+// element is on it's own line with clear indentation.
+func Pretty(json []byte) []byte { return PrettyOptions(json, nil) }
+
+// PrettyOptions is like Pretty but with customized options.
+func PrettyOptions(json []byte, opts *Options) []byte {
+	if opts == nil {
+		opts = DefaultOptions
+	}
+	buf := make([]byte, 0, len(json))
+	if len(opts.Prefix) != 0 {
+		buf = append(buf, opts.Prefix...)
+	}
+	buf, _, _, _ = appendPrettyAny(buf, json, 0, true,
+		opts.Width, opts.Prefix, opts.Indent, opts.SortKeys,
+		0, 0, -1)
+	if len(buf) > 0 {
+		buf = append(buf, '\n')
+	}
+	return buf
+}
+
+// Ugly removes insignificant space characters from the input json byte slice
+// and returns the compacted result.
+func Ugly(json []byte) []byte {
+	buf := make([]byte, 0, len(json))
+	return ugly(buf, json)
+}
+
+// UglyInPlace removes insignificant space characters from the input json
+// byte slice and returns the compacted result. This method reuses the
+// input json buffer to avoid allocations. Do not use the original bytes
+// slice upon return.
+func UglyInPlace(json []byte) []byte { return ugly(json, json) }
+
+func ugly(dst, src []byte) []byte {
+	dst = dst[:0]
+	for i := 0; i < len(src); i++ {
+		if src[i] > ' ' {
+			dst = append(dst, src[i])
+			if src[i] == '"' {
+				for i = i + 1; i < len(src); i++ {
+					dst = append(dst, src[i])
+					if src[i] == '"' {
+						j := i - 1
+						for ; ; j-- {
+							if src[j] != '\\' {
+								break
+							}
+						}
+						if (j-i)%2 != 0 {
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	return dst
+}
+
+func appendPrettyAny(buf, json []byte, i int, pretty bool, width int, prefix, indent string, sortkeys bool, tabs, nl, max int) ([]byte, int, int, bool) {
+	for ; i < len(json); i++ {
+		if json[i] <= ' ' {
+			continue
+		}
+		if json[i] == '"' {
+			return appendPrettyString(buf, json, i, nl)
+		}
+		if (json[i] >= '0' && json[i] <= '9') || json[i] == '-' {
+			return appendPrettyNumber(buf, json, i, nl)
+		}
+		if json[i] == '{' {
+			return appendPrettyObject(buf, json, i, '{', '}', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
+		}
+		if json[i] == '[' {
+			return appendPrettyObject(buf, json, i, '[', ']', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
+		}
+		switch json[i] {
+		case 't':
+			return append(buf, 't', 'r', 'u', 'e'), i + 4, nl, true
+		case 'f':
+			return append(buf, 'f', 'a', 'l', 's', 'e'), i + 5, nl, true
+		case 'n':
+			return append(buf, 'n', 'u', 'l', 'l'), i + 4, nl, true
+		}
+	}
+	return buf, i, nl, true
+}
+
+type pair struct {
+	kstart, kend int
+	vstart, vend int
+}
+
+type byKey struct {
+	sorted bool
+	json   []byte
+	pairs  []pair
+}
+
+func (arr *byKey) Len() int {
+	return len(arr.pairs)
+}
+func (arr *byKey) Less(i, j int) bool {
+	key1 := arr.json[arr.pairs[i].kstart+1 : arr.pairs[i].kend-1]
+	key2 := arr.json[arr.pairs[j].kstart+1 : arr.pairs[j].kend-1]
+	return string(key1) < string(key2)
+}
+func (arr *byKey) Swap(i, j int) {
+	arr.pairs[i], arr.pairs[j] = arr.pairs[j], arr.pairs[i]
+	arr.sorted = true
+}
+
+func appendPrettyObject(buf, json []byte, i int, open, close byte, pretty bool, width int, prefix, indent string, sortkeys bool, tabs, nl, max int) ([]byte, int, int, bool) {
+	var ok bool
+	if width > 0 {
+		if pretty && open == '[' && max == -1 {
+			// here we try to create a single line array
+			max := width - (len(buf) - nl)
+			if max > 3 {
+				s1, s2 := len(buf), i
+				buf, i, _, ok = appendPrettyObject(buf, json, i, '[', ']', false, width, prefix, "", sortkeys, 0, 0, max)
+				if ok && len(buf)-s1 <= max {
+					return buf, i, nl, true
+				}
+				buf = buf[:s1]
+				i = s2
+			}
+		} else if max != -1 && open == '{' {
+			return buf, i, nl, false
+		}
+	}
+	buf = append(buf, open)
+	i++
+	var pairs []pair
+	if open == '{' && sortkeys {
+		pairs = make([]pair, 0, 8)
+	}
+	var n int
+	for ; i < len(json); i++ {
+		if json[i] <= ' ' {
+			continue
+		}
+		if json[i] == close {
+			if pretty {
+				if open == '{' && sortkeys {
+					buf = sortPairs(json, buf, pairs)
+				}
+				if n > 0 {
+					nl = len(buf)
+					buf = append(buf, '\n')
+				}
+				if buf[len(buf)-1] != open {
+					buf = appendTabs(buf, prefix, indent, tabs)
+				}
+			}
+			buf = append(buf, close)
+			return buf, i + 1, nl, open != '{'
+		}
+		if open == '[' || json[i] == '"' {
+			if n > 0 {
+				buf = append(buf, ',')
+				if width != -1 && open == '[' {
+					buf = append(buf, ' ')
+				}
+			}
+			var p pair
+			if pretty {
+				nl = len(buf)
+				buf = append(buf, '\n')
+				if open == '{' && sortkeys {
+					p.kstart = i
+					p.vstart = len(buf)
+				}
+				buf = appendTabs(buf, prefix, indent, tabs+1)
+			}
+			if open == '{' {
+				buf, i, nl, _ = appendPrettyString(buf, json, i, nl)
+				if sortkeys {
+					p.kend = i
+				}
+				buf = append(buf, ':')
+				if pretty {
+					buf = append(buf, ' ')
+				}
+			}
+			buf, i, nl, ok = appendPrettyAny(buf, json, i, pretty, width, prefix, indent, sortkeys, tabs+1, nl, max)
+			if max != -1 && !ok {
+				return buf, i, nl, false
+			}
+			if pretty && open == '{' && sortkeys {
+				p.vend = len(buf)
+				if p.kstart > p.kend || p.vstart > p.vend {
+					// bad data. disable sorting
+					sortkeys = false
+				} else {
+					pairs = append(pairs, p)
+				}
+			}
+			i--
+			n++
+		}
+	}
+	return buf, i, nl, open != '{'
+}
+func sortPairs(json, buf []byte, pairs []pair) []byte {
+	if len(pairs) == 0 {
+		return buf
+	}
+	vstart := pairs[0].vstart
+	vend := pairs[len(pairs)-1].vend
+	arr := byKey{false, json, pairs}
+	sort.Sort(&arr)
+	if !arr.sorted {
+		return buf
+	}
+	nbuf := make([]byte, 0, vend-vstart)
+	for i, p := range pairs {
+		nbuf = append(nbuf, buf[p.vstart:p.vend]...)
+		if i < len(pairs)-1 {
+			nbuf = append(nbuf, ',')
+			nbuf = append(nbuf, '\n')
+		}
+	}
+	return append(buf[:vstart], nbuf...)
+}
+
+func appendPrettyString(buf, json []byte, i, nl int) ([]byte, int, int, bool) {
+	s := i
+	i++
+	for ; i < len(json); i++ {
+		if json[i] == '"' {
+			var sc int
+			for j := i - 1; j > s; j-- {
+				if json[j] == '\\' {
+					sc++
+				} else {
+					break
+				}
+			}
+			if sc%2 == 1 {
+				continue
+			}
+			i++
+			break
+		}
+	}
+	return append(buf, json[s:i]...), i, nl, true
+}
+
+func appendPrettyNumber(buf, json []byte, i, nl int) ([]byte, int, int, bool) {
+	s := i
+	i++
+	for ; i < len(json); i++ {
+		if json[i] <= ' ' || json[i] == ',' || json[i] == ':' || json[i] == ']' || json[i] == '}' {
+			break
+		}
+	}
+	return append(buf, json[s:i]...), i, nl, true
+}
+
+func appendTabs(buf []byte, prefix, indent string, tabs int) []byte {
+	if len(prefix) != 0 {
+		buf = append(buf, prefix...)
+	}
+	if len(indent) == 2 && indent[0] == ' ' && indent[1] == ' ' {
+		for i := 0; i < tabs; i++ {
+			buf = append(buf, ' ', ' ')
+		}
+	} else {
+		for i := 0; i < tabs; i++ {
+			buf = append(buf, indent...)
+		}
+	}
+	return buf
+}
+
+// Style is the color style
+type Style struct {
+	Key, String, Number [2]string
+	True, False, Null   [2]string
+	Append              func(dst []byte, c byte) []byte
+}
+
+func hexp(p byte) byte {
+	switch {
+	case p < 10:
+		return p + '0'
+	default:
+		return (p - 10) + 'a'
+	}
+}
+
+// TerminalStyle is for terminals
+var TerminalStyle = &Style{
+	Key:    [2]string{"\x1B[94m", "\x1B[0m"},
+	String: [2]string{"\x1B[92m", "\x1B[0m"},
+	Number: [2]string{"\x1B[93m", "\x1B[0m"},
+	True:   [2]string{"\x1B[96m", "\x1B[0m"},
+	False:  [2]string{"\x1B[96m", "\x1B[0m"},
+	Null:   [2]string{"\x1B[91m", "\x1B[0m"},
+	Append: func(dst []byte, c byte) []byte {
+		if c < ' ' && (c != '\r' && c != '\n' && c != '\t' && c != '\v') {
+			dst = append(dst, "\\u00"...)
+			dst = append(dst, hexp((c>>4)&0xF))
+			return append(dst, hexp((c)&0xF))
+		}
+		return append(dst, c)
+	},
+}
+
+// Color will colorize the json. The style parma is used for customizing
+// the colors. Passing nil to the style param will use the default
+// TerminalStyle.
+func Color(src []byte, style *Style) []byte {
+	if style == nil {
+		style = TerminalStyle
+	}
+	apnd := style.Append
+	if apnd == nil {
+		apnd = func(dst []byte, c byte) []byte {
+			return append(dst, c)
+		}
+	}
+	type stackt struct {
+		kind byte
+		key  bool
+	}
+	var dst []byte
+	var stack []stackt
+	for i := 0; i < len(src); i++ {
+		if src[i] == '"' {
+			key := len(stack) > 0 && stack[len(stack)-1].key
+			if key {
+				dst = append(dst, style.Key[0]...)
+			} else {
+				dst = append(dst, style.String[0]...)
+			}
+			dst = apnd(dst, '"')
+			for i = i + 1; i < len(src); i++ {
+				dst = apnd(dst, src[i])
+				if src[i] == '"' {
+					j := i - 1
+					for ; ; j-- {
+						if src[j] != '\\' {
+							break
+						}
+					}
+					if (j-i)%2 != 0 {
+						break
+					}
+				}
+			}
+			if key {
+				dst = append(dst, style.Key[1]...)
+			} else {
+				dst = append(dst, style.String[1]...)
+			}
+		} else if src[i] == '{' || src[i] == '[' {
+			stack = append(stack, stackt{src[i], src[i] == '{'})
+			dst = apnd(dst, src[i])
+		} else if (src[i] == '}' || src[i] == ']') && len(stack) > 0 {
+			stack = stack[:len(stack)-1]
+			dst = apnd(dst, src[i])
+		} else if (src[i] == ':' || src[i] == ',') && len(stack) > 0 && stack[len(stack)-1].kind == '{' {
+			stack[len(stack)-1].key = !stack[len(stack)-1].key
+			dst = apnd(dst, src[i])
+		} else {
+			var kind byte
+			if (src[i] >= '0' && src[i] <= '9') || src[i] == '-' {
+				kind = '0'
+				dst = append(dst, style.Number[0]...)
+			} else if src[i] == 't' {
+				kind = 't'
+				dst = append(dst, style.True[0]...)
+			} else if src[i] == 'f' {
+				kind = 'f'
+				dst = append(dst, style.False[0]...)
+			} else if src[i] == 'n' {
+				kind = 'n'
+				dst = append(dst, style.Null[0]...)
+			} else {
+				dst = apnd(dst, src[i])
+			}
+			if kind != 0 {
+				for ; i < len(src); i++ {
+					if src[i] <= ' ' || src[i] == ',' || src[i] == ':' || src[i] == ']' || src[i] == '}' {
+						i--
+						break
+					}
+					dst = apnd(dst, src[i])
+				}
+				if kind == '0' {
+					dst = append(dst, style.Number[1]...)
+				} else if kind == 't' {
+					dst = append(dst, style.True[1]...)
+				} else if kind == 'f' {
+					dst = append(dst, style.False[1]...)
+				} else if kind == 'n' {
+					dst = append(dst, style.Null[1]...)
+				}
+			}
+		}
+	}
+	return dst
+}


### PR DESCRIPTION
Only future version of nmstate/[NM](https://github.com/nmstate/nmstate/pull/440) supports linux bridges vlan filtering,
to bypass this problem this PR calls iproute commands ip/bridge to set the
vlan_filtering flag and add all vlans to the bridges itself and to outbound
interfaces.
