### PR TITLE
NodeSelector change does not trigger reconcile

### DIFF
--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
@@ -76,8 +76,7 @@ func forThisNodePredicate(cl client.Client) predicate.Funcs {
 			return nodeSelectorMatchesThisNode(cl, deleteEvent.Object)
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			return nodeSelectorMatchesThisNode(cl, updateEvent.ObjectOld) &&
-				nodeSelectorMatchesThisNode(cl, updateEvent.ObjectNew)
+			return nodeSelectorMatchesThisNode(cl, updateEvent.ObjectNew)
 		},
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
 			return nodeSelectorMatchesThisNode(cl, genericEvent.Object)

--- a/test/e2e/node_selector_test.go
+++ b/test/e2e/node_selector_test.go
@@ -7,7 +7,7 @@ import (
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
 )
 
-var _ = FDescribe("NodeSelector", func() {
+var _ = Describe("NodeSelector", func() {
 	br1Up := nmstatev1alpha1.State(`interfaces:
   - name: br1
     type: linux-bridge

--- a/test/e2e/node_selector_test.go
+++ b/test/e2e/node_selector_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = FDescribe("NodeSelector", func() {
-	br1WithEth1AndEth2 := nmstatev1alpha1.State(`interfaces:
+	br1Up := nmstatev1alpha1.State(`interfaces:
   - name: br1
     type: linux-bridge
     state: up
@@ -17,8 +17,7 @@ var _ = FDescribe("NodeSelector", func() {
         stp:
           enabled: false
       port:
-        - name: eth1
-        - name: eth2
+      - name: eth1
 `)
 	br1Absent := nmstatev1alpha1.State(`interfaces:
 - name: br1
@@ -29,16 +28,16 @@ var _ = FDescribe("NodeSelector", func() {
 
 	Context("when policy is set with node selector not matching any nodes", func() {
 		BeforeEach(func() {
-			setDesiredStateWithPolicyAndNodeSelector("bridge1", br1WithEth1AndEth2, nonexistentNodeSelector)
+			setDesiredStateWithPolicyAndNodeSelector("br1", br1Up, nonexistentNodeSelector)
 		})
 
 		AfterEach(func() {
-			setDesiredStateWithPolicy("bridge1", br1Absent)
+			setDesiredStateWithPolicy("br1", br1Absent)
 			for _, node := range nodes {
 				interfacesNameForNode(node).ShouldNot(ContainElement("br1"))
 			}
 
-			deletePolicy("bridge1")
+			deletePolicy("br1")
 		})
 
 		It("should not update any nodes", func() {
@@ -49,7 +48,7 @@ var _ = FDescribe("NodeSelector", func() {
 
 		Context("and we remove the node selector", func() {
 			BeforeEach(func() {
-				setDesiredStateWithPolicyAndNodeSelector("bridge1", br1WithEth1AndEth2, map[string]string{})
+				setDesiredStateWithPolicyAndNodeSelector("br1", br1Up, map[string]string{})
 			})
 
 			It("should update all nodes", func() {

--- a/test/e2e/node_selector_test.go
+++ b/test/e2e/node_selector_test.go
@@ -1,0 +1,62 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+)
+
+var _ = FDescribe("NodeSelector", func() {
+	br1WithEth1AndEth2 := nmstatev1alpha1.State(`interfaces:
+  - name: br1
+    type: linux-bridge
+    state: up
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth1
+        - name: eth2
+`)
+	br1Absent := nmstatev1alpha1.State(`interfaces:
+- name: br1
+  type: linux-bridge
+  state: absent
+`)
+	nonexistentNodeSelector := map[string]string{"nonexistentKey": "nonexistentValue"}
+
+	Context("when policy is set with node selector not matching any nodes", func() {
+		BeforeEach(func() {
+			setDesiredStateWithPolicyAndNodeSelector("bridge1", br1WithEth1AndEth2, nonexistentNodeSelector)
+		})
+
+		AfterEach(func() {
+			setDesiredStateWithPolicy("bridge1", br1Absent)
+			for _, node := range nodes {
+				interfacesNameForNode(node).ShouldNot(ContainElement("br1"))
+			}
+
+			deletePolicy("bridge1")
+		})
+
+		It("should not update any nodes", func() {
+			for _, node := range nodes {
+				interfacesNameForNode(node).ShouldNot(ContainElement("br1"))
+			}
+		})
+
+		Context("and we remove the node selector", func() {
+			BeforeEach(func() {
+				setDesiredStateWithPolicyAndNodeSelector("bridge1", br1WithEth1AndEth2, map[string]string{})
+			})
+
+			It("should update all nodes", func() {
+				for _, node := range nodes {
+					interfacesNameForNode(node).Should(ContainElement("br1"))
+				}
+			})
+		})
+	})
+})


### PR DESCRIPTION
When `nodeSelector` is changed and it matches a new node, this node ignores it.

This issue was caused by reconcile predicate `UpdateFunc` callback depending on
matching the node with both the new and the old policy `nodeSelector`. This
caused `UpdateFunc` to not work properly.

Now we check our node only against the new (updated) policy `nodeSelector`.

Resolves #180 

Signed-off-by: HlinaCZ <djhlinacz@gmail.com>