### PR TITLE
Add script to publish to quay.io

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -xe
+
+# This script publish kubernetes-nmstate-handler by default at quay.io/nmstate
+# organization to publish elsewhere export the following env vars
+# IMAGE_REGISTRY
+# IMAGE_REPO
+# To run it just do proper docker login and automation/publish.sh
+
+source automation/check-patch.setup.sh
+cd ${TMP_PROJECT_PATH}
+make \
+    IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}  \
+    IMAGE_REPO=${IMAGE_REPO:-nmstate} \
+    push-handler


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After moving to prow, we no longer are publishing containers at quay.io when we merge to master, this job add the script to do so it will be called from prow https://github.com/kubevirt/project-infra/pull/298

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
