### PR TITLE
Add Matching condition to enactments

### DIFF
--- a/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -42,19 +42,24 @@ const (
 	NodeNetworkConfigurationEnactmentConditionAvailable   ConditionType = "Available"
 	NodeNetworkConfigurationEnactmentConditionFailing     ConditionType = "Failing"
 	NodeNetworkConfigurationEnactmentConditionProgressing ConditionType = "Progressing"
+	NodeNetworkConfigurationEnactmentConditionMatching    ConditionType = "Matching"
 )
 
 const (
 	NodeNetworkConfigurationEnactmentPhaseAvailable   EnactmentPhase = "Available"
 	NodeNetworkConfigurationEnactmentPhaseFailing     EnactmentPhase = "Failing"
 	NodeNetworkConfigurationEnactmentPhaseProgressing EnactmentPhase = "Progressing"
+	NodeNetworkConfigurationEnactmentPhaseNotMatching EnactmentPhase = "NotMatching"
+	NodeNetworkConfigurationEnactmentPhaseMatching    EnactmentPhase = "Matching"
 	NodeNetworkConfigurationEnactmentPhaseUnknown     EnactmentPhase = "Unknown"
 )
 
 const (
-	NodeNetworkConfigurationEnactmentConditionFailedToConfigure        ConditionReason = "FailedToConfigure"
-	NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured   ConditionReason = "SuccessfullyConfigured"
-	NodeNetworkConfigurationEnactmentConditionConfigurationProgressing ConditionReason = "ConfigurationProgressing"
+	NodeNetworkConfigurationEnactmentConditionFailedToConfigure                 ConditionReason = "FailedToConfigure"
+	NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured            ConditionReason = "SuccessfullyConfigured"
+	NodeNetworkConfigurationEnactmentConditionConfigurationProgressing          ConditionReason = "ConfigurationProgressing"
+	NodeNetworkConfigurationEnactmentConditionNodeSelectorNotMatching           ConditionReason = "NodeSelectorNotMatching"
+	NodeNetworkConfigurationEnactmentConditionNodeSelectorAllConditionsMatching ConditionReason = "AllConditionsMatching"
 )
 
 func init() {

--- a/pkg/controller/nodenetworkconfigurationpolicy/conditions/enactments.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/conditions/enactments.go
@@ -75,3 +75,62 @@ func setEnactmentProgressing(enactment *nmstatev1alpha1.NodeNetworkConfiguration
 	)
 	enactment.Status.Phase = nmstatev1alpha1.NodeNetworkConfigurationEnactmentPhaseProgressing
 }
+
+func setEnactmentNodeSelectorNotMatching(enactment *nmstatev1alpha1.NodeNetworkConfigurationEnactment, message string) {
+	setEnactmentNotMatching(enactment, nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionNodeSelectorNotMatching, message)
+	enactment.Status.Phase = nmstatev1alpha1.NodeNetworkConfigurationEnactmentPhaseNotMatching
+}
+func setEnactmentNotMatching(enactment *nmstatev1alpha1.NodeNetworkConfigurationEnactment, reason nmstatev1alpha1.ConditionReason, message string) {
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionFailing,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionAvailable,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionProgressing,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionMatching,
+		corev1.ConditionFalse,
+		reason,
+		message,
+	)
+}
+
+func setEnactmentMatching(enactment *nmstatev1alpha1.NodeNetworkConfigurationEnactment, message string) {
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionFailing,
+		corev1.ConditionUnknown,
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllConditionsMatching,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionAvailable,
+		corev1.ConditionUnknown,
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllConditionsMatching,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionProgressing,
+		corev1.ConditionUnknown,
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllConditionsMatching,
+		"",
+	)
+	enactment.Status.Conditions.Set(
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionMatching,
+		corev1.ConditionTrue,
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllConditionsMatching,
+		message,
+	)
+	enactment.Status.Phase = nmstatev1alpha1.NodeNetworkConfigurationEnactmentPhaseMatching
+}

