### PR TITLE
Add Makefile targets to prepare a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,8 @@ the command `make release` do all this automatically, the version  is at
 `version/version.go` and the description at `version/description`.
 
 So the step would be:
- - Change version/version.go and versions/description
+ - Prepare a release calling `make prepare-(patch|minor|major)`
+ - Edit version/description to set a description and order commits
  - Create a PR to review it
  - Merge it to master
  - Call `make release` from master

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,13 @@ $(description): version/description
 	sed "s#HANDLER_IMAGE#$(HANDLER_IMAGE)#" \
 		version/description > $@
 
+prepare-patch:
+	./hack/prepare-release.sh patch
+prepare-minor:
+	./hack/prepare-release.sh minor
+prepare-major:
+	./hack/prepare-release.sh major
+
 # This uses target specific variables [1] so we can use push-handler as a
 # dependency and change the SUFFIX with the correct version so no need for
 # calling make on make is needed.

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+expected_types="(major|minor|patch)"
+current_type=$1
+
+bump() {
+    version=$(hack/version.sh)
+    version_part=$(echo $version |sed $1)
+    version_part=$((++version_part))
+    version=$(echo $version | sed $2 | sed "s/version_part/$version_part/g")
+    ./hack/version.sh $version
+}
+
+bump_major() {
+   bump "s/^v\(.*\)[.].*[.].*$/\1/g" "s/^v\(.*\)[.]\(.*\)[.]\(.*\)$/version_part.\2.\3/g"
+}
+
+bump_minor() {
+    bump "s/^v.*[.]\(.*\)[.].*$/\1/g" "s/^v\(.*\)[.]\(.*\)[.]\(.*\)$/\1.version_part.\3/g"
+}
+
+bump_patch() {
+    bump "s/^v.*[.].*[.]\(.*\)$/\1/g" "s/^v\(.*\)[.]\(.*\)[.]\(.*\)$/\1.\2.version_part/g"
+}
+
+if [[ ! $current_type =~ $expected_types ]]; then
+    echo "Usage: $0 $expected_types"
+    exit 1
+fi
+
+bump_$current_type
+hack/version.sh

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+version_type=$1
+old_version=$(hack/version.sh)
+new_version=$(hack/bump-version.sh $version_type)
+commits=$(git log --pretty=format:"* %s" $old_version..HEAD)
+
+
+cat << EOF > version/description
+$new_version
+
+TODO: Add description here
+
+
+TODO: keep at every category the
+      commits that make sense
+
+Features:
+$commits
+
+Bugs:
+$commits
+
+Docs:
+$commits
+
+\`\`\`
+docker pull HANDLER_IMAGE
+\`\`\`
+EOF
+
+${EDITOR:-vi} version/description
+
+git checkout -b release-$new_version
+git commit -a -s -m "Release $new_version"

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,2 +1,9 @@
 #!/bin/bash -e
-grep = version/version.go | sed -r 's/.*= \"(.*)"$$/v\1/g'
+version_file=version/version.go
+# If we don't pass a version just show current one
+if [ -z "$1" ]; then
+    grep = $version_file | sed -r 's/.*= \"(.*)"$$/v\1/g'
+# else change it
+else
+    sed -i "s/= \".*\"$/= \"$1\"/g" $version_file
+fi


### PR DESCRIPTION

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It will bump version and prepare description with commits, after
that version/description has to be manually edited to fix TODOs.

New make targets:
make prepare-patch
make prepare-minor
make prepare-major

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
