### PR TITLE
docs: use dhcp for cluster-wide policies

### DIFF
--- a/docs/user-guide-policy-configure-linux-bond-with-vlans.md
+++ b/docs/user-guide-policy-configure-linux-bond-with-vlans.md
@@ -28,9 +28,7 @@ spec:
       type: bond
       state: up
       ipv4:
-        address:
-        - ip: 10.10.10.10
-          prefix-length: 24
+        dhcp: true
         enabled: true
       link-aggregation:
         mode: balance-rr
@@ -43,9 +41,7 @@ spec:
       type: vlan
       state: up
       ipv4:
-        address:
-        - ip: 10.102.10.10
-          prefix-length: 24
+        dhcp: true
         enabled: true
       vlan:
         base-iface: bond0

--- a/docs/user-guide-policy-configure-linux-bond.md
+++ b/docs/user-guide-policy-configure-linux-bond.md
@@ -28,9 +28,7 @@ spec:
       type: bond
       state: up
       ipv4:
-        address:
-        - ip: 10.10.10.10
-          prefix-length: 24
+        dhcp: true
         enabled: true
       link-aggregation:
         mode: balance-rr

--- a/docs/user-guide-policy-configure-linux-bridge.md
+++ b/docs/user-guide-policy-configure-linux-bridge.md
@@ -28,6 +28,9 @@ spec:
         description: Linux bridge with eth1 as a port
         type: linux-bridge
         state: up
+        ipv4:
+          dhcp: true
+          enabled: true
         bridge:
           options:
             stp:
@@ -74,6 +77,10 @@ spec:
         description: Linux bridge with eth1 as a port
         type: linux-bridge
         state: up
+        ipv4:
+          address:
+          - ip: 192.0.2.10
+            prefix-length: 24
         bridge:
           options:
             stp:

--- a/docs/user-guide-policy-configure-ovs-bridge.md
+++ b/docs/user-guide-policy-configure-ovs-bridge.md
@@ -56,10 +56,8 @@ spec:
         type: ovs-interface
         state: up
         ipv4:
+          dhcp: true
           enabled: true
-          address:
-            - ip: 192.0.2.1
-              prefix-length: 24
       - name: br1
         description: ovs bridge with eth1 as a port and ovs0 as an internal interface
         type: ovs-bridge
@@ -110,6 +108,10 @@ spec:
         description: Ovs bridge with eth1 as a port
         type: ovs-bridge
         state: up
+        ipv4:
+          address:
+          - ip: 192.0.2.10
+            prefix-length: 24
         bridge:
           options:
             stp: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When showing a policy applying to multiple nodes, always use DHCP.
With static IPs, we would get collisions. Use static only with node
selectors per single node.

Resolves: #274 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
