### PR TITLE
Fix ocp lane

### DIFF
--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -15,7 +15,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='ocp-4.3'
+    export KUBEVIRT_PROVIDER='ocp-4.4'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
@@ -27,7 +27,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_ARGS="-ginkgo.noColor" test/e2e
+    make E2E_TEST_TIMEOUT=2h E2E_TEST_ARGS="-ginkgo.noColor " test/e2e
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-okd.sh
+++ b/automation/check-patch.e2e-okd.sh
@@ -30,7 +30,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_ARGS="-ginkgo.noColor" test/e2e
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-ginkgo.noColor " test/e2e
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -174,7 +174,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	// This is a cluster scope operator so there is no namespace
+	// The operator is cluster scoped so it does not have namespace
 	operatorNs := ""
 
 	// To generate metrics in other namespaces, add the values below.

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="9b8707c02d59ee1a7924103b6beca9b9cd010633"
+commit="0c3911794ad2b79a61a4bc7462c236251a73866f"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci

--- a/test/e2e/default_bridged_network_test.go
+++ b/test/e2e/default_bridged_network_test.go
@@ -30,7 +30,7 @@ func createBridgeOnTheDefaultInterface() nmstatev1alpha1.State {
           enabled: false
       port:
       - name: %s
-`, *primaryNic))
+`, primaryNic))
 }
 
 func resetDefaultInterface() nmstatev1alpha1.State {
@@ -44,7 +44,7 @@ func resetDefaultInterface() nmstatev1alpha1.State {
   - name: brext
     type: linux-bridge
     state: absent
-`, *primaryNic))
+`, primaryNic))
 }
 
 // FIXME: We have to fix this test https://github.com/nmstate/kubernetes-nmstate/issues/192
