### PR TITLE
cleanup vlan100 Policy

### DIFF
--- a/test/e2e/demos_test.go
+++ b/test/e2e/demos_test.go
@@ -39,6 +39,13 @@ var _ = Describe("Introduction", func() {
 		kubectlAndCheck("wait", "nncp", "vlan100", "--for", "condition=Available", "--timeout", "2m")
 	}
 
+	// Policies are not deleted as a part of the tutorial, so we need additional function here
+	cleanupConfiguration := func() {
+		deletePolicy("vlan100")
+		updateDesiredState(interfaceAbsent("eth1.100"))
+		waitForAvailableTestPolicy()
+	}
+
 	runTroubleshooting := func() {
 		kubectlAndCheck("apply", "-f", "docs/examples/eth666_up.yaml")
 		kubectlAndCheck("wait", "nncp", "eth666", "--for", "condition=Degraded", "--timeout", "2m")
@@ -49,13 +56,12 @@ var _ = Describe("Introduction", func() {
 		skipIfNotKubernetes()
 	})
 
-	AfterEach(func() {
-		updateDesiredState(interfaceAbsent("eth1.100"))
-		waitForAvailableTestPolicy()
-		resetDesiredStateForNodes()
-	})
-
 	Context("Configuration tutorial", func() {
+		AfterEach(func() {
+			cleanupConfiguration()
+			resetDesiredStateForNodes()
+		})
+
 		It("should succeed executing all the commands", func() {
 			runConfiguration()
 		})
@@ -68,6 +74,11 @@ var _ = Describe("Introduction", func() {
 	})
 
 	Context("All tutorials in a row", func() {
+		AfterEach(func() {
+			cleanupConfiguration()
+			resetDesiredStateForNodes()
+		})
+
 		It("should succeed executing all the commands", func() {
 			runConfiguration()
 			runTroubleshooting()


### PR DESCRIPTION

Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We never cleaned up the policy, that resulted to vlan100 being randomly
created during the tests execution.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
