### PR TITLE
Improve logging mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,8 @@ tags
 ### VisualStudioCode ###
 .vscode/*
 .history
+
+### Test logs ###
+test_logs
+
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ test/unit: $(GINKGO)
 test/e2e: $(OPERATOR_SDK)
 	# We have to unset mod=vendor here since operator-sdk is already
 	# building with it, and go tool fail if it's specified twice
+	mkdir -p test_logs/e2e
 	unset GOFLAGS && $(OPERATOR_SDK) test local ./test/e2e \
 		--kubeconfig $(KUBECONFIG) \
 		--namespace nmstate \

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -10,6 +10,7 @@
 teardown() {
     make cluster-down
     cp $(find . -name "*junit*.xml") $ARTIFACTS
+    [ -d ${E2E_LOGS} ] && cp ${E2E_LOGS}/*.log ${ARTIFACTS}
 }
 
 main() {

--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -10,6 +10,7 @@
 teardown() {
     make cluster-down
     cp $(find . -name "*junit*.xml") $ARTIFACTS
+    [ -d ${E2E_LOGS} ] && cp ${E2E_LOGS}/*.log ${ARTIFACTS}
 }
 
 main() {

--- a/automation/check-patch.e2e-okd.sh
+++ b/automation/check-patch.e2e-okd.sh
@@ -13,6 +13,7 @@ exit 0
 teardown() {
     make cluster-down
     cp $(find . -name "*junit*.xml") $ARTIFACTS
+    [ -d ${E2E_LOGS} ] && cp ${E2E_LOGS}/*.log ${ARTIFACTS}
 }
 
 main() {

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -9,6 +9,7 @@ rm -rf $tmp_dir
 mkdir -p $tmp_dir
 
 export TMP_PROJECT_PATH=$tmp_dir/kubernetes-nmstate
+export E2E_LOGS=${TMP_PROJECT_PATH}/test_logs/e2e
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -65,14 +65,23 @@ func TestE2E(tapi *testing.T) {
 }
 
 var _ = BeforeEach(func() {
+
 	bond1 = nextBond()
 	bridge1 = nextBridge()
 	_, namespace = prepare(t)
 	startTime = time.Now()
+	for _, node := range nodes{
+		printDeviceStatus(node)
+	}
+
 })
 
 var _ = AfterEach(func() {
-	writePodsLogs(namespace, startTime, GinkgoWriter)
+	writePodsLogs(namespace, startTime, CurrentGinkgoTestDescription().Failed)
+	for _, node := range nodes{
+		printDeviceStatus(node)
+		writeNetworkManagerLogs(node, 10 + int(CurrentGinkgoTestDescription().Duration.Seconds()))
+	}
 })
 
 func getMaxFailsFromEnv() int {


### PR DESCRIPTION
adding network manager log from all nodes to network manager log file
changing writePodsLogs behaviour -> write to log file on success , write to log and stdout on failure
adding print node connections, devices and ip status before and after each test

Signed-off-by: Igal Tsoiref <itsoiref@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Adding option to write to log files.
2. Adding Network manager logs that are printed to <test>_netmanager.log
3. Pod logs will be added to <test>_pod.log and will be printed to stdout only on test failure
4. adding print node connections, devices and ip status before and after each test ()
**Special notes for your reviewer**:
Maybe commit is too big? i can try to split it

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