@@ -55,24 +55,24 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 	Context("when there is a default interface with dynamic address", func() {
 		addressByNode := map[string]string{}
 		BeforeEach(func() {
-			By(fmt.Sprintf("Check %s is the default route interface and has dynamic address", *primaryNic))
+			By(fmt.Sprintf("Check %s is the default route interface and has dynamic address", primaryNic))
 			for _, node := range nodes {
-				defaultRouteNextHopInterface(node).Should(Equal(*primaryNic))
-				Expect(dhcpFlag(node, *primaryNic)).Should(BeTrue())
+				defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
+				Expect(dhcpFlag(node, primaryNic)).Should(BeTrue())
 			}
 
 			By("Fetching current IP address")
 			for _, node := range nodes {
 				address := ""
 				Eventually(func() string {
-					address = ipv4Address(node, *primaryNic)
+					address = ipv4Address(node, primaryNic)
 					return address
-				}, 15*time.Second, 1*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s has no ipv4 address", *primaryNic))
+				}, 15*time.Second, 1*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s has no ipv4 address", primaryNic))
 				addressByNode[node] = address
 			}
 		})
 		AfterEach(func() {
-			By(fmt.Sprintf("Removing bridge and configuring %s with dhcp", *primaryNic))
+			By(fmt.Sprintf("Removing bridge and configuring %s with dhcp", primaryNic))
 			setDesiredStateWithPolicy(DefaultNetwork, resetDefaultInterface())
 
 			By("Waiting until the node becomes ready again")
@@ -81,16 +81,16 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 			By("Wait for policy to be ready")
 			waitForAvailablePolicy(DefaultNetwork)
 
-			By(fmt.Sprintf("Check %s has the default ip address", *primaryNic))
+			By(fmt.Sprintf("Check %s has the default ip address", primaryNic))
 			for _, node := range nodes {
 				Eventually(func() string {
-					return ipv4Address(node, *primaryNic)
-				}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", *primaryNic))
+					return ipv4Address(node, primaryNic)
+				}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", primaryNic))
 			}
 
-			By(fmt.Sprintf("Check %s is back as the default route interface", *primaryNic))
+			By(fmt.Sprintf("Check %s is back as the default route interface", primaryNic))
 			for _, node := range nodes {
-				defaultRouteNextHopInterface(node).Should(Equal(*primaryNic))
+				defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
 			}
 
 			By("Remove the policy")
@@ -114,7 +114,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 			for _, node := range nodes {
 				Eventually(func() string {
 					return ipv4Address(node, "brext")
-				}, 15*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface brext has not take over the %s address", *primaryNic))
+				}, 15*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface brext has not take over the %s address", primaryNic))
 			}
 
 			By("Verify that next-hop-interface for default route is brext")
@@ -122,7 +122,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				defaultRouteNextHopInterface(node).Should(Equal("brext"))
 
 				By("Verify that VLAN configuration is done properly")
-				hasVlans(node, *primaryNic, 2, 4094).Should(Succeed())
+				hasVlans(node, primaryNic, 2, 4094).Should(Succeed())
 				getVLANFlagsEventually(node, "brext", 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 			}
 		})

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -31,9 +30,9 @@ var (
 	startTime            time.Time
 	bond1                string
 	bridge1              string
-	primaryNic           = flag.String("primaryNic", "eth0", "Primary network interface name")
-	firstSecondaryNic    = flag.String("firstSecondaryNic", "eth1", "First secondary network interface name")
-	secondSecondaryNic   = flag.String("secondSecondaryNic", "eth2", "Second secondary network interface name")
+	primaryNic           string
+	firstSecondaryNic    string
+	secondSecondaryNic   string
 	nodesInterfacesState = make(map[string][]byte)
 	interfacesToIgnore   = []string{"flannel.1", "dummy0"}
 )
@@ -48,7 +47,18 @@ var _ = BeforeSuite(func() {
 })
 
 func TestMain(m *testing.M) {
+	primaryNic = getEnv("PRIMARY_NIC", "eth0")
+	firstSecondaryNic = getEnv("FIRST_SECONDARY_NIC", "eth1")
+	secondSecondaryNic = getEnv("SECOND_SECONDARY_NIC", "eth2")
 	framework.MainEntry(m)
+}
+
+func getEnv(name string, defaultValue string) string {
+	value := os.Getenv(name)
+	if len(value) == 0 {
+		value = defaultValue
+	}
+	return value
 }
 
 func TestE2E(tapi *testing.T) {

--- a/test/e2e/multiple_policies_for_same_node_test.go
+++ b/test/e2e/multiple_policies_for_same_node_test.go
@@ -17,15 +17,15 @@ var _ = Describe("NodeNetworkState", func() {
 		)
 
 		BeforeEach(func() {
-			setDesiredStateWithPolicy(staticIpPolicy, ifaceUpWithStaticIP(*firstSecondaryNic, ipAddress))
-			setDesiredStateWithPolicy(vlanPolicy, ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))
+			setDesiredStateWithPolicy(staticIpPolicy, ifaceUpWithStaticIP(firstSecondaryNic, ipAddress))
+			setDesiredStateWithPolicy(vlanPolicy, ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(staticIpPolicy)
 			waitForAvailablePolicy(vlanPolicy)
 		})
 
 		AfterEach(func() {
-			setDesiredStateWithPolicy(staticIpPolicy, ifaceDownIPv4Disabled(*firstSecondaryNic))
-			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(*firstSecondaryNic, vlanId))
+			setDesiredStateWithPolicy(staticIpPolicy, ifaceDownIPv4Disabled(firstSecondaryNic))
+			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(staticIpPolicy)
 			waitForAvailablePolicy(vlanPolicy)
 			deletePolicy(staticIpPolicy)
@@ -35,9 +35,9 @@ var _ = Describe("NodeNetworkState", func() {
 
 		It("should have the IP and vlan interface configured", func() {
 			for _, node := range nodes {
-				ipAddressForNodeInterfaceEventually(node, *firstSecondaryNic).Should(Equal(ipAddress))
-				interfacesNameForNodeEventually(node).Should(ContainElement(fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)))
-				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).Should(Equal(vlanId))
+				ipAddressForNodeInterfaceEventually(node, firstSecondaryNic).Should(Equal(ipAddress))
+				interfacesNameForNodeEventually(node).Should(ContainElement(fmt.Sprintf(`%s.%s`, firstSecondaryNic, vlanId)))
+				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, firstSecondaryNic, vlanId)).Should(Equal(vlanId))
 			}
 		})
 	})

--- a/test/e2e/nodes_test.go
+++ b/test/e2e/nodes_test.go
@@ -9,7 +9,7 @@ var _ = Describe("Nodes", func() {
 	Context("when are up", func() {
 		It("should have NodeNetworkState with currentState for each node", func() {
 			for _, node := range nodes {
-				interfacesNameForNodeEventually(node).Should(ContainElement(*primaryNic))
+				interfacesNameForNodeEventually(node).Should(ContainElement(primaryNic))
 			}
 		})
 		Context("and node network state is deleted", func() {
@@ -18,7 +18,7 @@ var _ = Describe("Nodes", func() {
 			})
 			It("should recreate it with currentState", func() {
 				for _, node := range nodes {
-					interfacesNameForNodeEventually(node).Should(ContainElement(*primaryNic))
+					interfacesNameForNodeEventually(node).Should(ContainElement(primaryNic))
 				}
 			})
 		})

--- a/test/e2e/rollback_test.go
+++ b/test/e2e/rollback_test.go
@@ -66,10 +66,10 @@ var _ = Describe("rollback", func() {
 			By("Configure a invalid default gw")
 			var address string
 			Eventually(func() string {
-				address = ipv4Address(nodes[0], *primaryNic)
+				address = ipv4Address(nodes[0], primaryNic)
 				return address
 			}, ReadTimeout, ReadInterval).ShouldNot(BeEmpty())
-			updateDesiredStateAtNode(nodes[0], badDefaultGw(address, *primaryNic))
+			updateDesiredStateAtNode(nodes[0], badDefaultGw(address, primaryNic))
 		})
 		AfterEach(func() {
 			By("Clean up desired state")
@@ -78,14 +78,14 @@ var _ = Describe("rollback", func() {
 		It("should rollback to a good gw configuration", func() {
 			By("Wait for reconcile to fail")
 			waitForDegradedTestPolicy()
-			By(fmt.Sprintf("Check that %s is rolled back", *primaryNic))
+			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
 			Eventually(func() bool {
-				return dhcpFlag(nodes[0], *primaryNic)
+				return dhcpFlag(nodes[0], primaryNic)
 			}, ReadTimeout, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
 
-			By(fmt.Sprintf("Check that %s continue with rolled back state", *primaryNic))
+			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
 			Consistently(func() bool {
-				return dhcpFlag(nodes[0], *primaryNic)
+				return dhcpFlag(nodes[0], primaryNic)
 			}, 5*time.Second, 1*time.Second).Should(BeTrue(), "DHCP flag has change to false")
 		})
 	})

--- a/test/e2e/simple_bridge_and_bond_test.go
+++ b/test/e2e/simple_bridge_and_bond_test.go
@@ -39,7 +39,7 @@ func bondUp(bondName string) nmstatev1alpha1.State {
         - %s
       options:
         miimon: '120'
-`, bondName, *firstSecondaryNic))
+`, bondName, firstSecondaryNic))
 }
 
 func brWithBondUp(bridgeName string, bondName string) nmstatev1alpha1.State {
@@ -62,7 +62,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstatev1alpha1.State {
           enabled: false
       port:
         - name: %s
-`, bondName, *firstSecondaryNic, bridgeName, bondName))
+`, bondName, firstSecondaryNic, bridgeName, bondName))
 }
 
 func bondUpWithEth1AndEth2(bondName string) nmstatev1alpha1.State {
@@ -82,7 +82,7 @@ func bondUpWithEth1AndEth2(bondName string) nmstatev1alpha1.State {
     slaves:
     - %s
     - %s
-`, bondName, *firstSecondaryNic, *secondSecondaryNic))
+`, bondName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func bondUpWithEth1Eth2AndVlan(bondName string) nmstatev1alpha1.State {
@@ -113,7 +113,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstatev1alpha1.State {
   vlan:
     base-iface: %s
     id: 102
-`, bondName, *firstSecondaryNic, *secondSecondaryNic, bondName, bondName))
+`, bondName, firstSecondaryNic, secondSecondaryNic, bondName, bondName))
 }
 
 var _ = Describe("NodeNetworkState", func() {
@@ -155,10 +155,10 @@ var _ = Describe("NodeNetworkState", func() {
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
 					getVLANFlagsEventually(node, bridge1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-					getVLANFlagsEventually(node, *firstSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-					hasVlans(node, *firstSecondaryNic, 2, 4094).Should(Succeed())
-					getVLANFlagsEventually(node, *secondSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-					hasVlans(node, *secondSecondaryNic, 2, 4094).Should(Succeed())
+					getVLANFlagsEventually(node, firstSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
+					hasVlans(node, firstSecondaryNic, 2, 4094).Should(Succeed())
+					getVLANFlagsEventually(node, secondSecondaryNic, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
+					hasVlans(node, secondSecondaryNic, 2, 4094).Should(Succeed())
 				}
 			})
 		})
@@ -229,8 +229,8 @@ var _ = Describe("NodeNetworkState", func() {
 					getVLANFlagsEventually(node, bridge1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 					hasVlans(node, bond1, 2, 4094).Should(Succeed())
 					getVLANFlagsEventually(node, bond1, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-					vlansCardinality(node, *firstSecondaryNic).Should(Equal(0))
-					vlansCardinality(node, *secondSecondaryNic).Should(Equal(0))
+					vlansCardinality(node, firstSecondaryNic).Should(Equal(0))
+					vlansCardinality(node, secondSecondaryNic).Should(Equal(0))
 				}
 			})
 		})
@@ -260,7 +260,7 @@ var _ = Describe("NodeNetworkState", func() {
 						HaveKeyWithValue("state", expectedBond["state"]),
 						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
 						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{*firstSecondaryNic, *secondSecondaryNic}))),
+						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{firstSecondaryNic, secondSecondaryNic}))),
 					)))
 				}
 			})
