### PR TITLE
Revert "use NM 1.22 on Kubernetes kubevirtci"

### DIFF
--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -4,7 +4,7 @@ function install_nm_on_node() {
     node=$1
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
-    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
+    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.20
     $SSH $node sudo -- yum install -y NetworkManager NetworkManager-ovs
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager


### PR DESCRIPTION

Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This reverts commit 77bf8e7e6c156ed8047129cecc2893a3a4d055d4.

We will branch out for 1.20 branch. Let's make sure we test the correct
version. Once we branch out, we can revert this.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
