### PR TITLE
use nmstate 0.1.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:31
 
 RUN sudo dnf install -y dnf-plugins-core && \
     sudo dnf copr enable -y nmstate/nmstate-git-fedora && \
-    sudo dnf install -y nmstate-0.0.8-0.20191022.669git5701bbe.fc31.noarch iproute iputils && \
+    sudo dnf install -y nmstate-0.1.1 iproute iputils && \
     sudo dnf remove -y dnf-plugins-core && \
     sudo dnf clean all
 


### PR DESCRIPTION
We cannot pin to a specific master release in copr since they are
being removed after a while. nmstate releases are now fixed and master
is being pushed under version 0.1.1. Let's use that.

Signed-off-by: Petr Horacek <phoracek@redhat.com>