### PR TITLE
Fix release scripts

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 git tag $TAG
-git push upstream --tags
+git push origin --tags
 
 $GITHUB_RELEASE release -u nmstate -r kubernetes-nmstate \
     --tag $TAG \

--- a/version/version.go
+++ b/version/version.go
@@ -3,3 +3,5 @@ package version
 var (
 	Version = "0.13.0"
 )
+
+// * Force release after fixing release.sh


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The remote name of the command line that push tags was wrong at the release.sh this fix it and also 
do a noop version.go change so we trigger the release prow job.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
