### PR TITLE
Re-read policy on conflict

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -13,7 +13,7 @@ teardown() {
 
 main() {
     export KUBEVIRT_PROVIDER='k8s-1.15.1'
-
+    export KUBEVIRT_NUM_NODES=2
     source automation/check-patch.e2e.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
@@ -161,7 +161,7 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) Reconcile(request reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	policyconditions.Reset(r.client, instance)
+	policyconditions.Reset(r.client, request.NamespacedName)
 
 	err = r.initializeEnactment(*instance)
 	if err != nil {
@@ -173,7 +173,7 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) Reconcile(request reconcile.Re
 	// Policy conditions will be updated at the end so updating it
 	// does not impact at applying state, it will increase just
 	// reconcile time.
-	defer policyconditions.Update(r.client, instance)
+	defer policyconditions.Update(r.client, request.NamespacedName)
 
 	policySelectors := selectors.NewFromPolicy(r.client, *instance)
 	unmatchingNodeLabels, err := policySelectors.UnmatchedNodeLabels(nodeName)

--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,10 +31,14 @@ var _ = Describe("EnactmentCondition", func() {
 		AfterEach(func() {
 			By("Restore original vlan-filtering")
 			runAtPods("mv", "/usr/local/bin/vlan-filtering.bak", "/usr/local/bin/vlan-filtering")
+			By("Remove the bridge")
 			updateDesiredState(linuxBrAbsent(bridge1))
-			for _, node := range nodes {
-				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
-			}
+			policyConditionsStatusEventually().Should(ContainElement(
+				nmstatev1alpha1.Condition{
+					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			))
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
 		})
@@ -74,16 +79,30 @@ var _ = Describe("EnactmentCondition", func() {
 					Status: corev1.ConditionTrue,
 				},
 			}
-			for _, node := range nodes {
-				By("Check progressing state is reached")
-				enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
+			var wg sync.WaitGroup
+			wg.Add(len(nodes))
+			for i, _ := range nodes {
+				node := nodes[i]
+				go func() {
+					defer wg.Done()
+					By(fmt.Sprintf("Check %s progressing state is reached", node))
+					enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
 
-				By("Check available is the next condition")
-				enactmentConditionsStatusEventually(node).Should(ConsistOf(availableConditions))
+					By(fmt.Sprintf("Check %s available state is the next condition", node))
+					enactmentConditionsStatusEventually(node).Should(ConsistOf(availableConditions))
 
-				By("Check that we available is keep")
-				enactmentConditionsStatusConsistently(node).Should(ConsistOf(availableConditions))
+					By(fmt.Sprintf("Check %s available state is kept", node))
+					enactmentConditionsStatusConsistently(node).Should(ConsistOf(availableConditions))
+				}()
 			}
+			wg.Wait()
+			By("Check policy is at available state")
+			policyConditionsStatusEventually().Should(ContainElement(
+				nmstatev1alpha1.Condition{
+					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			))
 		})
 	})
 

--- a/test/e2e/nncp_cleanup_test.go
+++ b/test/e2e/nncp_cleanup_test.go
@@ -31,6 +31,12 @@ var _ = Describe("NNCP cleanup", func() {
 
 	AfterEach(func() {
 		updateDesiredState(linuxBrAbsent(bridge1))
+		policyConditionsStatusEventually().Should(ContainElement(
+			nmstatev1alpha1.Condition{
+				Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
+				Status: corev1.ConditionTrue,
+			},
+		))
 		resetDesiredStateForNodes()
 	})
 

--- a/test/e2e/simple_bridge_and_bond.go
+++ b/test/e2e/simple_bridge_and_bond.go
@@ -113,7 +113,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstatev1alpha1.State {
   vlan:
     base-iface: %s
     id: 102
-`, bondName, *firstSecondaryNic, *secondSecondaryNic,bondName,bondName))
+`, bondName, *firstSecondaryNic, *secondSecondaryNic, bondName, bondName))
 }
 
 var _ = Describe("NodeNetworkState", func() {
@@ -268,25 +268,25 @@ var _ = Describe("NodeNetworkState", func() {
 			})
 			It("should have the bond interface with 2 slaves at currentState", func() {
 				var (
-					expectedBond = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), bond1)
+					expectedBond        = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), bond1)
 					expectedVlanBond102 = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), fmt.Sprintf("%s.102", bond1))
-					expectedSpecs      = expectedBond["link-aggregation"].(map[string]interface{})
+					expectedSpecs       = expectedBond["link-aggregation"].(map[string]interface{})
 				)
 
 				for _, node := range nodes {
 					interfacesForNode(node).Should(SatisfyAll(
 						ContainElement(SatisfyAll(
-						HaveKeyWithValue("name", expectedBond["name"]),
-						HaveKeyWithValue("type", expectedBond["type"]),
-						HaveKeyWithValue("state", expectedBond["state"]),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{*firstSecondaryNic, *secondSecondaryNic}))),
-					)),
-					ContainElement(SatisfyAll(
-						HaveKeyWithValue("name", expectedVlanBond102["name"]),
-						HaveKeyWithValue("type", expectedVlanBond102["type"]),
-						HaveKeyWithValue("state", expectedVlanBond102["state"])))))
+							HaveKeyWithValue("name", expectedBond["name"]),
+							HaveKeyWithValue("type", expectedBond["type"]),
+							HaveKeyWithValue("state", expectedBond["state"]),
+							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
+							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
+							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{*firstSecondaryNic, *secondSecondaryNic}))),
+						)),
+						ContainElement(SatisfyAll(
+							HaveKeyWithValue("name", expectedVlanBond102["name"]),
+							HaveKeyWithValue("type", expectedVlanBond102["type"]),
+							HaveKeyWithValue("state", expectedVlanBond102["state"])))))
 				}
 			})
 		})

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -206,7 +206,7 @@ func nodeNetworkState(key types.NamespacedName) nmstatev1alpha1.NodeNetworkState
 func nodeNetworkConfigurationPolicy(policyName string) nmstatev1alpha1.NodeNetworkConfigurationPolicy {
 	key := types.NamespacedName{Name: policyName}
 	policy := nmstatev1alpha1.NodeNetworkConfigurationPolicy{}
-	Eventually(func() error {
+	EventuallyWithOffset(1, func() error {
 		return framework.Global.Client.Get(context.TODO(), key, &policy)
 	}, ReadTimeout, ReadInterval).ShouldNot(HaveOccurred())
 	return policy
@@ -228,10 +228,10 @@ func deletePolicy(name string) {
 	policy := &nmstatev1alpha1.NodeNetworkConfigurationPolicy{}
 	policy.Name = name
 	err := framework.Global.Client.Delete(context.TODO(), policy)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	// Wait for policy to be removed
-	Eventually(func() bool {
+	EventuallyWithOffset(1, func() bool {
 		err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: name}, &nmstatev1alpha1.NodeNetworkConfigurationPolicy{})
 		return apierrors.IsNotFound(err)
 	}, 60*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Policy %s not deleted", name))


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Now that we are checking policy overall conditions at e2e tests, is good idea to run k8s tests with
two nodes to ensure that the distributed operator updated it correctly, doing so we found a but a knmstate, policy was not reaching the final state, issue was at retryOnConflict code tat knmstate not
re-reading the policy, so we were always on conflict.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
