### PR TITLE
don't retry the configuration

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -103,24 +103,10 @@ func nmstatectl(arguments []string, input string) (string, error) {
 }
 
 func set(desiredState nmstatev1alpha1.State) (string, error) {
-	output := ""
-	var err error = nil
-	// FIXME: Remove this retries after nmstate team fixes
-	//        https://nmstate.atlassian.net/browse/NMSTATE-247
-	retries := 3
-	for retries > 0 {
-		// commit timeout doubles the default gw ping probe timeout, to
-		// ensure the Checkpoint is alive before rolling it back
-		// https://nmstate.github.io/cli_guide#manual-transaction-control
-		output, err = nmstatectl([]string{"set", "--no-commit", "--timeout", strconv.Itoa(int(defaultGwProbeTimeout.Seconds()) * 2)}, string(desiredState.Raw))
-		if err == nil {
-			log.Info(fmt.Sprintf("nmstatectl set recovered, output: %s", output))
-			break
-		}
-		retries--
-		time.Sleep(1 * time.Second)
-		log.Info(fmt.Sprintf("%d retries left after nmstatectl set command error: %v", retries, err))
-	}
+	// commit timeout doubles the default gw ping probe timeout, to
+	// ensure the Checkpoint is alive before rolling it back
+	// https://nmstate.github.io/cli_guide#manual-transaction-control
+	output, err := nmstatectl([]string{"set", "--no-commit", "--timeout", strconv.Itoa(int(defaultGwProbeTimeout.Seconds()) * 2)}, string(desiredState.Raw))
 	return output, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The bug on nmstate has been resolved in 1.20, which is the current version
we are compatible with.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
