### PR TITLE
use dynamic NIC assignment in OVS states

### DIFF
--- a/test/e2e/states.go
+++ b/test/e2e/states.go
@@ -63,9 +63,9 @@ func ovsBrUp(bridgeName string) nmstatev1alpha1.State {
       options:
         stp: false
       port:
-        - name: eth1
-        - name: eth2
-`, bridgeName))
+        - name: %s
+        - name: %s
+`, bridgeName, *firstSecondaryNic, *secondSecondaryNic))
 }
 
 func ovsbBrWithInternalInterface(bridgeName string) nmstatev1alpha1.State {
@@ -85,9 +85,9 @@ func ovsbBrWithInternalInterface(bridgeName string) nmstatev1alpha1.State {
       options:
         stp: true
       port:
-        - name: eth1
+        - name: %s
           type: system
         - name: ovs0
           type: internal`,
-		bridgeName))
+		bridgeName, *firstSecondaryNic))
 }


### PR DESCRIPTION
We failed to rebase the PR introducing OVS tests. We should use
templates for NICs to our tests work on both OKD and k8s providers.

Signed-off-by: Petr Horacek <phoracek@redhat.com>