### PR TITLE
test: move kubectl to a separate module

### DIFF
--- a/test/cmd/kubectl.go
+++ b/test/cmd/kubectl.go
@@ -1,0 +1,5 @@
+package cmd
+
+func Kubectl(arguments ...string) (string, error) {
+	return Run("./kubevirtci/cluster-up/kubectl.sh", false, arguments...)
+}

--- a/test/cmd/run.go
+++ b/test/cmd/run.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func Run(command string, quiet bool, arguments ...string) (string, error) {
+	cmd := exec.Command(command, arguments...)
+	if !quiet {
+		GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if !quiet {
+		GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
+	}
+	return stdout.String(), err
+}

--- a/test/runner/node.go
+++ b/test/runner/node.go
@@ -1,33 +1,15 @@
 package runner
 
 import (
-	"bytes"
-	"fmt"
-	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 )
-
-func run(command string, quiet bool, arguments ...string) (string, error) {
-	cmd := exec.Command(command, arguments...)
-	if !quiet {
-		GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
-	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	cmd.Stdout = &stdout
-	err := cmd.Run()
-	if !quiet {
-		GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
-	}
-	return stdout.String(), err
-}
 
 func runAtNodeWithExtras(node string, quiet bool, command ...string) (string, error) {
 	ssh_command := []string{node, "--"}
 	ssh_command = append(ssh_command, command...)
-	output, err := run("./kubevirtci/cluster-up/ssh.sh", quiet, ssh_command...)
+	output, err := cmd.Run("./kubevirtci/cluster-up/ssh.sh", quiet, ssh_command...)
 	// Remove first two lines from output, ssh.sh add garbage there
 	outputLines := strings.Split(output, "\n")
 	if len(outputLines) > 2 {

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -6,14 +6,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 )
 
-func kubectl(arguments ...string) (string, error) {
-	return run("./kubevirtci/cluster-up/kubectl.sh", false, arguments...)
-}
-
 func nmstatePods() ([]string, error) {
-	output, err := kubectl("get", "pod", "-n", framework.Global.Namespace, "--no-headers=true", "-o", "custom-columns=:metadata.name")
+	output, err := cmd.Kubectl("get", "pod", "-n", framework.Global.Namespace, "--no-headers=true", "-o", "custom-columns=:metadata.name")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	names := strings.Split(strings.TrimSpace(output), "\n")
 	return names, err
@@ -25,7 +23,7 @@ func RunAtPods(arguments ...string) {
 	for _, nmstatePod := range nmstatePods {
 		exec := []string{"exec", "-n", framework.Global.Namespace, nmstatePod, "--"}
 		execArguments := append(exec, arguments...)
-		_, err := kubectl(execArguments...)
+		_, err := cmd.Kubectl(execArguments...)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Let's move kubectl and shell executors to decouple the dependecnies

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
