### PR TITLE
Fix vlan filter bash

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,7 @@
-FROM centos:7
+FROM fedora:30
 
-RUN yum -y install epel-release && \
-    yum -y update && \
-    yum -y install \
-        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.8/1.el7/noarch/python2-libnmstate-0.0.8-1.el7.noarch.rpm \
-        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.8/1.el7/noarch/nmstate-0.0.8-1.el7.noarch.rpm \
-        iproute && \
-    yum clean all
+RUN sudo dnf install -y nmstate iproute && \
+    sudo dnf clean all
 
 # Cannot change the binary to nmstate-handler since the name
 # is taken from the directory name [1]

--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -1,15 +1,13 @@
-#!/bin/bash -e
+#!/bin/bash -xe
+
+bridge=$1
+shift
+ports=$@
 
 vlan_range=2-4094
 
-for bridge in $@; do
-   ip link set dev $bridge type bridge vlan_filtering 1
-   bridge vlan add dev $bridge vid $vlan_range self
+ip link set dev $bridge type bridge vlan_filtering 1
 
-   IFS=$'\n'
-   for port in $(bridge link show $bridge | grep -v @ | grep "state forwarding"); do
-      outbound=$(echo $port | sed -r "s/^.*: (.*) state .* :.*$/\1/")
-      bridge vlan add dev $outbound vid $vlan_range
-   done
-
+for port in $ports; do
+    bridge vlan add dev $port vid $vlan_range
 done

--- a/pkg/helper/bridges.go
+++ b/pkg/helper/bridges.go
@@ -10,22 +10,30 @@ import (
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
 )
 
-func getBridgesUp(desiredState nmstatev1alpha1.State) ([]string, error) {
-	foundBridges := []string{}
+func getBridgesUp(desiredState nmstatev1alpha1.State) (map[string][]string, error) {
+	foundBridgesWithPorts := map[string][]string{}
 
 	desiredStateYaml, err := yaml.YAMLToJSON([]byte(desiredState))
 	if err != nil {
-		return foundBridges, fmt.Errorf("error converting desiredState to JSON: %v", err)
+		return foundBridgesWithPorts, fmt.Errorf("error converting desiredState to JSON: %v", err)
 	}
 
-	queryResults := gjson.ParseBytes(desiredStateYaml).
+	bridgesUp := gjson.ParseBytes(desiredStateYaml).
 		Get("interfaces.#(type==linux-bridge)#").
-		Get("#(state==up)#.name").
+		Get("#(state==up)#").
 		Array()
 
-	for _, queryResult := range queryResults {
-		foundBridges = append(foundBridges, queryResult.String())
+	for _, bridgeUp := range bridgesUp {
+		portList := []string{}
+		for _, port := range bridgeUp.Get("bridge.port.#.name").Array() {
+			portList = append(portList, port.String())
+		}
+
+		// Add only the bridge we have some outbound port to configure
+		if len(portList) > 0 {
+			foundBridgesWithPorts[bridgeUp.Get("name").String()] = portList
+		}
 	}
 
-	return foundBridges, nil
+	return foundBridgesWithPorts, nil
 }

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -27,8 +27,11 @@ func show(arguments ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-func applyVlanFiltering(bridgesUp []string) (string, error) {
-	cmd := exec.Command("vlan-filtering", bridgesUp...)
+func applyVlanFiltering(bridgeName string, ports []string) (string, error) {
+	command := []string{bridgeName}
+	command = append(command, ports...)
+
+	cmd := exec.Command("vlan-filtering", command...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -125,14 +128,20 @@ func ApplyDesiredState(nodeNetworkState *nmstatev1alpha1.NodeNetworkState) (stri
 	// set
 	// TODO: After implementing commit/rollack from nmstate we have to
 	//       rollback if vlanfiltering fails
-	bridgesUp, err := getBridgesUp(nodeNetworkState.Spec.DesiredState)
+	bridgesUpWithPorts, err := getBridgesUp(nodeNetworkState.Spec.DesiredState)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving up bridges from desired state: %v", err)
 	}
-	outputVlanFiltering, err := applyVlanFiltering(bridgesUp)
-	if err != nil {
-		return outputVlanFiltering, err
+
+	commandOutput := ""
+	for bridge, ports := range bridgesUpWithPorts {
+		outputVlanFiltering, err := applyVlanFiltering(bridge, ports)
+		commandOutput += fmt.Sprintf("bridge %s ports %v applyVlanFiltering command output: %s\n", bridge, ports, outputVlanFiltering)
+		if err != nil {
+			return commandOutput, err
+		}
 	}
 
-	return setOutput + outputVlanFiltering, nil
+	commandOutput += fmt.Sprintf("setOutput: %s \n", setOutput)
+	return commandOutput, nil
 }


### PR DESCRIPTION
This PR fix the vlan filter function.

Now we pass one bridge every time with all it's interfaces.
We also confiure the vlan filtering only on the uplink interfaces
an not on the bridge itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/kubernetes-nmstate/163)
<!-- Reviewable:end -->
