### PR TITLE
Move e2e libs to separate path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ check: vet whitespace-check gofmt-check
 format: whitespace-format gofmt
 
 vet: $(GO)
-	$(GO) vet ./cmd/... ./pkg/...
+	$(GO) vet ./cmd/... ./pkg/... ./test/...
 
 whitespace-format:
 	hack/whitespace.sh format

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -21,7 +21,7 @@ import (
 
 	apis "github.com/nmstate/kubernetes-nmstate/pkg/apis"
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
-	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/e2e/reporter"
+	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
 )
 
 var (

--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
-	runner "github.com/nmstate/kubernetes-nmstate/test/e2e/runner"
+	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
 func invalidConfig(bridgeName string) nmstatev1alpha1.State {

--- a/test/e2e/rollback_test.go
+++ b/test/e2e/rollback_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
-	runner "github.com/nmstate/kubernetes-nmstate/test/e2e/runner"
+	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
 // We cannot change routes at nmstate if the interface is with dhcp true

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -26,7 +26,7 @@ import (
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
-	runner "github.com/nmstate/kubernetes-nmstate/test/e2e/runner"
+	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
 const ReadTimeout = 180 * time.Second

--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -1,4 +1,4 @@
-package e2e
+package reporter
 
 import (
 	"fmt"

--- a/test/reporter/writers.go
+++ b/test/reporter/writers.go
@@ -1,4 +1,4 @@
-package e2e
+package reporter
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	runner "github.com/nmstate/kubernetes-nmstate/test/e2e/runner"
+	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
 const (
@@ -70,7 +70,7 @@ func networkManagerLogsWriter(nodes []string, sinceTime time.Time) func(io.Write
 
 func writePodsLogs(writer io.Writer, namespace string, sinceTime time.Time) {
 	podLogOpts := corev1.PodLogOptions{}
-	podLogOpts.SinceTime = &metav1.Time{sinceTime}
+	podLogOpts.SinceTime = &metav1.Time{Time: sinceTime}
 	podList := &corev1.PodList{}
 	err := framework.Global.Client.List(context.TODO(), podList, &dynclient.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/test/runner/node.go
+++ b/test/runner/node.go
@@ -1,4 +1,4 @@
-package e2e
+package runner
 
 import (
 	"bytes"

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -1,4 +1,4 @@
-package e2e
+package runner
 
 import (
 	"strings"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Looks like having then under test breaks ginkgo output and
does not shows until the end

Also add ./test to vet and put correct package name at modules
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
