### PR TITLE
Change webhook port to 54874

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -60,6 +60,8 @@ spec:
                 configMapKeyRef:
                   name: nmstate-config
                   key: interfaces_filter
+            - name: WEBHOOK_PORT
+              value: "54874"
             - name: ENABLE_PROFILER
               value: "False"
             - name: PROFILER_PORT
@@ -173,7 +175,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - port: 443
-      targetPort: 8443
+      targetPort: 54874
   selector:
     name: nmstate-handler
 ---

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -1,6 +1,12 @@
 package nodenetworkconfigurationpolicy
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	webhookserver "github.com/qinqon/kube-admission-webhook/pkg/webhook/server"
@@ -13,6 +19,17 @@ const (
 
 func Add(mgr manager.Manager) error {
 
+	webhookPortString, isSet := os.LookupEnv("WEBHOOK_PORT")
+	if !isSet || len(webhookPortString) == 0 {
+		return fmt.Errorf("WEBHOOK_PORT env var is mandatory")
+	}
+
+	var err error
+	webhookPort, err := strconv.Atoi(webhookPortString)
+	if err != nil {
+		return errors.Wrap(err, "WEBHOOK_PORT env var has bad format")
+	}
+
 	// We need two hooks, the update of nncp and nncp/status (it's a subresource) happends
 	// at different times, also if you modify status at nncp webhook it does not modify it
 	// you need at nncp/status webhook that will catch that and do the final modifications.
@@ -21,6 +38,7 @@ func Add(mgr manager.Manager) error {
 	// 2.- Since we have delete the condition the status-mutate webhook get called and
 	//     there we set conditions to Unknown this final result will be updated.
 	server := webhookserver.New(mgr, webhookName, certificate.MutatingWebhook,
+		webhookserver.WithPort(webhookPort),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook()),


### PR DESCRIPTION
**What this PR does / why we need it**:
We have found that 8443 is a conflicting port [1] so we change to 54874 here.

[1]: https://github.com/openshift/cluster-kube-apiserver-operator/blob/f5e8c4e9a81c5f5d7477c535d8c7e55af29321c0/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
