### PR TITLE
add test for bonding as the default interface

### DIFF
--- a/test/e2e/bonding_default_interface_test.go
+++ b/test/e2e/bonding_default_interface_test.go
@@ -1,0 +1,138 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+)
+
+func boundUpWithPrimaryAndSecondary(bondName string) nmstatev1alpha1.State {
+	return nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    type: bond
+    state: up
+    ipv4:
+      dhcp: true
+      enabled: true
+    link-aggregation:
+      mode: balance-rr
+      options:
+        miimon: '140'
+      slaves:
+        - %s
+        - %s
+`, bondName, *primaryNic, *firstSecondaryNic))
+}
+
+func bondAbsentWithPrimaryUp(bondName string) nmstatev1alpha1.State {
+	return nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    type: bond
+    state: absent
+  - name: %s
+    state: up
+    type: ethernet
+    ipv4:
+      dhcp: true
+      enabled: true
+`, bondName, *primaryNic))
+}
+
+var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", func() {
+	Context("when there is a default interface with dynamic address", func() {
+		addressByNode := map[string]string{}
+		BeforeEach(func() {
+			By(fmt.Sprintf("Check %s is the default route interface and has dynamic address", *primaryNic))
+			for _, node := range nodes {
+				defaultRouteNextHopInterface(node).Should(Equal(*primaryNic))
+				Expect(dhcpFlag(node, *primaryNic)).Should(BeTrue())
+			}
+
+			By("Fetching current IP address")
+			for _, node := range nodes {
+				address := ""
+				Eventually(func() string {
+					address = ipv4Address(node, *primaryNic)
+					return address
+				}, 15*time.Second, 1*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s has no ipv4 address", *primaryNic))
+				By(fmt.Sprintf("Fetching current IP address %s", address))
+				addressByNode[node] = address
+			}
+			By(fmt.Sprintf("Reseting state of %s", *firstSecondaryNic))
+			resetNicStateForNodes(*firstSecondaryNic)
+			By(fmt.Sprintf("Creating %s on %s and %s", bond1, *primaryNic, *firstSecondaryNic))
+			updateDesiredState(boundUpWithPrimaryAndSecondary(bond1))
+			waitForAvailableTestPolicy()
+			By("Done configuring test")
+
+		})
+		AfterEach(func() {
+			By(fmt.Sprintf("Removing bond %s and configuring %s with dhcp", bond1, *primaryNic))
+			updateDesiredState(bondAbsentWithPrimaryUp(bond1))
+			waitForAvailableTestPolicy()
+
+			By("Waiting until the node becomes ready again")
+			for _, node := range nodes {
+
+				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
+			}
+
+			resetDesiredStateForNodes()
+
+			By(fmt.Sprintf("Check %s has the default ip address", *primaryNic))
+			for _, node := range nodes {
+				Eventually(func() string {
+					return ipv4Address(node, *primaryNic)
+				}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", *primaryNic))
+			}
+
+
+		})
+
+		It("should successfully move default IP address on top of the bond", func() {
+			var (
+				expectedBond  = interfaceByName(interfaces(boundUpWithPrimaryAndSecondary(bond1)), bond1)
+				expectedSpecs = expectedBond["link-aggregation"].(map[string]interface{})
+			)
+
+			By("Checking that bond was configured and obtained the same IP address")
+			for _, node := range nodes {
+				verifyBondIsUpWithPrimaryNicIp(node, expectedBond, expectedSpecs, addressByNode[node])
+			}
+			// Restart only first node that it master if other node is restarted it will stuck in NotReady state
+			nodeToReboot := nodes[0]
+			By(fmt.Sprintf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot))
+			err := restartNode(nodeToReboot)
+			Expect(err).ToNot(HaveOccurred())
+			By(fmt.Sprintf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1))
+			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, expectedSpecs, addressByNode[nodeToReboot])
+		})
+	})
+})
+
+
+func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interface{}, expectedSpecs map[string]interface{}, ip string){
+	interfacesForNode(node).Should(ContainElement(SatisfyAll(
+		HaveKeyWithValue("name", expectedBond["name"]),
+		HaveKeyWithValue("type", expectedBond["type"]),
+		HaveKeyWithValue("state", expectedBond["state"]),
+		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
+		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
+		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{*primaryNic, *firstSecondaryNic}))),
+	)))
+
+	Eventually(func() string {
+		return ipv4Address(node, bond1)
+	}, 30*time.Second, 1*time.Second).Should(Equal(ip), fmt.Sprintf("Interface bond1 has not take over the %s address", *primaryNic))
+}
+
+
+func resetNicStateForNodes(nicName string) {
+	updateDesiredState(ethernetNicUp(nicName))
+	waitForAvailableTestPolicy()
+	deletePolicy(TestPolicy)
+}

--- a/test/e2e/default_bridged_network_test.go
+++ b/test/e2e/default_bridged_network_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidwall/gjson"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -130,13 +128,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 		})
 	})
 })
-
-func defaultRouteNextHopInterface(node string) AsyncAssertion {
-	return Eventually(func() string {
-		path := "routes.running.#(destination==\"0.0.0.0/0\").next-hop-interface"
-		return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()
-	}, 15*time.Second, 1*time.Second)
-}
 
 func nodeReadyConditionStatus(nodeName string) (corev1.ConditionStatus, error) {
 	key := types.NamespacedName{Name: nodeName}


### PR DESCRIPTION
Adding test that creates bond from primary and secondary nics. Verifies bonds creation and that bond got same ip as primary nic. Then nodes are restarted and test verifies that bond still exists and still has same ip of primary nic.

```release-note
NONE
```
