### PR TITLE
expose Reason on NNCP and NNCE list

### DIFF
--- a/deploy/crds/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
@@ -3,6 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   name: nodenetworkconfigurationenactments.nmstate.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Available")].reason
+    description: Status
+    name: Status
+    type: string
   group: nmstate.io
   names:
     kind: NodeNetworkConfigurationEnactment

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
@@ -3,6 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   name: nodenetworkconfigurationpolicies.nmstate.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Available")].reason
+    description: Status
+    name: Status
+    type: string
   group: nmstate.io
   names:
     kind: NodeNetworkConfigurationPolicy

--- a/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -24,6 +24,7 @@ type NodeNetworkConfigurationEnactmentList struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nodenetworkconfigurationenactments,shortName=nnce,scope=Cluster
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason",description="Status"
 type NodeNetworkConfigurationEnactment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationpolicy_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationpolicy_types.go
@@ -22,6 +22,7 @@ type NodeNetworkConfigurationPolicyList struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nodenetworkconfigurationpolicies,shortName=nncp,scope=Cluster
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason",description="Status"
 type NodeNetworkConfigurationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make it easier for users to detect faulty NNCP and NNCE by exposing
Reason of Available condition in kubectl get list.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Expose status in `kubectl get` list
```
