### PR TITLE
run test in verbose mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifdef UNIT_TEST_EXTRA_ARGS
 	UNIT_TEST_ARGS += $(UNIT_TEST_ARGS)
 endif
 
-E2E_TEST_ARGS ?= -test.v --ginkgo.slowSpecThreshold=60
+E2E_TEST_ARGS ?= -test.v -test.timeout=20m -ginkgo.v -ginkgo.slowSpecThreshold=60
 ifdef E2E_TEST_FOCUS
 	E2E_TEST_ARGS +=  -ginkgo.focus $(E2E_TEST_FOCUS)
 endif

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -16,7 +16,7 @@ trap teardown EXIT SIGINT SIGTERM SIGSTOP
 make cluster-down
 make cluster-up
 make cluster-sync
-test_args="-ginkgo.v -ginkgo.noColor -test.timeout 20m"
+test_args="-ginkgo.noColor"
 skip_tests=""
 
 # FIXME: Delete it when we migrate to okd4 provider, since os-3.11.0 is not


### PR DESCRIPTION
Otherwise it is not possible to detect which test has failed
after we lost connectivity to the local cluster.