### PR TITLE
Parameterize GOROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BIN_DIR = $(CURDIR)/build/_output/bin/
 
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
-export GOROOT=$(BIN_DIR)/go/
+export GOROOT ?= $(BIN_DIR)/go/
 export GOBIN=$(GOROOT)/bin/
 export PATH := $(GOROOT)/bin:$(PATH)
 


### PR DESCRIPTION
In case a user want to use already installed golang compiler
it has to be able to pass the GOROOT like this

make GOROOT=... handler

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
