### PR TITLE
Flush ip address at secondary nics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ $(CLUSTER_DIR)/%: $(install_kubevirtci)
 cluster-up: $(CLUSTER_UP)
 	$(CLUSTER_UP)
 	hack/install-nm.sh
+	hack/flush-secondary-nics.sh
 
 cluster-down: $(CLUSTER_DOWN)
 	$(CLUSTER_DOWN)

--- a/hack/flush-secondary-nics.sh
+++ b/hack/flush-secondary-nics.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# TODO: Iterate all the nodes
+script_dir=$(dirname "$(readlink -f "$0")")
+ssh=$script_dir/../kubevirtci/cluster-up/ssh.sh
+
+# TODO okd4.1
+if [[ "$KUBEVIRT_PROVIDER" =~ k8s ]]; then
+    for n in $(seq 1 $KUBEVIRT_NUM_SECONDARY_NICS); do
+        echo 'Flushing nic $n'
+        $ssh node01 -- sudo nmcli con del "\"Wired connection $n\""
+    done
+fi


### PR DESCRIPTION
Our e2e tests expect secondary nics without IP addresses also
the ip addresses assigned by kubevirtci dnsmasq has the same CIDR
as the primary nic, this make impossible to test default-bridge
test propertly.

Signed-off-by: Quique Llorente <ellorent@redhat.com>