### PR TITLE
Add junit and polarion reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/_test
 # Cloned kubevirtci
 kubevirtci
 
+# Junit
+*junit*.xml
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -25,6 +25,7 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -25,6 +25,7 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-okd.sh
+++ b/automation/check-patch.e2e-okd.sh
@@ -28,6 +28,7 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -19,5 +19,9 @@ mkdir -p $gimme_dir
 curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${gimme_dir} bash >> ${gimme_dir}/gimme.sh
 source $gimme_dir/gimme.sh
 
+
 export TMP_PROJECT_PATH=$tmp_dir/kubernetes-nmstate
+export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
+mkdir -p $ARTIFACTS
 rsync -rt --links --filter=':- .gitignore' $(pwd)/ $TMP_PROJECT_PATH
+

--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 # This script should be able to execute functional tests against Kubernetes
 # cluster on any environment with basic dependencies listed in
@@ -12,6 +12,7 @@ main() {
     cd ${TMP_PROJECT_PATH}
     make all
     make UNIT_TEST_ARGS="-noColor --compilers=2" test/unit
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/pkg/apis/nmstate/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/nmstate/v1alpha1/v1alpha1_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "API Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.apis-nmstate-v1alpha1-v1alpha1_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "API Test Suite", []Reporter{junitReporter})
 }

--- a/pkg/controller/node/node_suite_test.go
+++ b/pkg/controller/node/node_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Node controller Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.controller-node-node_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Node Controller Test Suite", []Reporter{junitReporter})
 }

--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_suite_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NodeNetworkConfigurationPolicy controller Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-nodenetworkconfigurationpolicy_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "NodeNetworkConfigurationPolicy controller Test Suite", []Reporter{junitReporter})
 }

--- a/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/policyconditions_suite_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/policyconditions_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Conditions Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-policyconditions-policyconditions_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Conditions Test Suite", []Reporter{junitReporter})
 }

--- a/pkg/controller/nodenetworkconfigurationpolicy/selectors/selectors_suite_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/selectors/selectors_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Policy Selectors Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-selectors-selectors_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Policy Selectors Test Suite", []Reporter{junitReporter})
 }

--- a/pkg/helper/helper_suite_test.go
+++ b/pkg/helper/helper_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Helpers Test Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.helper-helper_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Helper Test Suite", []Reporter{junitReporter})
 }


### PR DESCRIPTION
It uses the kubevirt's ones

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This generate a junit and polarion reports to be consumed by tools and show the results in 
a proper way.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