@@ -293,7 +293,7 @@ var _ = Describe("NodeNetworkState", func() {
 							HaveKeyWithValue("state", expectedBond["state"]),
 							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
 							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{*firstSecondaryNic, *secondSecondaryNic}))),
+							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{firstSecondaryNic, secondSecondaryNic}))),
 						)),
 						ContainElement(SatisfyAll(
 							HaveKeyWithValue("name", expectedVlanBond102["name"]),

--- a/test/e2e/simple_vlan_and_ip_test.go
+++ b/test/e2e/simple_vlan_and_ip_test.go
@@ -13,16 +13,16 @@ var _ = Describe("NodeNetworkState", func() {
 		)
 
 		BeforeEach(func() {
-			updateDesiredState(ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))
+			updateDesiredState(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			waitForAvailableTestPolicy()
 		})
 		AfterEach(func() {
-			updateDesiredState(vlanAbsent(*firstSecondaryNic, vlanId))
+			updateDesiredState(vlanAbsent(firstSecondaryNic, vlanId))
 			resetDesiredStateForNodes()
 		})
 		It("should have the vlan interface configured", func() {
 			for _, node := range nodes {
-				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).Should(Equal(vlanId))
+				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, firstSecondaryNic, vlanId)).Should(Equal(vlanId))
 			}
 		})
 	})
