### PR TITLE
use NM 1.22 on Kubernetes kubevirtci

### DIFF
--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -4,7 +4,7 @@ function install_nm_on_node() {
     node=$1
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
-    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.20
+    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
     $SSH $node sudo -- yum install -y NetworkManager NetworkManager-ovs
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to test the proper NetworkManager for nmstate 0.2, we will run
our CI against NetworkManager 1.22. This should prepare us for future on
RHEL 8.2.

We should keep another lane with OCP and NetworkManager 1.20 in order to
make sure that the current release is still fine.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
