### PR TITLE
check for trailing whitespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,19 @@ description = build/_output/description
 resources = deploy/namespace.yaml deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml
 all: check handler
 
-check: format vet
+check: format vet whitespace-check
 
-format:
+format: whitespace-format
 	gofmt -d cmd/ pkg/
 
 vet:
 	go vet ./cmd/... ./pkg/...
+
+whitespace-format:
+	hack/whitespace.sh format
+
+whitespace-check:
+	hack/whitespace.sh check
 
 $(GINKGO): go.mod
 	GOBIN=$$(pwd)/$(BIN_DIR) go install ./vendor/github.com/onsi/ginkgo/ginkgo
@@ -177,4 +183,6 @@ tools-vendoring:
 	cluster-sync-handler \
 	cluster-sync \
 	cluster-clean \
-	release
+	release \
+	whitespace-check \
+	whitespace-format

--- a/docs/user-guide-state-reporting.md
+++ b/docs/user-guide-state-reporting.md
@@ -252,10 +252,10 @@ If you want to learn more about the `observedState` API, see [nmstate documentat
 
 ## Additional configuration
 
-We can set the period of update time in seconds in config map in variable 
+We can set the period of update time in seconds in config map in variable
 named `node_network_state_refresh_interval`.
 
-We can also set filter for interfaces we wish to omit in reporting 
+We can also set filter for interfaces we wish to omit in reporting
 via `interfaces_filter`. This variable uses glob for pattern matching.
 For example we can use values such as: `""` to keep all interfaces (disable
 filtering), `"veth*"` to omit all interfaces with `veth` prefix or

--- a/hack/whitespace.sh
+++ b/hack/whitespace.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Check for trailing whitespaces in all tracked files.
+#
+# Usage:
+# hack/whitespace.sh check # Check for trailing whitespaces
+# hack/whitespace.sh format # Drop trailing whitespaces
+
+set -e
+
+function format() {
+    git ls-files -- ':!vendor/' | xargs sed --follow-symlinks -i 's/[[:space:]]*$//'
+}
+
+function check() {
+    invalid_files=$(git ls-files -- ':!vendor/' | xargs egrep -Hn " +$" || true)
+    if [[ $invalid_files ]]; then
+        echo 'Found trailing whitespaces. Please remove trailing whitespaces using `make format`:'
+        echo "$invalid_files"
+        return 1
+    fi
+}
+
+if [ "$1" == "format" ]; then
+    format
+elif [ "$1" == "check" ]; then
+    check
+else
+    echo "Please provide an argument [format|check]"
+    exit 1
+fi


### PR DESCRIPTION
gofmt checks that there are no trailing whitespaces in .go modules,
we should do something similar for all files under the source tree.

Signed-off-by: Petr Horacek <phoracek@redhat.com>