@@ -33,28 +33,28 @@ var _ = Describe("NodeNetworkState", func() {
 			vlanId            = "102"
 		)
 		BeforeEach(func() {
-			updateDesiredState(ifaceUpWithVlanUp(*firstSecondaryNic, vlanId))
+			updateDesiredState(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			waitForAvailableTestPolicy()
 			for index, node := range nodes {
 				ipAddress := fmt.Sprintf(ipAddressTemplate, index)
 				By(fmt.Sprintf("applying static IP %s on node %s", ipAddress, node))
-				updateDesiredStateAtNode(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", *firstSecondaryNic, vlanId), ipAddress))
+				updateDesiredStateAtNode(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", firstSecondaryNic, vlanId), ipAddress))
 				waitForAvailableTestPolicy()
 			}
 
 		})
 
 		AfterEach(func() {
-			updateDesiredState(vlanAbsent(*firstSecondaryNic, vlanId))
+			updateDesiredState(vlanAbsent(firstSecondaryNic, vlanId))
 			waitForAvailableTestPolicy()
 			resetDesiredStateForNodes()
 		})
 
 		It("should have the vlan interface configured and IP configured", func() {
 			for index, node := range nodes {
-				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).
+				vlanForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, firstSecondaryNic, vlanId)).
 					Should(Equal(vlanId))
-				ipAddressForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, *firstSecondaryNic, vlanId)).
+				ipAddressForNodeInterfaceEventually(node, fmt.Sprintf(`%s.%s`, firstSecondaryNic, vlanId)).
 					Should(Equal(fmt.Sprintf(ipAddressTemplate, index)))
 			}
 		})

