### PR TITLE
Retrieve policy at unit/test

### DIFF
--- a/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/conditions_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/conditions_test.go
@@ -1,6 +1,7 @@
 package policyconditions
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -112,7 +114,10 @@ var _ = Describe("Policy Conditions", func() {
 			objs = append(objs, updatedPolicy)
 
 			client := fake.NewFakeClientWithScheme(s, objs...)
-			err := Update(client, updatedPolicy)
+			key := types.NamespacedName{Name: updatedPolicy.Name}
+			err := Update(client, key)
+			Expect(err).ToNot(HaveOccurred())
+			err = client.Get(context.TODO(), key, updatedPolicy)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cleanTimestamps(updatedPolicy.Status.Conditions)).To(ConsistOf(cleanTimestamps(c.Policy.Status.Conditions)))
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After fixing the policy re-read at conflict we broke the unit test, this PR fix that reading the policy before checking conditions at test.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
