### PR TITLE
Use NNCP to set desiredState at e2e tests

### DIFF
--- a/test/e2e/nncp_conditions_test.go
+++ b/test/e2e/nncp_conditions_test.go
@@ -34,10 +34,10 @@ var _ = Describe("NodeNetworkStateCondition", func() {
 		})
 		It("should have Available ConditionType set to true", func() {
 			for _, node := range nodes {
-				checkCondition(node, nmstatev1alpha1.NodeNetworkStateConditionAvailable).Should(
+				checkEnactmentConditionEventually(node, nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable).Should(
 					Equal(corev1.ConditionTrue),
 				)
-				checkCondition(node, nmstatev1alpha1.NodeNetworkStateConditionFailing).Should(
+				checkEnactmentConditionEventually(node, nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionFailing).Should(
 					Equal(corev1.ConditionFalse),
 				)
 			}
@@ -57,10 +57,10 @@ var _ = Describe("NodeNetworkStateCondition", func() {
 
 		It("should have Failing ConditionType set to true", func() {
 			for _, node := range nodes {
-				checkCondition(node, nmstatev1alpha1.NodeNetworkStateConditionFailing).Should(
+				checkEnactmentConditionEventually(node, nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionFailing).Should(
 					Equal(corev1.ConditionTrue),
 				)
-				checkCondition(node, nmstatev1alpha1.NodeNetworkStateConditionAvailable).Should(
+				checkEnactmentConditionEventually(node, nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable).Should(
 					Equal(corev1.ConditionFalse),
 				)
 			}


### PR DESCRIPTION
Now that we have move desiredState to NNCP we have to change
e2e to use it instead of NNS to fix them.

Signed-off-by: Quique Llorente <ellorent@redhat.com>