### PR TITLE
Add script to automatize github release

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+# This script tags current version and create a new release at github and pushes
+# to quay.io
+# To run it just do proper docker login and pass the git hub user password/token as
+# GITHUB_USER and GITHUB_TOKEN env variables.
+
+# To pass user/password from automations, idea is taken from [1]
+# [1] https://stackoverflow.com/questions/8536732/can-i-hold-git-credentials-in-environment-variables
+git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
+
+source automation/check-patch.setup.sh
+cd ${TMP_PROJECT_PATH}
+make \
+    IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}  \
+    IMAGE_REPO=${IMAGE_REPO:-nmstate} \
+    release


### PR DESCRIPTION
It will instruct github to use GITHUB_USER and GITHUB_TOKEN as
user password and call `make release`

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
