### PR TITLE
Adding config map controller

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,11 +53,13 @@ spec:
             - name: NODE_NETWORK_STATE_REFRESH_INTERVAL
               valueFrom:
                 configMapKeyRef:
+                  optional: true
                   name: nmstate-config
                   key: node_network_state_refresh_interval
             - name: INTERFACES_FILTER
               valueFrom:
                 configMapKeyRef:
+                  optional: true
                   name: nmstate-config
                   key: interfaces_filter
             - name: ENABLE_PROFILER
@@ -69,6 +71,8 @@ spec:
             mountPath: /run/dbus/system_bus_socket
           securityContext:
             privileged: true
+          ports:
+            - containerPort: 6060
       volumes:
       - name: dbus-socket
         hostPath:
@@ -131,6 +135,7 @@ spec:
             - name: NODE_NETWORK_STATE_REFRESH_INTERVAL
               valueFrom:
                 configMapKeyRef:
+                  optional: true
                   name: nmstate-config
                   key: node_network_state_refresh_interval
             - name: INTERFACES_FILTER
@@ -138,6 +143,7 @@ spec:
                 configMapKeyRef:
                   name: nmstate-config
                   key: interfaces_filter
+                  optional: true
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket
@@ -148,15 +154,6 @@ spec:
           hostPath:
             path: /run/dbus/system_bus_socket
             type: Socket
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: nmstate-config
-  namespace: nmstate
-data:
-  node_network_state_refresh_interval: "5"
-  interfaces_filter: "veth*"
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/controller/add_config.go
+++ b/pkg/controller/add_config.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/nmstate/kubernetes-nmstate/pkg/controller/config"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, config.Add)
+}

--- a/pkg/controller/config/configmap_controller.go
+++ b/pkg/controller/config/configmap_controller.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	nnscontroller "github.com/nmstate/kubernetes-nmstate/pkg/controller/nodenetworkstate"
+	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
+)
+
+var (
+	log = logf.Log.WithName("controller_config")
+)
+
+// Add creates a new config Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileConfig{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("config-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		panic(err)
+	}
+	onCreationForThisNode := predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return nmstate.EventIsForNmConfig(createEvent.Meta)
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return nmstate.EventIsForNmConfig(deleteEvent.Meta)
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return nmstate.EventIsForNmConfig(updateEvent.MetaNew)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+	// Watch for changes to primary resource Node
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, onCreationForThisNode)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// blank assignment to verify that ReconcileNode implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileConfig{}
+
+// ReconcileConfig reconciles a Node object
+type ReconcileConfig struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a Node object and makes changes based on the state read
+// and what is in the Node.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.V(1).Info("Reconciling CONFIG")
+
+	// Fetch the config instance
+	instance := &corev1.ConfigMap{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		reqLogger.V(1).Info("Not fount config map, setting defaults")
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// setting defaults
+		configMapDataOperations(make(map[string]string))
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	reqLogger.V(1).Info("Reconciling InitClient")
+	configMapDataOperations(instance.Data)
+	return reconcile.Result{}, nil
+}
+
+func configMapDataOperations(configData map[string]string) {
+	// Initializing client with new filter
+	nmstate.InitClient(configData["interfaces_filter"])
+	// Initializing node state controller with new refresh interval
+	nnscontroller.InitNodeNetworkController(configData["node_network_state_refresh_interval"])
+}

--- a/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
+++ b/pkg/controller/nodenetworkstate/nodenetworkstate_controller.go
@@ -29,11 +29,18 @@ var (
 	nodenetworkstateRefresh time.Duration
 )
 
+const nodenetworkstateRefreshDefault = "5"
+
 func init() {
-	refreshTime, isSet := os.LookupEnv("NODE_NETWORK_STATE_REFRESH_INTERVAL")
-	if !isSet {
-		panic("NODE_NETWORK_STATE_REFRESH_INTERVAL is mandatory")
+	refreshTime, _ := os.LookupEnv("NODE_NETWORK_STATE_REFRESH_INTERVAL")
+	InitNodeNetworkController(refreshTime)
+}
+
+func InitNodeNetworkController(refreshTime string) {
+	if refreshTime == "" {
+		refreshTime = nodenetworkstateRefreshDefault
 	}
+	fmt.Println(fmt.Sprintf("Initializng node network controller with refresh time = %s", refreshTime))
 	intRefreshTime, err := strconv.Atoi(refreshTime)
 	if err != nil {
 		panic(fmt.Sprintf("Failed while converting evnironment variable to int: %v", err))
@@ -118,6 +125,7 @@ func (r *ReconcileNodeNetworkState) Reconcile(request reconcile.Request) (reconc
 			return err
 		}
 		return nil
+
 	})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -128,5 +136,6 @@ func (r *ReconcileNodeNetworkState) Reconcile(request reconcile.Request) (reconc
 		}
 		return reconcile.Result{}, err
 	}
+	fmt.Println(fmt.Sprintf("Refreshing %d", nodenetworkstateRefresh))
 	return reconcile.Result{RequeueAfter: nodenetworkstateRefresh}, nil
 }

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -38,16 +38,22 @@ const vlanFilteringCommand = "vlan-filtering"
 const defaultGwRetrieveTimeout = 120 * time.Second
 const defaultGwProbeTimeout = 120 * time.Second
 const apiServerProbeTimeout = 120 * time.Second
+const defaultInterfacesFilter = "veth*"
 
 var (
 	interfacesFilterGlob glob.Glob
 )
 
 func init() {
-	interfacesFilter, isSet := os.LookupEnv("INTERFACES_FILTER")
-	if !isSet {
-		panic("INTERFACES_FILTER is mandatory")
+	interfacesFilter, _ := os.LookupEnv("INTERFACES_FILTER")
+	InitClient(interfacesFilter)
+}
+
+func InitClient(interfacesFilter string) {
+	if interfacesFilter == "" {
+		interfacesFilter = defaultInterfacesFilter
 	}
+	fmt.Println(fmt.Sprintf("Inittializng client with filter = %s", interfacesFilter))
 	interfacesFilterGlob = glob.MustCompile(interfacesFilter)
 }
 

--- a/pkg/helper/config_controller_helper.go
+++ b/pkg/helper/config_controller_helper.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const configMapName = "nmstate-config"
+
+// return True if config map name is nmstate-config
+func EventIsForNmConfig(meta v1.Object) bool {
+	configName := meta.GetName()
+	return configName == configMapName
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Making configuration map optional.
Adding config map controller that listen on events and run reconcile only if event is relevant to nmstate-config

**Special notes for your reviewer**:

@phoracek Just wanted to check if i got right the ticket, still no tests are added.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