--- a/test/e2e/states.go
+++ b/test/e2e/states.go
@@ -43,7 +43,7 @@ func linuxBrUp(bridgeName string) nmstatev1alpha1.State {
       port:
         - name: %s
         - name: %s
-`, bridgeName, *firstSecondaryNic, *secondSecondaryNic))
+`, bridgeName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func linuxBrAbsent(bridgeName string) nmstatev1alpha1.State {
@@ -85,7 +85,7 @@ func ovsBrUp(bridgeName string) nmstatev1alpha1.State {
       port:
         - name: %s
         - name: %s
-`, bridgeName, *firstSecondaryNic, *secondSecondaryNic))
+`, bridgeName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func ovsbBrWithInternalInterface(bridgeName string) nmstatev1alpha1.State {
@@ -107,7 +107,7 @@ func ovsbBrWithInternalInterface(bridgeName string) nmstatev1alpha1.State {
       port:
         - name: %s
         - name: ovs0`,
-		bridgeName, *firstSecondaryNic))
+		bridgeName, firstSecondaryNic))
 }
 
 func ifaceUpWithStaticIP(iface string, ipAddress string) nmstatev1alpha1.State {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -151,9 +151,9 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 //       to remove this
 func resetDesiredStateForNodes() {
 	states := map[string]string{
-		*primaryNic:         "up",
-		*firstSecondaryNic:  "down",
-		*secondSecondaryNic: "down",
+		primaryNic:         "up",
+		firstSecondaryNic:  "down",
+		secondSecondaryNic: "down",
 	}
 	updateDesiredState(ethernetNicsState(states))
 	waitForAvailableTestPolicy()

--- a/test/runner/node.go
+++ b/test/runner/node.go
@@ -30,7 +30,9 @@ func runAtNodeWithExtras(node string, quiet bool, command ...string) (string, er
 	output, err := run("./kubevirtci/cluster-up/ssh.sh", quiet, ssh_command...)
 	// Remove first two lines from output, ssh.sh add garbage there
 	outputLines := strings.Split(output, "\n")
-	output = strings.Join(outputLines[2:], "\n")
+	if len(outputLines) > 2 {
+		output = strings.Join(outputLines[2:], "\n")
+	}
 	return output, err
 }
 


### PR DESCRIPTION

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Our OCP lane is broken, we fix it by:

- Use ocp-4.4 provider
- Use env to get nics names at e2e tests
- Fix 'failed to list *unstructured.Unstructured' log
- Continue loop if kubectl.sh fails at cluster-sync
- Fix core dump at e2e test when EOF
- Skip OVS e2e tests for okd/ocp lanes
- Parameterize e2e test timeout

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
