### PR TITLE
test/e2e: Set secondary nics down at teardown

### DIFF
--- a/test/e2e/bonding_default_interface_test.go
+++ b/test/e2e/bonding_default_interface_test.go
@@ -129,7 +129,7 @@ func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interfa
 }
 
 func resetNicStateForNodes(nicName string) {
-	updateDesiredState(ethernetNicUp(nicName))
+	updateDesiredState(ethernetNicsUp(nicName))
 	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -127,7 +127,7 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstatev
 			return err
 		}
 		return framework.Global.Client.Update(context.TODO(), &policy)
-	}, ReadTimeout, ReadInterval).ShouldNot(HaveOccurred())
+	}, ReadTimeout, ReadInterval).ShouldNot(HaveOccurred(), fmt.Sprintf("Failed updating desired state : %s", desiredState))
 	//FIXME: until we don't have webhook we have to wait for reconcile
 	//       to start so we are sure that conditions are reset and we can
 	//       check them correctly
@@ -150,7 +150,12 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
 //       to remove this
 func resetDesiredStateForNodes() {
-	updateDesiredState(ethernetNicUp(*primaryNic))
+	states := map[string]string{
+		*primaryNic:         "up",
+		*firstSecondaryNic:  "down",
+		*secondSecondaryNic: "down",
+	}
+	updateDesiredState(ethernetNicsState(states))
 	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After a check at e2e test was added to see if we have extra interfaces not cleaned up 
after the test, looks like sometimes secondary nics has up/down unexpected state, this
PR enforces them to down since is their state after cluster-up.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
