### PR TITLE
doc: add ubuntu netplan configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,28 @@ There is a possibility to enable golang pprof profiler.
 
 - [prow](https://prow.apps.ovirt.org/)
 - [flakefinder](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/nmstate/kubernetes-nmstate/index.html)
+
+# FAQ
+
+## The NodeNetworkState does not show the state correctly at ubuntu 18.04 nodes.
+
+In Ubuntu 18.04 they introduced netplan for the network configuration. So to enable NetworkManager you need to
+follow these steps:
+
+```yaml
+# 1.- - edit /etc/netplan with:
+network:
+  version: 2
+  renderer: NetworkManager
+```
+
+```bash
+# 2.- apply the changes
+netplan generate
+netplan apply
+```
+
+References:
+
+- https://netplan.io/
+- https://askubuntu.com/questions/1031956/network-manager-not-working-when-installing-ubuntu-desktop-on-a-ubuntu-18-04-ser


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
After https://github.com/nmstate/kubernetes-nmstate/issues/399 we found
that NetworkManager has to be activated at Ubuntu systems.
**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
