### PR TITLE
drop leftover focus in tests

### DIFF
--- a/test/e2e/rollback_test.go
+++ b/test/e2e/rollback_test.go
@@ -32,7 +32,7 @@ routes:
 `, nic, address, nic))
 }
 
-var _ = FDescribe("rollback", func() {
+var _ = Describe("rollback", func() {
 	Context("when an error happens during state configuration", func() {
 		BeforeEach(func() {
 			By("Rename vlan-filtering to vlan-filtering.bak to force failure during state configuration")


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We forgot a Focus in the tests.

**Special notes for your reviewer**:
Double-check that all tests are indeed executed. I think that F does not apply on Describe, but this is still fishy.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
