### PR TITLE
drop unused Dockerfile

### DIFF
--- a/build/handler/Dockerfile
+++ b/build/handler/Dockerfile
@@ -1,9 +1,0 @@
-FROM centos:7
-
-RUN yum -y install epel-release && \
-    yum -y update && \
-    yum -y install \
-        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/python2-libnmstate-0.0.6-2.el7.noarch.rpm \
-        https://kojipkgs.fedoraproject.org/packages/nmstate/0.0.6/2.el7/noarch/nmstate-0.0.6-2.el7.noarch.rpm \
-    yum clean all
-CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"


### PR DESCRIPTION
There was a leftover Dockerfile from the ancient times. Let's not
keep it.

Signed-off-by: Petr Horacek <phoracek@redhat.com>