### PR TITLE
report conditions with state report status

### DIFF
--- a/pkg/apis/nmstate/v1alpha1/condition_types_test.go
+++ b/pkg/apis/nmstate/v1alpha1/condition_types_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("Conditions list", func() {
 	Context("is empty", func() {
 		It("should return nil when finding a condition", func() {
-			condition := ConditionList{}.Find(NodeNetworkStateConditionFailing)
+			condition := ConditionList{}.Find(NodeNetworkStateConditionDegraded)
 			Expect(condition).To(BeNil())
 		})
 	})
@@ -21,7 +21,7 @@ var _ = Describe("Conditions list", func() {
 	Context("contains a single item", func() {
 		originalConditions := ConditionList{
 			Condition{
-				Type:    NodeNetworkStateConditionFailing,
+				Type:    NodeNetworkStateConditionDegraded,
 				Status:  corev1.ConditionUnknown,
 				Reason:  ConditionReason("foo"),
 				Message: "bar",

--- a/pkg/apis/nmstate/v1alpha1/nodenetworkstate_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkstate_types.go
@@ -15,13 +15,18 @@ type NodeNetworkStateStatus struct {
 
 const (
 	NodeNetworkStateConditionAvailable ConditionType = "Available"
-	NodeNetworkStateConditionFailing   ConditionType = "Failing"
+	NodeNetworkStateConditionDegraded  ConditionType = "Degraded"
 )
 
 const (
-	NodeNetworkStateConditionFailedToConfigure      ConditionReason = "FailedToConfigure"
-	NodeNetworkStateConditionSuccessfullyConfigured ConditionReason = "SuccessfullyConfigured"
+	NodeNetworkStateConditionFailedToObtainCurrentState        ConditionReason = "FailedToObtainCurrentState"
+	NodeNetworkStateConditionSuccessfullyObtainedCurrentStatus ConditionReason = "SuccessfullyObtainedCurrentStatus"
 )
+
+var NodeNetworkStateConditionTypes = [...]ConditionType{
+	NodeNetworkStateConditionAvailable,
+	NodeNetworkStateConditionDegraded,
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -90,28 +90,20 @@ func InitializeNodeNeworkState(client client.Client, node *corev1.Node, scheme *
 	return nil
 }
 
-func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1alpha1.NodeNetworkState) error {
-	observedStateRaw, err := nmstatectl.Show()
+func CurrentState() (nmstatev1alpha1.State, error) {
+	currentStateRaw, err := nmstatectl.Show()
 	if err != nil {
-		return fmt.Errorf("error running nmstatectl show: %v", err)
+		return nmstatev1alpha1.State{}, fmt.Errorf("error running nmstatectl show: %v", err)
 	}
-	observedState := nmstatev1alpha1.State{Raw: []byte(observedStateRaw)}
+	currentState := nmstatev1alpha1.State{Raw: []byte(currentStateRaw)}
 
-	stateToReport, err := filterOut(observedState, interfacesFilterGlob)
+	stateToReport, err := filterOut(currentState, interfacesFilterGlob)
 	if err != nil {
 		fmt.Printf("failed filtering out interfaces from NodeNetworkState, keeping orignal content, please fix the glob: %v", err)
-		stateToReport = observedState
+		stateToReport = currentState
 	}
 
-	nodeNetworkState.Status.CurrentState = stateToReport
-	nodeNetworkState.Status.LastSuccessfulUpdateTime = metav1.Time{Time: time.Now()}
-
-	err = client.Status().Update(context.Background(), nodeNetworkState)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return stateToReport, nil
 }
 
 func ping(target string, timeout time.Duration) (string, error) {

--- a/test/e2e/nns_conditions_test.go
+++ b/test/e2e/nns_conditions_test.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
+)
+
+var _ = Describe("NodeNetworkStateCondition", func() {
+	Context("when cluster is initialized", func() {
+		BeforeEach(func() {
+			deleteNodeNeworkStates()
+		})
+		It("should have Available ConditionType set to true", func() {
+			for _, node := range nodes {
+				stateConditionsStatusEventually(node).Should(SatisfyAll(
+					containStateAvailable(),
+					containStateNotDegraded(),
+				))
+			}
+		})
+	})
+
+	Context("when nmstatectl show fails", func() {
+		BeforeEach(func() {
+			By("Rename nmstatectl to nmstatectl.bak to force failure during nmstatectl show")
+			runner.RunAtPods("mv", "/usr/bin/nmstatectl", "/usr/bin/nmstatectl.bak")
+			deleteNodeNeworkStates()
+		})
+		AfterEach(func() {
+			By("Rename nmstatectl.bak to nmstatectl to have functional nmstatectl")
+			runner.RunAtPods("mv", "/usr/bin/nmstatectl.bak", "/usr/bin/nmstatectl")
+		})
+		It("should fail", func() {
+			for _, node := range nodes {
+				stateConditionsStatusEventually(node).Should(SatisfyAll(
+					containStateNotAvailable(),
+					containStateDegraded(),
+				))
+			}
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In case something really bad happens and we fail to obtain the current network state to update NNS, we should be able to report it. With this PR, we start reporting conditions in NNS.

**Special notes for your reviewer**:

This patch also piggy-backs fix of state_utils.go module name and +option
annotations.

Note that NNS attributes had to be changed into pointers. Without this change,
it was not possible to UPDATE NNS after unsuccessful reporting (the client would
complain about invalid type of attributes "null").

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NNS conditions reporting success/failure of obtaining the current state of network
```
