### PR TITLE
fix linux bridge cleanup

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,8 @@ RUN sudo dnf install -y nmstate iproute && \
 # TODO: Delete this line after we update nmstate to include the change
 # https://github.com/nmstate/nmstate/commit/a4baaff50fef84d6d326977ff647bece1e917a26
 RUN sed -i "s/run(timeout=20/run(timeout=60/g" /usr/lib/python3.7/site-packages/libnmstate/netapplier.py
+# TODO: Delete this line after nmstate fixes https://github.com/nmstate/nmstate/issues/516
+RUN sed -i "s/nmclient.NM.DeviceType.OVS_INTERFACE,/nmclient.NM.DeviceType.OVS_INTERFACE, nmclient.NM.DeviceType.BRIDGE,/" /usr/lib/python3.7/site-packages/libnmstate/nm/applier.py
 
 # Cannot change the binary to nmstate-handler since the name
 # is taken from the directory name [1]


### PR DESCRIPTION
When bridge setup fails, nmstate sometimes leaves its netlink iface
behind although it removes the connection. This issue is tracked in
https://github.com/nmstate/nmstate/issues/516. Until that gets
resolved, we fix it with ugly sed workaround.

Signed-off-by: Petr Horacek <phoracek@redhat.com>