### PR TITLE
pin nmstate to 0.2 branch

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:31
 
 RUN sudo dnf install -y dnf-plugins-core && \
-    sudo dnf copr enable -y nmstate/nmstate-git && \
+    sudo dnf copr enable -y nmstate/nmstate-0.2 && \
     sudo dnf install -y nmstate iproute iputils && \
     sudo dnf remove -y dnf-plugins-core && \
     sudo dnf clean all


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Before we release 0.15.0 let's make sure we are pinned to a stable branch

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