--- a/pkg/controller/nodenetworkconfigurationpolicy/conditions/manager.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/conditions/manager.go
@@ -31,7 +31,18 @@ func NewManager(client client.Client, nodeName string, policy nmstatev1alpha1.No
 	manager.logger = logf.Log.WithName("policy/conditions/manager").WithValues("enactment", manager.enactmentName)
 	return manager
 }
-
+func (m *Manager) NotifyNodeSelectorNotMatching(message string) {
+	err := m.updateEnactmentCondition(setEnactmentNodeSelectorNotMatching, message)
+	if err != nil {
+		m.logger.Error(err, "Error notifying state NodeSelectorNotMatching")
+	}
+}
+func (m *Manager) NotifyMatching() {
+	err := m.updateEnactmentCondition(setEnactmentMatching, "All policy selectors are matching the node")
+	if err != nil {
+		m.logger.Error(err, "Error notifying state Matching")
+	}
+}
 func (m *Manager) NotifyProgressing() {
 	err := m.updateEnactmentCondition(setEnactmentProgressing, "Applying desired state")
 	if err != nil {

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -29,6 +29,10 @@ func conditionsToYaml(conditions nmstatev1alpha1.ConditionList) string {
 	return string(manifest)
 }
 
+func enactmentKey(node string, policy string) types.NamespacedName {
+	return types.NamespacedName{Name: node + "-" + policy}
+}
+
 func nodeNetworkConfigurationEnactment(key types.NamespacedName) nmstatev1alpha1.NodeNetworkConfigurationEnactment {
 	state := nmstatev1alpha1.NodeNetworkConfigurationEnactment{}
 	Eventually(func() error {
@@ -37,14 +41,15 @@ func nodeNetworkConfigurationEnactment(key types.NamespacedName) nmstatev1alpha1
 	return state
 }
 
-func enactmentConditionsStatus(node string) nmstatev1alpha1.ConditionList {
+func enactmentConditionsStatus(node string, policy string) nmstatev1alpha1.ConditionList {
 	//TODO: Take the format from pkg
-	key := types.NamespacedName{Name: node + "-" + TestPolicy}
+	key := enactmentKey(node, policy)
 	enactment := nodeNetworkConfigurationEnactment(key)
 	enactmentsConditionTypes := []nmstatev1alpha1.ConditionType{
 		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionAvailable,
 		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionFailing,
 		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionProgressing,
+		nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionMatching,
 	}
 	obtainedConditions := nmstatev1alpha1.ConditionList{}
 	for _, enactmentsConditionType := range enactmentsConditionTypes {
@@ -61,14 +66,22 @@ func enactmentConditionsStatus(node string) nmstatev1alpha1.ConditionList {
 	return obtainedConditions
 }
 
-func enactmentConditionsStatusEventually(node string) AsyncAssertion {
+func enactmentConditionsStatusForPolicyEventually(node string, policy string) AsyncAssertion {
 	return Eventually(func() nmstatev1alpha1.ConditionList {
-		return enactmentConditionsStatus(node)
+		return enactmentConditionsStatus(node, policy)
+	}, 5*time.Second, 1*time.Second)
+}
+
+func enactmentConditionsStatusForPolicyConsistently(node string, policy string) AsyncAssertion {
+	return Consistently(func() nmstatev1alpha1.ConditionList {
+		return enactmentConditionsStatus(node, policy)
 	}, 180*time.Second, 1*time.Second)
 }
 
+func enactmentConditionsStatusEventually(node string) AsyncAssertion {
+	return enactmentConditionsStatusForPolicyEventually(node, TestPolicy)
+}
+
 func enactmentConditionsStatusConsistently(node string) AsyncAssertion {
-	return Consistently(func() nmstatev1alpha1.ConditionList {
-		return enactmentConditionsStatus(node)
-	}, 5*time.Second, 1*time.Second)
+	return enactmentConditionsStatusForPolicyConsistently(node, TestPolicy)
 }


### PR DESCRIPTION
Enactment CRD should show if the node matches the policy, in that case
Matching will be True otherwise it will be False.

Also the 'kubectl get nnce' command will show "NotMatching" or "Matching".

Signed-off-by: Quique Llorente <ellorent@redhat.com>