### PR TITLE
Call generators before handler build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,14 +71,15 @@ $(OPERATOR_SDK): go.mod
 $(GITHUB_RELEASE): go.mod
 	GOBIN=$$(pwd)/$(BIN_DIR) go install ./vendor/github.com/aktau/github-release
 
-handler: $(OPERATOR_SDK)
-	$(OPERATOR_SDK) build $(HANDLER_IMAGE)
 
 gen-k8s: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate k8s
 
 gen-openapi: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate openapi
+
+handler: gen-openapi gen-k8s $(OPERATOR_SDK)
+	$(OPERATOR_SDK) build $(HANDLER_IMAGE)
 
 push-handler: handler
 	docker push $(HANDLER_IMAGE)


### PR DESCRIPTION

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->
It increases a little the build time but ensure that we
don't miss some openapi or deepcopy bit.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
