### PR TITLE
configure VLAN on the bridge device

### DIFF
--- a/build/bin/vlan-filtering
+++ b/build/bin/vlan-filtering
@@ -8,6 +8,8 @@ vlan_range=2-4094
 
 ip link set dev $bridge type bridge vlan_filtering 1
 
+bridge vlan add dev $bridge vid 1 pvid untagged self
+
 for port in $ports; do
     bridge vlan add dev $port vid $vlan_range
 done

--- a/test/e2e/default_bridged_network_test.go
+++ b/test/e2e/default_bridged_network_test.go
@@ -110,7 +110,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 
 				By("Verify that VLAN configuration is done properly")
 				hasVlans(node, *primaryNic, 2, 4094).Should(Succeed())
-				vlansCardinality(node, "brext").Should(Equal(0))
+				getVLANFlagsEventually(node, "brext", 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 			}
 		})
 	})

--- a/test/e2e/simple_bridge_and_bond.go
+++ b/test/e2e/simple_bridge_and_bond.go
@@ -119,7 +119,7 @@ var _ = Describe("NodeNetworkState", func() {
 			It("should have the linux bridge at currentState", func() {
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
-					vlansCardinality(node, bridge1).Should(Equal(0))
+					getVLANFlagsEventually(node, bridge1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 					getVLANFlagsEventually(node, *firstSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 					hasVlans(node, *firstSecondaryNic, 2, 4094).Should(Succeed())
 					getVLANFlagsEventually(node, *secondSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
@@ -187,8 +187,8 @@ var _ = Describe("NodeNetworkState", func() {
 								ContainElement(HaveKeyWithValue("name", bond1)))),
 						))))
 
+					getVLANFlagsEventually(node, bridge1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 					hasVlans(node, bond1, 2, 4094).Should(Succeed())
-					vlansCardinality(node, bridge1).Should(Equal(0))
 					getVLANFlagsEventually(node, bond1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 					vlansCardinality(node, *firstSecondaryNic).Should(Equal(0))
 					vlansCardinality(node, *secondSecondaryNic).Should(Equal(0))


### PR DESCRIPTION
Without explicit configuration of bridge's VID, it is not possible
to use it for IP connectivity of the host. This patch sets default
VID on the bridge.

Signed-off-by: Petr Horacek <phoracek@redhat.com>