### PR TITLE
Deactivate okd lane

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,6 +1,7 @@
 sub-stages:
   - e2e-k8s
-  - e2e-okd
+# TODO:  Activate it after okd-4.3 provider is good for us
+#  - e2e-okd
 
 runtime_requirements:
   support_nesting_level: 2


### PR DESCRIPTION
Actual okd lane is based on okd 4.1 that's too old and it's not working
we will re-activate when okd 4.3 provide is good for knmstate.

Signed-off-by: Quique Llorente <ellorent@redhat.com>