### PR TITLE
docs: workaround for MAC+IP inheritance issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,3 +180,20 @@ References:
 
 - https://netplan.io/
 - https://askubuntu.com/questions/1031956/network-manager-not-working-when-installing-ubuntu-desktop-on-a-ubuntu-18-04-ser
+
+## Bridge does not inherit MAC and IP of its NIC
+
+There is a bug in NetworkManager 1.20 that causes that. It should be solved on
+NetworkManager 1.22. To workaround this issue on earlier release, please set the
+following:
+
+```
+# /etc/systemd/network/98-bridge-inherit-mac.link
+[Match]
+Type=bridge
+
+[Link]
+MACAddressPolicy=none
+```
+
+Change log with explanation: https://github.com/systemd/systemd/blob/master/NEWS#L1004


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There is a bug in NetworkManager 1.20 that causes that. It should be solved on
NetworkManager 1.22. This PR adds a documentation entry to workaround this issue.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
