### PR TITLE
Add e2e test waitFor functions for common policy conditions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -60,6 +60,7 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -11,12 +11,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	yaml "sigs.k8s.io/yaml"
 
@@ -33,6 +36,7 @@ var (
 const nmstateCommand = "nmstatectl"
 const vlanFilteringCommand = "vlan-filtering"
 const defaultGwProbeTimeout = 120
+const apiServerProbeTimeout = 120
 
 var (
 	interfacesFilterGlob glob.Glob
@@ -196,6 +200,28 @@ func ping(target string, timeout time.Duration) (string, error) {
 	})
 }
 
+func checkApiServerConnectivity(timeout time.Duration) error {
+	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		// Create new custom client to bypass cache [1]
+		// [1] https://github.com/operator-framework/operator-sdk/blob/master/doc/user/client.md#non-default-client
+		config, err := config.GetConfig()
+		if err != nil {
+			return false, errors.Wrap(err, "getting config")
+		}
+		// Since we are going to retrieve Nodes default schema is good
+		// enough
+		client, err := client.New(config, client.Options{})
+		if err != nil {
+			return false, errors.Wrap(err, "creating new custom client")
+		}
+		err = client.Get(context.TODO(), types.NamespacedName{Name: metav1.NamespaceDefault}, &corev1.Namespace{})
+		if err != nil {
+			return false, errors.Wrap(err, "reaching to apiserver failed")
+		}
+		return true, nil
+	})
+}
+
 func defaultGw() (string, error) {
 	observedStateRaw, err := show()
 	if err != nil {
@@ -258,6 +284,11 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 	pingOutput, err := ping(defaultGw, defaultGwProbeTimeout*time.Second)
 	if err != nil {
 		return pingOutput, rollback(fmt.Errorf("error pinging external address after network reconfiguration -> error: %v, currentState: %s", err, currentState))
+	}
+
+	err = checkApiServerConnectivity(apiServerProbeTimeout * time.Second)
+	if err != nil {
+		return "", rollback(fmt.Errorf("error checking api server connectivity after network reconfiguration -> error: %v, currentState: %s", err, currentState))
 	}
 
 	commitOutput, err := commit()

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/types"
 
 	"k8s.io/apimachinery/pkg/types"
 	yaml "sigs.k8s.io/yaml"
@@ -112,4 +113,34 @@ func policyConditionsStatusEventually() AsyncAssertion {
 
 func policyConditionsStatusConsistently() AsyncAssertion {
 	return policyConditionsStatusForPolicyConsistently(TestPolicy)
+}
+
+func containPolicyAvailable() GomegaMatcher {
+	return ContainElement(nmstatev1alpha1.Condition{
+		Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
+		Status: corev1.ConditionTrue,
+	})
+}
+
+func containPolicyDegraded() GomegaMatcher {
+	return ContainElement(nmstatev1alpha1.Condition{
+		Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionDegraded,
+		Status: corev1.ConditionTrue,
+	})
+}
+
+func waitForAvailableTestPolicy() {
+	policyConditionsStatusEventually().Should(containPolicyAvailable())
+}
+
+func waitForDegradedTestPolicy() {
+	policyConditionsStatusEventually().Should(containPolicyDegraded())
+}
+
+func waitForAvailablePolicy(policy string) {
+	policyConditionsStatusForPolicyEventually(policy).Should(containPolicyAvailable())
+}
+
+func waitForDegradedPolicy(policy string) {
+	policyConditionsStatusForPolicyEventually(policy).Should(containPolicyDegraded())
 }

--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -31,14 +31,11 @@ var _ = Describe("EnactmentCondition", func() {
 		AfterEach(func() {
 			By("Restore original vlan-filtering")
 			runAtPods("mv", "/usr/local/bin/vlan-filtering.bak", "/usr/local/bin/vlan-filtering")
+
 			By("Remove the bridge")
 			updateDesiredState(linuxBrAbsent(bridge1))
-			policyConditionsStatusEventually().Should(ContainElement(
-				nmstatev1alpha1.Condition{
-					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			))
+			waitForAvailableTestPolicy()
+
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
 		})
@@ -97,12 +94,7 @@ var _ = Describe("EnactmentCondition", func() {
 			}
 			wg.Wait()
 			By("Check policy is at available state")
-			policyConditionsStatusEventually().Should(ContainElement(
-				nmstatev1alpha1.Condition{
-					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			))
+			waitForAvailableTestPolicy()
 		})
 	})
 
@@ -138,6 +130,8 @@ var _ = Describe("EnactmentCondition", func() {
 					},
 				))
 			}
+			By("Check policy is at degraded state")
+			waitForDegradedTestPolicy()
 		})
 	})
 })

--- a/test/e2e/nncp_cleanup_test.go
+++ b/test/e2e/nncp_cleanup_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -21,22 +20,12 @@ var _ = Describe("NNCP cleanup", func() {
 		setDesiredStateWithPolicy(bridge1, linuxBrUp(bridge1))
 
 		By("Wait for policy to be ready")
-		policyConditionsStatusForPolicyEventually(bridge1).Should(ContainElement(
-			nmstatev1alpha1.Condition{
-				Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-				Status: corev1.ConditionTrue,
-			},
-		))
+		waitForAvailablePolicy(bridge1)
 	})
 
 	AfterEach(func() {
 		updateDesiredState(linuxBrAbsent(bridge1))
-		policyConditionsStatusEventually().Should(ContainElement(
-			nmstatev1alpha1.Condition{
-				Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-				Status: corev1.ConditionTrue,
-			},
-		))
+		waitForAvailableTestPolicy()
 		resetDesiredStateForNodes()
 	})
 

