### PR TITLE
Use policy generation to calculate overall condition.

### DIFF
--- a/deploy/crds/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
@@ -66,6 +66,11 @@ spec:
               description: The desired state rendered for the enactment's node using
                 the policy desiredState as template
               type: object
+            policyGeneration:
+              description: The generation from policy needed to check if an enactment
+                condition status belongs to the same policy version
+              format: int64
+              type: integer
           type: object
       type: object
   version: v1alpha1

--- a/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -40,7 +40,10 @@ type NodeNetworkConfigurationEnactmentStatus struct {
 	// the policy desiredState as template
 	DesiredState State `json:"desiredState,omitempty"`
 
-	Conditions ConditionList `json:"conditions,omitempty"`
+	// The generation from policy needed to check if an enactment
+	// condition status belongs to the same policy version
+	PolicyGeneration int64         `json:"policyGeneration,omitempty"`
+	Conditions       ConditionList `json:"conditions,omitempty"`
 }
 
 const (

--- a/pkg/apis/nmstate/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/nmstate/v1alpha1/zz_generated.openapi.go
@@ -124,6 +124,13 @@ func schema_pkg_apis_nmstate_v1alpha1_NodeNetworkConfigurationEnactmentStatus(re
 							Ref:         ref("./pkg/apis/nmstate/v1alpha1.State"),
 						},
 					},
+					"policyGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The generation from policy needed to check if an enactment condition status belongs to the same policy version",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},

