### PR TITLE
Set vlan_filtering 1 at linux-bridge without ports

### DIFF
--- a/pkg/helper/bridges.go
+++ b/pkg/helper/bridges.go
@@ -29,10 +29,7 @@ func getBridgesUp(desiredState nmstatev1alpha1.State) (map[string][]string, erro
 			portList = append(portList, port.String())
 		}
 
-		// Add only the bridge we have some outbound port to configure
-		if len(portList) > 0 {
-			foundBridgesWithPorts[bridgeUp.Get("name").String()] = portList
-		}
+		foundBridgesWithPorts[bridgeUp.Get("name").String()] = portList
 	}
 
 	return foundBridgesWithPorts, nil

--- a/pkg/helper/bridges_test.go
+++ b/pkg/helper/bridges_test.go
@@ -116,9 +116,9 @@ var _ = Describe("Network desired state bridge parser", func() {
 		BeforeEach(func() {
 			desiredState = bridgeWithNoPorts
 		})
-		It("should return empty map", func() {
+		It("should return the bridge with empty port list", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(obtainedBridgesAndPorts).To(BeEmpty())
+			Expect(obtainedBridgesAndPorts).To(HaveKeyWithValue("br1", BeEmpty()))
 		})
 	})
 	Context("when there are bridges up", func() {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -368,3 +368,9 @@ func vlansCardinality(node string, connection string) AsyncAssertion {
 	}, ReadTimeout, ReadInterval)
 
 }
+
+func bridgeDescription(node string, bridgeName string) AsyncAssertion {
+	return Eventually(func() (string, error) {
+		return run(node, "sudo", "ip", "-d", "link", "show", "type", "bridge", bridgeName)
+	}, ReadTimeout, ReadTimeout)
+}


### PR DESCRIPTION
This PR add vlanfiltering_flag even if there is not port configured at the
linux bridge in the desiredState.

This is necessary in case ports are added outside of nmstate (linux bridge CNI) and vlan
communicatoin and filtering is needed

Signed-off-by: Quique Llorente <ellorent@redhat.com>