--- a/test/e2e/node_selector_test.go
+++ b/test/e2e/node_selector_test.go
@@ -18,20 +18,12 @@ var _ = Describe("NodeSelector", func() {
 		BeforeEach(func() {
 			By(fmt.Sprintf("Set policy %s with not matching node selector", bridge1))
 			setDesiredStateWithPolicyAndNodeSelector(bridge1, linuxBrUp(bridge1), nonexistentNodeSelector)
-			policyConditionsStatusForPolicyEventually(bridge1).Should(ContainElement(
-				nmstatev1alpha1.Condition{
-					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			))
+			waitForAvailablePolicy(bridge1)
 		})
 
 		AfterEach(func() {
 			setDesiredStateWithPolicy(bridge1, linuxBrAbsent(bridge1))
-			policyConditionsStatusForPolicyEventually(bridge1).Should(ContainElement(nmstatev1alpha1.Condition{
-				Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-				Status: corev1.ConditionTrue,
-			}))
+			waitForAvailablePolicy(bridge1)
 			deletePolicy(bridge1)
 			resetDesiredStateForNodes()
 		})
@@ -53,12 +45,7 @@ var _ = Describe("NodeSelector", func() {
 			BeforeEach(func() {
 				By(fmt.Sprintf("Remove node selector at policy %s", bridge1))
 				setDesiredStateWithPolicyAndNodeSelector(bridge1, linuxBrUp(bridge1), map[string]string{})
-				policyConditionsStatusForPolicyEventually(bridge1).Should(ContainElement(
-					nmstatev1alpha1.Condition{
-						Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-						Status: corev1.ConditionTrue,
-					},
-				))
+				waitForAvailablePolicy(bridge1)
 			})
 
 			It("should update all nodes and have Matching enactment state", func() {

--- a/test/e2e/simple_bridge_and_bond.go
+++ b/test/e2e/simple_bridge_and_bond.go
@@ -121,9 +121,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with a linux bridge up with no ports", func() {
 			BeforeEach(func() {
 				updateDesiredState(linuxBrUpNoPorts(bridge1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(linuxBrAbsent(bridge1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 				}
@@ -139,9 +141,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with a linux bridge up", func() {
 			BeforeEach(func() {
 				updateDesiredState(linuxBrUp(bridge1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(linuxBrAbsent(bridge1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 				}
@@ -161,9 +165,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with a active-backup miimon 100 bond interface up", func() {
 			BeforeEach(func() {
 				updateDesiredState(bondUp(bond1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(bondAbsent(bond1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}
@@ -187,9 +193,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with the bond interface as linux bridge port", func() {
 			BeforeEach(func() {
 				updateDesiredState(brWithBondUp(bridge1, bond1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(brAndBondAbsent(bridge1, bond1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
@@ -229,9 +237,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with bond interface that has 2 eths as slaves", func() {
 			BeforeEach(func() {
 				updateDesiredState(bondUpWithEth1AndEth2(bond1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(bondAbsent(bond1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}
@@ -258,9 +268,11 @@ var _ = Describe("NodeNetworkState", func() {
 		Context("with bond interface that has 2 eths as slaves and vlan tag on the bond", func() {
 			BeforeEach(func() {
 				updateDesiredState(bondUpWithEth1Eth2AndVlan(bond1))
+				waitForAvailableTestPolicy()
 			})
 			AfterEach(func() {
 				updateDesiredState(bondAbsent(bond1))
+				waitForAvailableTestPolicy()
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}

--- a/test/e2e/simple_ovs_bridge.go
+++ b/test/e2e/simple_ovs_bridge.go
@@ -9,9 +9,11 @@ var _ = Describe("Simple OVS bridge", func() {
 	Context("when desiredState is configured with an ovs bridge up", func() {
 		BeforeEach(func() {
 			updateDesiredState(ovsBrUp(bridge1))
+			waitForAvailableTestPolicy()
 		})
 		AfterEach(func() {
 			updateDesiredState(ovsBrAbsent(bridge1))
+			waitForAvailableTestPolicy()
 			for _, node := range nodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}
@@ -30,9 +32,11 @@ var _ = Describe("Simple OVS bridge", func() {
 	Context("when desiredState is configured with an ovs bridge with internal port up", func() {
 		BeforeEach(func() {
 			updateDesiredState(ovsbBrWithInternalInterface(bridge1))
+			waitForAvailableTestPolicy()
 		})
 		AfterEach(func() {
 			updateDesiredState(ovsBrAbsent(bridge1))
+			waitForAvailableTestPolicy()
 			for _, node := range nodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -188,10 +188,7 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 //       to remove this
 func resetDesiredStateForNodes() {
 	updateDesiredState(ethernetNicUp(*primaryNic))
-	policyConditionsStatusEventually().Should(ContainElement(nmstatev1alpha1.Condition{
-		Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-		Status: corev1.ConditionTrue,
-	}))
+	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The main conditions e2e tests wait for are policy Available/Degraded,
this commit wrap them at a waitForAvailable and waitForDegraded functions.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
