### PR TITLE
Rename e2e junit report to make flakefinder happy

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 func TestE2E(tapi *testing.T) {
 	t = tapi
 	RegisterFailHandler(Fail)
-	junitReporter := reporters.NewJUnitReporter("junit.e2e.xml")
+	junitReporter := reporters.NewJUnitReporter("junit.functest.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "E2E Test Suite", []Reporter{junitReporter})
 
 }


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Rename the junit.e2e.xml report to junit.functest.xml, this is the spected for flakefinder to parse results, so we will get proper stuff at https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/nmstate/kubernetes-nmstate/index.html

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
