### PR TITLE
wait for scc resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,9 @@ cluster-clean: $(KUBECTL)
 	fi
 
 cluster-sync-resources: $(KUBECTL)
+	if [[ "$$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$$ ]]; then \
+		while ! $(KUBECTL) get securitycontextconstraints; do sleep 1; done; \
+	fi
 	for resource in $(resources); do \
 		$(KUBECTL) apply -f $$resource || exit 1; \
 	done


### PR DESCRIPTION

Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After cluster-up of OpenShift, the SCC resource is not immediately available,
let's wait before applying any manifest.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
