### PR TITLE
tests: fix cleanup function

### DIFF
--- a/test/e2e/demos_test.go
+++ b/test/e2e/demos_test.go
@@ -24,8 +24,11 @@ func skipIfNotKubernetes() {
 }
 
 var _ = Describe("Introduction: Configuration", func() {
-	AfterEach(func() {
+	BeforeEach(func() {
 		skipIfNotKubernetes()
+	})
+
+	AfterEach(func() {
 		updateDesiredState(interfaceAbsent("eth1.100"))
 		waitForAvailableTestPolicy()
 		resetDesiredStateForNodes()


### PR DESCRIPTION

Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We merged Skip into AfterEach. It should be in BeforeEach. In the current
state, it causes this cleanup to be skipped and therefore the test
leaves mess behind.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
