### PR TITLE
WIP: perform dry run before applying configuration

### DIFF
--- a/build/bin/nmstatectl_set_dry.py
+++ b/build/bin/nmstatectl_set_dry.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# nmstatectl set dry run
+#
+# To check if there is a difference between desired state and actual
+# configuration, pass desired state yaml to standard input of this script.
+#
+# To reduce risks, this should be executed only if the desired configuration is
+# the same as in the previous execution.
+#
+# Although this script may be enough for checking of interfaces, it may not
+# always work with routes and DNS.
+
+import sys
+
+import yaml
+
+from libnmstate import metadata
+from libnmstate import netinfo
+from libnmstate import state
+
+
+def _get_diff_ifaces(desired_state_raw):
+    desired_state = state.State(yaml.safe_load(desired_state_raw))
+    current_state = state.State(netinfo.show())
+
+    desired_state.sanitize_ethernet(current_state)
+    desired_state.sanitize_dynamic_ip()
+    desired_state.merge_routes(current_state)
+    desired_state.merge_dns(current_state)
+    desired_state.merge_route_rules(current_state)
+    desired_state.remove_unknown_interfaces()
+    metadata.generate_ifaces_metadata(desired_state, current_state)
+
+    state2edit = state.create_state(
+        desired_state.state,
+        interfaces_to_filter=(set(current_state.interfaces))
+    )
+    state2edit.merge_interfaces(current_state)
+
+    return set(state2edit.interfaces)
+
+
+def _main():
+    diff_ifaces = _get_diff_ifaces(sys.stdin.read())
+
+    if diff_ifaces:
+        print(f'Some interfaces need to be edited: {diff_ifaces}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    _main()

--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
@@ -169,6 +169,7 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) Reconcile(request reconcile.Re
 
 	policyconditions.Reset(r.client, request.NamespacedName)
 
+	// TODO: get previous enactment if there is any, that would mean we are updating
 	err = r.initializeEnactment(*instance)
 	if err != nil {
 		log.Error(err, "Error initializing enactment")
@@ -194,6 +195,13 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) Reconcile(request reconcile.Re
 	}
 
 	enactmentConditions.NotifyMatching()
+
+	// TODO:
+	// if there was a previous enactment (we are updating),
+	// and if the desired state has changed
+	// test the dry run
+	// if fails, execute the configuration,
+	// otherwise just skip to NotifySuccess
 
 	enactmentConditions.NotifyProgressing()
 	nmstateOutput, err := nmstate.ApplyDesiredState(instance.Spec.DesiredState)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In order to support multiple policies changing the same node, we plan
to periodically reapply all matching policies on the node. In order not
to run the configuration every time we re-reconcile, we have to perform
a dry run first. Since the dry run is not yet supported in nmstate, we
introduce a script which uses libnmstate functions to perform the check.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
