### PR TITLE
bump NetworkManager requirements to 1.22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,17 @@ deployed as a DaemonSet instead of Deployment with
 only events for the DaemonSet pod node.
 
 
+# NetworkManager compatibility
+
+kubernetes-nmstate is connecting to NetworkManager running on a host. That
+implies following dependency requirements:
+
+| kubernetes-nmstate version | NetworkManager version |
+| ---                        | ---                    |
+| master, `> 0.15.0`         | `>= 1.22`              |
+| `<= 0.15.0`                | `>= 1.20`              |
+
+
 # Development
 
 ## Local Kubernetes cluster

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ spec:
         - name: eth0
 ```
 
-The only external dependency is NetworkManager `>= 1.20` running on nodes.
+The only external dependency is NetworkManager running on nodes. See more
+details in
+[Compatibility documentation](CONTRIBUTING.md#networkmanager-compatibility).
 
 # Deployment and Usage
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,10 @@
-FROM fedora:31
+FROM fedora:32
 
-RUN sudo dnf install -y dnf-plugins-core && \
-    sudo dnf copr enable -y nmstate/nmstate-0.2 && \
-    sudo dnf install -y nmstate iproute iputils && \
-    sudo dnf remove -y dnf-plugins-core && \
-    sudo dnf clean all
-
-# Looks like 35 is not enough we need 60 to propertly recover after reboot
-# TODO: Remove this when we merge https://github.com/nmstate/nmstate/pull/555
-RUN sed -i "s/MAINLOOP_TIMEOUT = 35/MAINLOOP_TIMEOUT = 60/g" /usr/lib/python3.7/site-packages/libnmstate/netapplier.py
+RUN dnf install -y dnf-plugins-core && \
+    dnf copr enable -y nmstate/nmstate-0.2 && \
+    dnf install -y nmstate iproute iputils && \
+    dnf remove -y dnf-plugins-core && \
+    dnf clean all
 
 # Cannot change the binary to nmstate-handler since the name
 # is taken from the directory name [1]

--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -4,7 +4,7 @@ function install_nm_on_node() {
     node=$1
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
-    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.20
+    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
     $SSH $node sudo -- yum install -y NetworkManager NetworkManager-ovs
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Update node NetworkManager to 1.22
* Update used nmstate version to 0.2
* Add compatibility section to documentation

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Minimal required NetworkManager version is changed to 1.22
```
