### PR TITLE
get latest fix with jq installed on OpenShift providers

### DIFF
--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="78dcc4f8aaec467bba8ae325646056128268a169"
+commit="effb245dc018e7f502119c1e9f30e703ae8bbe14"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We need to include https://github.com/kubevirt/kubevirtci/pull/231 in order to support OCP lane on CI.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
