### PR TITLE
Default to 0 if numberAvailable is not present

### DIFF
--- a/hack/cluster-sync-handler.sh
+++ b/hack/cluster-sync-handler.sh
@@ -13,7 +13,8 @@ function getDesiredNumberScheduled {
 }
 
 function getNumberAvailable {
-        echo $(${KUBECTL} get daemonset -n nmstate $1 -o=jsonpath='{.status.numberAvailable}')
+        numberAvailable=$(${KUBECTL} get daemonset -n nmstate $1 -o=jsonpath='{.status.numberAvailable}')
+        echo ${numberAvailable:-0}
 }
 
 function isOk {


### PR DESCRIPTION

**What this PR does / why we need it**:
Now that there is two daemonsets one for master and one for worker
the one master node scenario we have by default at knmstate
does not work well, since numberAvailable value is not present so
it an infinite loop of "'0' == ''", to fix that we can just return 0
is the value is not set.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
