### PR TITLE
Remove unnneded linux bridge stp attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,6 @@ spec:
             enabled: false
         port:
         - name: eth1
-          stp-hairpin-mode: false
-          stp-path-cost: 100
-          stp-priority: 32
 ```
 
 ## Deployment and Usage

--- a/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
+++ b/deploy/crds/nmstate_v1alpha1_nodenetworkconfigurationpolicy_cr.yaml
@@ -20,9 +20,6 @@ spec:
             enabled: false
         port:
           - name: eth1
-            stp-hairpin-mode: false
-            stp-path-cost: 100
-            stp-priority: 32
     - name: br1
       type: linux-bridge
       state: up
@@ -32,6 +29,3 @@ spec:
             enabled: false
         port:
           - name: eth2
-            stp-hairpin-mode: false
-            stp-path-cost: 100
-            stp-priority: 32

--- a/docs/user-guide-policy-configure-linux-bridge.md
+++ b/docs/user-guide-policy-configure-linux-bridge.md
@@ -38,9 +38,6 @@ spec:
               enabled: false
           port:
             - name: eth1
-              stp-hairpin-mode: false
-              stp-path-cost: 100
-              stp-priority: 32
 EOF
 ```
 

--- a/pkg/helper/bridges_test.go
+++ b/pkg/helper/bridges_test.go
@@ -59,9 +59,6 @@ var (
           enabled: false
       port:
         - name: eth1
-          stp-hairpin-mode: false
-          stp-path-cost: 100
-          stp-priority: 32
   - name: br2
     type: linux-bridge
     state: up
@@ -71,9 +68,6 @@ var (
           enabled: false
       port:
         - name: eth2
-          stp-hairpin-mode: false
-          stp-path-cost: 100
-          stp-priority: 32
   - name: br3
     type: linux-bridge
     state: down

--- a/test/e2e/nodenetworkstate_test.go
+++ b/test/e2e/nodenetworkstate_test.go
@@ -76,9 +76,6 @@ var _ = Describe("NodeNetworkState", func() {
           enabled: false
       port:
         - name: bond1
-          stp-hairpin-mode: false
-          stp-path-cost: 100
-          stp-priority: 32
 `)
 
 		br1Absent = nmstatev1alpha1.State(`interfaces:
@@ -213,10 +210,9 @@ var _ = Describe("NodeNetworkState", func() {
 			})
 			It("should have the bond in the linux bridge as port at currentState", func() {
 				var (
-					expectedInterfaces  = interfaces(br1WithBond1Up)
-					expectedBond        = interfaceByName(expectedInterfaces, "bond1")
-					expectedBridge      = interfaceByName(expectedInterfaces, "br1")
-					expectedBridgePorts = expectedBridge["bridge"].(map[string]interface{})["port"]
+					expectedInterfaces = interfaces(br1WithBond1Up)
+					expectedBond       = interfaceByName(expectedInterfaces, "bond1")
+					expectedBridge     = interfaceByName(expectedInterfaces, "br1")
 				)
 				for _, node := range nodes {
 					interfacesForNode(node).Should(SatisfyAll(
@@ -230,7 +226,8 @@ var _ = Describe("NodeNetworkState", func() {
 							HaveKeyWithValue("name", expectedBridge["name"]),
 							HaveKeyWithValue("type", expectedBridge["type"]),
 							HaveKeyWithValue("state", expectedBridge["state"]),
-							HaveKeyWithValue("bridge", HaveKeyWithValue("port", expectedBridgePorts)),
+							HaveKeyWithValue("bridge", HaveKeyWithValue("port",
+								ContainElement(HaveKeyWithValue("name", "bond1")))),
 						))))
 				}
 				Eventually(func() bool {


### PR DESCRIPTION
With the latest version from nmstate if stp is not enabled the
stp attributes at linux bridge port are not mandatory.