### PR TITLE
add OCP 4.3 CI lane

### DIFF
--- a/automation/check-patch.e2e-k8s.mounts
+++ b/automation/check-patch.e2e-k8s.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-k8s.packages
+++ b/automation/check-patch.e2e-k8s.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -xe
+
+# This script should be able to execute functional tests against OKD cluster on
+# any environment with basic dependencies listed in check-patch.packages
+# installed and docker running.
+#
+# yum -y install automation/check-patch.packages
+# automation/check-patch.e2e-okd.sh
+
+teardown() {
+    make cluster-down
+}
+
+main() {
+    export KUBEVIRT_PROVIDER='ocp-4.3'
+
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+
+    # Let's fail fast if it's not compiling
+    make handler
+
+    make cluster-down
+    make cluster-up
+    trap teardown EXIT SIGINT SIGTERM SIGSTOP
+    make cluster-sync
+    make \
+        E2E_TEST_ARGS='-ginkgo.noColor -ginkgo.skip .*NNS.*cleanup.*|.*OVS.*' \
+        test/e2e
+    make \
+        E2E_TEST_ARGS='-ginkgo.noColor -ginkgo.focus .*NNS.*cleanup.*' \
+        test/e2e
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-okd.mounts
+++ b/automation/check-patch.e2e-okd.mounts
@@ -1,1 +1,0 @@
-check-patch.e2e.mounts

--- a/automation/check-patch.e2e-okd.packages
+++ b/automation/check-patch.e2e-okd.packages
@@ -1,1 +1,0 @@
-check-patch.e2e.packages

--- a/automation/check-patch.e2e.mounts
+++ b/automation/check-patch.e2e.mounts
@@ -1,1 +1,0 @@
-/var/run/docker.sock:/var/run/docker.sock

--- a/automation/check-patch.e2e.packages
+++ b/automation/check-patch.e2e.packages
@@ -1,3 +1,0 @@
-docker
-make
-git

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="6132f2efcf2aa2d48f256a409fe90cc0b74c3563"
+commit="78dcc4f8aaec467bba8ae325646056128268a169"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The OCP provider seems to be more stable in a moment, so it may allow us to unblock the CI for OpenShift.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
