### PR TITLE
Changing the way format and check works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,9 @@ description = build/_output/description
 resources = deploy/namespace.yaml deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml
 all: check handler
 
-check: format vet whitespace-check
+check: vet whitespace-check gofmt-check
 
-format: whitespace-format $(GO)
-	$(GOFMT) -d cmd/ pkg/
+format: whitespace-format gofmt
 
 vet: $(GO)
 	$(GO) vet ./cmd/... ./pkg/...
@@ -67,8 +66,14 @@ vet: $(GO)
 whitespace-format:
 	hack/whitespace.sh format
 
+gofmt: $(GO)
+	$(GOFMT) -w cmd/ pkg/ test/e2e/
+
 whitespace-check:
 	hack/whitespace.sh check
+
+gofmt-check: $(GO)
+	test -z "`$(GOFMT) -l cmd/ pkg/ test/e2e/`" || ($(GOFMT) -l cmd/ pkg/ test/e2e/ && exit 1)
 
 $(GO):
 	hack/install-go.sh $(BIN_DIR)

--- a/test/e2e/bonding_default_interface_test.go
+++ b/test/e2e/bonding_default_interface_test.go
@@ -90,7 +90,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 				}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", *primaryNic))
 			}
 
-
 		})
 
 		It("should successfully move default IP address on top of the bond", func() {
@@ -114,8 +113,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 	})
 })
 
-
-func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interface{}, expectedSpecs map[string]interface{}, ip string){
+func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interface{}, expectedSpecs map[string]interface{}, ip string) {
 	interfacesForNode(node).Should(ContainElement(SatisfyAll(
 		HaveKeyWithValue("name", expectedBond["name"]),
 		HaveKeyWithValue("type", expectedBond["type"]),
@@ -129,7 +127,6 @@ func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interfa
 		return ipv4Address(node, bond1)
 	}, 30*time.Second, 1*time.Second).Should(Equal(ip), fmt.Sprintf("Interface bond1 has not take over the %s address", *primaryNic))
 }
-
 
 func resetNicStateForNodes(nicName string) {
 	updateDesiredState(ethernetNicUp(nicName))

--- a/test/e2e/simple_vlan_and_ip_test.go
+++ b/test/e2e/simple_vlan_and_ip_test.go
@@ -30,7 +30,7 @@ var _ = Describe("NodeNetworkState", func() {
 	Context("when static address is configured on top of vlan interface", func() {
 		var (
 			ipAddressTemplate = "62.76.47.%d"
-			vlanId      = "102"
+			vlanId            = "102"
 		)
 		BeforeEach(func() {
 			updateDesiredState(ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -304,7 +304,7 @@ func deleteConnectionAtNodes(name string) []error {
 
 func deleteDeviceAtNode(node string, name string) error {
 	By(fmt.Sprintf("Delete device %s  at node %s", name, node))
-	_, err := runAtNode(node , "sudo", "nmcli", "device", "delete", name)
+	_, err := runAtNode(node, "sudo", "nmcli", "device", "delete", name)
 	return err
 }
 
@@ -493,9 +493,9 @@ func dhcpFlag(node string, name string) bool {
 	return gjson.ParseBytes(currentStateJSON(node)).Get(path).Bool()
 }
 
-func ifaceInSlice(ifaceName string, names []string) bool{
-	for _, name := range names{
-		if ifaceName == name{
+func ifaceInSlice(ifaceName string, names []string) bool {
+	for _, name := range names {
+		if ifaceName == name {
 			return true
 		}
 	}
@@ -514,17 +514,17 @@ func nodeInterfacesState(node string, exclude []string) []byte {
 	for _, iface := range interfaces {
 		name, hasName := iface.(map[string]interface{})["name"]
 		Expect(hasName).To(BeTrue(), "should have name field in the interfaces, https://github.com/nmstate/nmstate/blob/master/libnmstate/schemas/operational-state.yaml")
-		if ifaceInSlice(name.(string), exclude){
+		if ifaceInSlice(name.(string), exclude) {
 			continue
 		}
 		state, hasState := iface.(map[string]interface{})["state"]
-		if !hasState{
+		if !hasState {
 			state = "unknown"
 		}
 		ifacesState[name.(string)] = state.(string)
 	}
 	ret, err := json.Marshal(ifacesState)
-	if err != nil{
+	if err != nil {
 		return []byte{}
 	}
 	return ret


### PR DESCRIPTION
make format will generate format changes and not only print them
make check will fail if there are files that are not formatted
adding test/e2e to format list
fixing files with format issues

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
make format will generate format changes and not only print them
make check will fail if there are files that are not formatted
adding test/e2e to format list
I am sure that it is better to fail on build while the are files that needs to be formatted than to find out it on review.
As for me it is much better to have generated code when one runs make format than just to print changes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
