### PR TITLE
Retry on conflict at network configuration report

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -163,7 +163,7 @@ func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1alpha1.
 
 	err = client.Status().Update(context.Background(), nodeNetworkState)
 	if err != nil {
-		return fmt.Errorf("error updating status of NodeNetworkState: %v", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
We have two controllers that update Status of NodeNetworkState, conflicts
where resolved re-conconcile, but that takes too much time, also it produces
a confusing error, with this commit in case of a conflict on NodeNetworKState it
retries.

Signed-off-by: Quique Llorente <ellorent@redhat.com>