--- a/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/conditions_suite_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/conditions_suite_test.go
@@ -1,0 +1,16 @@
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-enactmentstatus-conditions_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Enactment Status Conditions Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter.go
@@ -15,7 +15,11 @@ type ConditionCount map[nmstatev1alpha1.ConditionType]CountByConditionStatus
 func Count(enactments nmstatev1alpha1.NodeNetworkConfigurationEnactmentList) ConditionCount {
 	conditionCount := ConditionCount{}
 	for _, conditionType := range nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionTypes {
-		conditionCount[conditionType] = CountByConditionStatus{}
+		conditionCount[conditionType] = CountByConditionStatus{
+			corev1.ConditionTrue:    0,
+			corev1.ConditionFalse:   0,
+			corev1.ConditionUnknown: 0,
+		}
 		for _, enactment := range enactments.Items {
 			condition := enactment.Status.Conditions.Find(conditionType)
 			if condition != nil {

--- a/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter.go
@@ -12,7 +12,7 @@ type CountByConditionStatus map[corev1.ConditionStatus]int
 
 type ConditionCount map[nmstatev1alpha1.ConditionType]CountByConditionStatus
 
-func Count(enactments nmstatev1alpha1.NodeNetworkConfigurationEnactmentList) ConditionCount {
+func Count(enactments nmstatev1alpha1.NodeNetworkConfigurationEnactmentList, policyGeneration int64) ConditionCount {
 	conditionCount := ConditionCount{}
 	for _, conditionType := range nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionTypes {
 		conditionCount[conditionType] = CountByConditionStatus{
@@ -22,7 +22,8 @@ func Count(enactments nmstatev1alpha1.NodeNetworkConfigurationEnactmentList) Con
 		}
 		for _, enactment := range enactments.Items {
 			condition := enactment.Status.Conditions.Find(conditionType)
-			if condition != nil {
+			// If there is a condition status and it's from the current policy update
+			if condition != nil && enactment.Status.PolicyGeneration == policyGeneration {
 				conditionCount[conditionType][condition.Status] += 1
 			} else {
 				conditionCount[conditionType][corev1.ConditionUnknown] += 1

--- a/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter_test.go
@@ -50,7 +50,6 @@ var _ = Describe("Enactment condition counter", func() {
 	DescribeTable("the enactments statuses", func(c EnactmentCounterCase) {
 		obtainedCount := Count(c.enactmentsToCount, c.policyGeneration)
 		Expect(obtainedCount).To(Equal(c.expectedCount))
-		//TODO: Do we also check getters ? available().true(), etc...
 	},
 		Entry("e(), e()", EnactmentCounterCase{
 			policyGeneration: 1,

--- a/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter_test.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/enactmentstatus/conditions/counter_test.go
@@ -1,0 +1,150 @@
+package conditions
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+)
+
+const (
+	failing     = nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionFailing
+	available   = nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionAvailable
+	progressing = nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionProgressing
+	matching    = nmstatev1alpha1.NodeNetworkConfigurationEnactmentConditionMatching
+	t           = corev1.ConditionTrue
+	f           = corev1.ConditionFalse
+	u           = corev1.ConditionUnknown
+)
+
+type setter = func(*nmstatev1alpha1.ConditionList, string)
+
+func enactments(enactments ...nmstatev1alpha1.NodeNetworkConfigurationEnactment) nmstatev1alpha1.NodeNetworkConfigurationEnactmentList {
+	return nmstatev1alpha1.NodeNetworkConfigurationEnactmentList{
+		Items: append([]nmstatev1alpha1.NodeNetworkConfigurationEnactment{}, enactments...),
+	}
+}
+
+func enactment(setters ...setter) nmstatev1alpha1.NodeNetworkConfigurationEnactment {
+	enactment := nmstatev1alpha1.NodeNetworkConfigurationEnactment{
+		Status: nmstatev1alpha1.NodeNetworkConfigurationEnactmentStatus{
+			Conditions: nmstatev1alpha1.ConditionList{},
+		},
+	}
+	for _, setter := range setters {
+		setter(&enactment.Status.Conditions, "")
+	}
+	return enactment
+}
+
+var _ = Describe("Enactment condition counter", func() {
+	type EnactmentCounterCase struct {
+		enactmentsToCount nmstatev1alpha1.NodeNetworkConfigurationEnactmentList
+		expectedCount     ConditionCount
+	}
+	DescribeTable("the enactments statuses", func(c EnactmentCounterCase) {
+		obtainedCount := Count(c.enactmentsToCount)
+		Expect(obtainedCount).To(Equal(c.expectedCount))
+		//TODO: Do we also check getters ? available().true(), etc...
+	},
+		Entry("e(), e()", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(),
+				enactment(),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
+				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
+				progressing: CountByConditionStatus{t: 0, f: 0, u: 2},
+				matching:    CountByConditionStatus{t: 0, f: 0, u: 2},
+			},
+		}),
+		Entry("e(NotMatching), e(NotMatching)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetNodeSelectorNotMatching),
+				enactment(SetNodeSelectorNotMatching),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 2, u: 0},
+				failing:     CountByConditionStatus{t: 0, f: 2, u: 0},
+				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
+				matching:    CountByConditionStatus{t: 0, f: 2, u: 0},
+			},
+		}),
+		Entry("e(NotMatching), e(Matching, Progressing)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetNodeSelectorNotMatching),
+				enactment(SetMatching, SetProgressing),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
+				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
+				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
+				matching:    CountByConditionStatus{t: 1, f: 1, u: 0},
+			},
+		}),
+		Entry("e(Matching, Failed), e(Matching, Progressing)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetMatching, SetFailedToConfigure),
+				enactment(SetMatching, SetProgressing),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
+				failing:     CountByConditionStatus{t: 1, f: 0, u: 1},
+				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
+				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
+			},
+		}),
+		Entry("e(Matching, Success), e(Matching, Progressing)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetMatching, SetSuccess),
+				enactment(SetMatching, SetProgressing),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 1, f: 0, u: 1},
+				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
+				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
+				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
+			},
+		}),
+		Entry("e(Matching, Progressing), e(Matching, Progressing)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetMatching, SetProgressing),
+				enactment(SetMatching, SetProgressing),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
+				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
+				progressing: CountByConditionStatus{t: 2, f: 0, u: 0},
+				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
+			},
+		}),
+		Entry("e(Matching, Success), e(Matching, Success)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetMatching, SetSuccess),
+				enactment(SetMatching, SetSuccess),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 2, f: 0, u: 0},
+				failing:     CountByConditionStatus{t: 0, f: 2, u: 0},
+				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
+				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
+			},
+		}),
+		Entry("e(Matching, Failed), e(Matching, Failed)", EnactmentCounterCase{
+			enactmentsToCount: enactments(
+				enactment(SetMatching, SetFailedToConfigure),
+				enactment(SetMatching, SetFailedToConfigure),
+			),
+			expectedCount: ConditionCount{
+				available:   CountByConditionStatus{t: 0, f: 2, u: 0},
+				failing:     CountByConditionStatus{t: 2, f: 0, u: 0},
+				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
+				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
+			},
+		}),
+	)
+})

--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
@@ -140,6 +140,7 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) initializeEnactment(policy nms
 
 	return enactmentstatus.Update(r.client, enactmentKey, func(status *nmstatev1alpha1.NodeNetworkConfigurationEnactmentStatus) {
 		status.DesiredState = policy.Spec.DesiredState
+		status.PolicyGeneration = policy.Generation
 	})
 }
 

--- a/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/conditions.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/policyconditions/conditions.go
@@ -119,8 +119,8 @@ func Update(cli client.Client, policyKey types.NamespacedName) error {
 			}
 		}
 
-		// Let's get conditions with true status count
-		enactmentsCount := enactmentconditions.Count(enactments)
+		// Let's get conditions with true status count filtered by policy generation
+		enactmentsCount := enactmentconditions.Count(enactments, policy.Generation)
 
 		numberOfFinishedEnactments := enactmentsCount.Available() + enactmentsCount.Failed() + enactmentsCount.NotMatching()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a race condition when when a policy is being updated and the status is calculated before, 
Reconcile is reached for an enactment so it will use old enactment status, to fix that this PR saves the policy generation at the enactment and check that when calculating the overall condition so it ignore the enactment status with old policy generation.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
