### PR TITLE
Add dockerignore to project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# We cannot call `docker build` out of top dir since this is controlled by
+# operator-sdk and it does not has the option to change that, but future
+# versin of operator-sdk is going to split the build process into small
+# makefile targets and we will be able to tune that, so this file will
+# be smaller
+
+# git stuff
+.git
+.github
+
+# The path for kubevirtci installation
+_kubevirtci
+
+# The old path for kubevirtci installation, in case checkout is done from and
+# old branch this can exists
+kubevirtci
+
+# No need for source code is already compiled
+pkg
+cmd
+vendor
+docs
+
+# Test and infra
+test
+test_logs
+automation
+
+
+# go tools
+build/**/go*
+build/**/go


### PR DESCRIPTION
**What this PR does / why we need it**:
It will prevent copying the kubevirtci dir and golang installations into
docker build context when we build the handler

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
