### PR TITLE
Add user guide for vlan and dynamic ip policy

### DIFF
--- a/docs/user-guide-policy-configure-vlan-and-dynamic-ip.md
+++ b/docs/user-guide-policy-configure-vlan-and-dynamic-ip.md
@@ -1,0 +1,125 @@
+# Tutorial: configure VLAN on a Node Interface
+
+Use Node Network Configuration Policy to configure a new vlan on a node interface `eth1`.
+
+## Requirements
+
+Before we start, please make sure that you have your Kubernetes/OpenShift
+cluster ready. In order to do that, you can follow the guides of deployment on
+[local cluster](deployment-local-cluster.md) or your
+[arbitrary cluster](deployment-arbitrary-cluster.md).
+
+## Configure vlan
+
+All you have to do in order to configure the vlan on all nodes across cluster is
+to apply the following policy
+(In this example, the vlan ID is '102', the base interface is 'eth1' and the new vlan interface name is 'eth1.102'):
+
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-eth1-policy
+spec:
+  desiredState:
+    interfaces:
+    - name: eth1.102
+      type: vlan
+      state: up
+      vlan:
+        base-iface: eth1
+        id: 102
+EOF
+```
+
+You can also remove the vlan with following:
+
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-eth1 -policy
+spec:
+  desiredState:
+    interfaces:
+    - name: eth1.102
+      type: vlan
+      state: absent
+EOF
+```
+
+## Selecting nodes
+
+`NodeNetworkConfigurationPolicy` supports node selectors.
+Thanks to them you can select a subset of nodes or a specific node by its name:
+
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-eth1-node01-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: node01
+  desiredState:
+    interfaces:
+    - name: eth1.102
+      type: vlan
+      state: up
+      vlan:
+        base-iface: eth1
+        id: 102
+EOF
+```
+
+## Set static IP address on a vlan
+
+In order to set a static IP address on the vlan interface on all nodes across cluster, apply the following policy:
+Note that when configuring a static IP you must use a node selector since we cannot set the same IP across multiple nodes.
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: static-ip-on-vlan-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: node01
+  desiredState:
+    interfaces:
+    - name: eth1.102
+      type: vlan
+      state: up
+      ipv4:
+        address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        dhcp: false
+        enabled: true
+EOF
+```
+
+## Set dynamic IP address on a vlan
+
+In order to set dynamic IP address on the vlan interface on all nodes across cluster, apply the following policy:
+
+```yaml
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: dynamic-ip-on-vlan-policy
+spec:
+  desiredState:
+    interfaces:
+    - name: eth1.102
+      type: vlan
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+EOF
+```

--- a/test/e2e/simple_vlan_and_ip_test.go
+++ b/test/e2e/simple_vlan_and_ip_test.go
@@ -1,0 +1,62 @@
+package e2e
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NodeNetworkState", func() {
+	Context("when vlan configured", func() {
+		var (
+			vlanId = "102"
+		)
+
+		BeforeEach(func() {
+			updateDesiredState(ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))
+			waitForAvailableTestPolicy()
+		})
+		AfterEach(func() {
+			updateDesiredState(vlanAbsent(*firstSecondaryNic, vlanId))
+			resetDesiredStateForNodes()
+		})
+		It("should have the vlan interface configured", func() {
+			for _, node := range nodes {
+				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).Should(Equal(vlanId))
+			}
+		})
+	})
+	//TODO: change static IP to DHCP once we have a DHCP server running on a VLAN.
+	Context("when static address is configured on top of vlan interface", func() {
+		var (
+			ipAddressTemplate = "62.76.47.%d"
+			vlanId      = "102"
+		)
+		BeforeEach(func() {
+			updateDesiredState(ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))
+			waitForAvailableTestPolicy()
+			for index, node := range nodes {
+				ipAddress := fmt.Sprintf(ipAddressTemplate, index)
+				By(fmt.Sprintf("applying static IP %s on node %s", ipAddress, node))
+				updateDesiredStateAtNode(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", *firstSecondaryNic, vlanId), ipAddress))
+				waitForAvailableTestPolicy()
+			}
+
+		})
+
+		AfterEach(func() {
+			updateDesiredState(vlanAbsent(*firstSecondaryNic, vlanId))
+			waitForAvailableTestPolicy()
+			resetDesiredStateForNodes()
+		})
+
+		It("should have the vlan interface configured and IP configured", func() {
+			for index, node := range nodes {
+				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).
+					Should(Equal(vlanId))
+				ipAddressForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).
+					Should(Equal(fmt.Sprintf(ipAddressTemplate, index)))
+			}
+		})
+	})
+})

--- a/test/e2e/states.go
+++ b/test/e2e/states.go
@@ -135,3 +135,17 @@ func ifaceDownIPv4Disabled(iface string) nmstatev1alpha1.State {
         enabled: false
 `, iface))
 }
+
+func vlanUpWithStaticIP(iface string, ipAddress string) nmstatev1alpha1.State {
+	return nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+    - name: %s
+      type: vlan
+      state: up
+      ipv4:
+        address:
+        - ip: %s
+          prefix-length: 24
+        dhcp: false
+        enabled: true
+`, iface, ipAddress))
+}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -578,6 +578,7 @@ func defaultRouteNextHopInterface(node string) AsyncAssertion {
 		return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()
 	}, 15*time.Second, 1*time.Second)
 }
+
 func vlan(node string, iface string) string {
 	vlanFilter := fmt.Sprintf("interfaces.#(name==\"%s\").vlan.id", iface)
 	return gjson.ParseBytes(currentStateJSON(node)).Get(vlanFilter).String()


### PR DESCRIPTION
Add user-guide-policy-configure-vlan-and-dynamic-ip.md

The guide show:
- How to configure and delete a vlan on an interface on all nodes.
- How to configure a vlan on an interface on a specific node.
- How and to configure dynamic IP on a vlan interface.
    
CNV-3553 kubernetes-nmstate: add documentation for vlan

**Special notes for your reviewer**:
The test will be in a different PR

```release-note
NONE
```
