### PR TITLE
Run default bridge test at different job

### DIFF
--- a/automation/check-patch.k8s-1.14.6.default-bridge.mounts
+++ b/automation/check-patch.k8s-1.14.6.default-bridge.mounts
@@ -1,0 +1,1 @@
+check-patch.mounts

--- a/automation/check-patch.k8s-1.14.6.default-bridge.packages
+++ b/automation/check-patch.k8s-1.14.6.default-bridge.packages
@@ -1,0 +1,1 @@
+check-patch.packages

--- a/automation/check-patch.k8s-1.14.6.default-bridge.sh
+++ b/automation/check-patch.k8s-1.14.6.default-bridge.sh
@@ -1,0 +1,1 @@
+check-patch.sh

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,13 +1,14 @@
 #!/bin/bash -xe
 
 main() {
-    TARGET="$0"
-    TARGET="${TARGET#./}"
+    export SCRIPT_NAME="$0"
+
+    TARGET="${SCRIPT_NAME#./}"
     TARGET="${TARGET%.*}"
     TARGET="${TARGET#*.}"
+    TARGET="${TARGET//[.]default-bridge/}"
     echo "TARGET=$TARGET"
     export TARGET
-
     echo "Setup Go paths"
     cd ..
     export GOROOT=/usr/local/go

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -18,11 +18,12 @@ make cluster-up
 make cluster-sync
 test_args="-ginkgo.noColor"
 skip_tests=""
+skip_tests=""
 
-# FIXME: Delete it when we migrate to okd4 provider, since os-3.11.0 is not
-#        working alright I we don't want to debug not supported providers.
-if [[ $KUBEVIRT_PROVIDER =~ os- ]]; then
-    skip_tests="move.*default.*IP"
+if [[ $SCRIPT_NAME =~ default-bridge ]]; then
+    focus_test=".*move.*default.*IP.*"
+else
+    skip_tests=".*move.*default.*IP.*"
 fi
 
-make E2E_TEST_EXTRA_ARGS="$test_args" E2E_TEST_SKIP="$skip_tests" test/e2e
+make E2E_TEST_EXTRA_ARGS="$test_args" E2E_TEST_FOCUS="$focus_tests" E2E_TEST_SKIP="$skip_tests" test/e2e

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,4 +1,5 @@
 sub-stages:
+  - k8s-1.14.6.default-bridge
   - k8s-1.14.6
   - os-3.11.0
 

--- a/test/e2e/default_bridged_network_test.go
+++ b/test/e2e/default_bridged_network_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 // FIXME: We have to fix this test https://github.com/nmstate/kubernetes-nmstate/issues/192
-var _ = PDescribe("NodeNetworkConfigurationPolicy default bridged network", func() {
+var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func() {
 	createBridgeOnTheDefaultInterface := nmstatev1alpha1.State(`interfaces:
   - name: brext
     type: linux-bridge


### PR DESCRIPTION
This job is instable now, but we don't want to skip running it
at the PRs, also if it fails it will break all the other tests.

Signed-off-by: Quique Llorente <ellorent@redhat.com>