### PR TITLE
Fix vlan work around

### DIFF
--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-vlan_range=1-4094
+vlan_range=2-4094
 
 for bridge in $@; do
    ip link set dev $bridge type bridge vlan_filtering 1


### PR DESCRIPTION
This PR change the vlan list to start from 2.
We leave the first vlan to untag packets that came from the bridge
interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/kubernetes-nmstate/158)
<!-- Reviewable:end -->
