### PR TITLE
Pin and install go from go.mod version

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -6,22 +6,11 @@
 tmp_dir=/tmp/knmstate/
 
 rm -rf $tmp_dir
-
-echo 'Setup Go paths'
-export GOROOT=$tmp_dir/go/root
-mkdir -p $GOROOT
-export PATH=${GOROOT}/bin:${PATH}
-
-export GIMME_GO_VERSION=$(grep "^go " go.mod |awk '{print $2}')
-echo "Install Go $GIMME_GO_VERSION"
-gimme_dir=$tmp_dir/go/gimme
-mkdir -p $gimme_dir
-curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${gimme_dir} bash >> ${gimme_dir}/gimme.sh
-source $gimme_dir/gimme.sh
-
+mkdir -p $tmp_dir
 
 export TMP_PROJECT_PATH=$tmp_dir/kubernetes-nmstate
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
+
 rsync -rt --links --filter=':- .gitignore' $(pwd)/ $TMP_PROJECT_PATH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nmstate/kubernetes-nmstate
 
-go 1.12
+go 1.12.15
 
 require (
 	github.com/aktau/github-release v0.7.2

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod |awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xvf $destination/$tarball -C $destination


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This include a super low tech mechanism not docker multistage either
dockerized golang, it just download a golang tarball and install it under
repo.

There are missaligns between goalang dep from project and users environments, this way we always use the golang version needed by project.

We have skip multistage since we are based our build on Makefiles, so for example for make vet, gofmt etc we would need to include those as the multistage, and call them somehow from make running partial stage, let's just keep it simple, it may download tarball more than once, if we see it's brings more pain than help we can change to multistage.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
