### PR TITLE
We don't care about the list of file inside golang tarball

### DIFF
--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -7,4 +7,4 @@ url=https://dl.google.com/go/
 
 mkdir -p $destination
 curl -L $url/$tarball -o $destination/$tarball
-tar -xvf $destination/$tarball -C $destination
+tar -xf $destination/$tarball -C $destination

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -243,7 +243,7 @@ func defaultGw() (string, error) {
 		defaultGw = gjson.ParseBytes(currentState).
 			Get("routes.running.#(destination==\"0.0.0.0/0\").next-hop-address").String()
 		if defaultGw == "" {
-			log.Info("default gw missing", "state", currentState)
+			log.Info("default gw missing", "state", string(currentState))
 			return false, nil
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Inspecting the logs with at long list of files we don't care at the beginning make no sense, let's
be quiet unpacking golang tarball.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
