### PR TITLE
Always copy junit reports at CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HANDLER_IMAGE ?= $(IMAGE_REGISTRY)/$(HANDLER_IMAGE_FULL_NAME)
 
 WHAT ?= ./pkg
 
-unit_test_args ?=  -r --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
+unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
 
 export KUBEVIRT_PROVIDER ?= k8s-1.15.1
 export KUBEVIRT_NUM_NODES ?= 1

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -9,6 +9,7 @@
 
 teardown() {
     make cluster-down
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 main() {
@@ -25,7 +26,6 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
-    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -9,6 +9,7 @@
 
 teardown() {
     make cluster-down
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 main() {
@@ -25,7 +26,6 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
-    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-okd.sh
+++ b/automation/check-patch.e2e-okd.sh
@@ -12,6 +12,7 @@ exit 0
 
 teardown() {
     make cluster-down
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 main() {
@@ -28,7 +29,6 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
     make E2E_TEST_ARG="-ginkgo.noColor" test/e2e
-    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -7,12 +7,16 @@
 # yum -y install automation/check-patch.packages
 # automation/check-patch.e2e-k8s.sh
 
+teardown() {
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
+}
+
 main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
     make all
+    trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make UNIT_TEST_ARGS="-noColor --compilers=2" test/unit
-    cp $(find . -name "*junit*.xml") $ARTIFACTS
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If unit-test/e2e-test fail junit reports where not being copied to artifacts, so they don't appear, also
at unit test we were not exuting the rest of the suite if one fails.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
