### PR TITLE
use new nmstate copr repos

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:31
 
 RUN sudo dnf install -y dnf-plugins-core && \
-    sudo dnf copr enable -y nmstate/nmstate-git-fedora && \
-    sudo dnf install -y nmstate-0.1.1 iproute iputils && \
+    sudo dnf copr enable -y nmstate/nmstate-git && \
+    sudo dnf install -y nmstate iproute iputils && \
     sudo dnf remove -y dnf-plugins-core && \
     sudo dnf clean all
 


### PR DESCRIPTION
nmstate-git-fedora is getting deprecated, let's use nmstate-git
which will always include the latest master.

Signed-off-by: Petr Horacek <phoracek@redhat.com>