### PR TITLE
Use centos8, fedora:32 is problematic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WHAT ?= ./pkg
 
 unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
 
-export KUBEVIRT_PROVIDER ?= k8s-1.17.0
+export KUBEVIRT_PROVIDER ?= k8s-1.17
 export KUBEVIRT_NUM_NODES ?= 1
 export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 
@@ -138,7 +138,6 @@ $(CLUSTER_DIR)/%: $(install_kubevirtci)
 	$(install_kubevirtci)
 
 cluster-prepare:
-	hack/install-ovs.sh
 	hack/install-nm.sh
 	hack/flush-secondary-nics.sh
 

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -15,7 +15,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17.0'
+    export KUBEVIRT_PROVIDER='k8s-1.17'
     export KUBEVIRT_NUM_NODES=2
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -27,7 +27,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_ARGS="-ginkgo.noColor" test/e2e
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-ginkgo.noColor " test/e2e
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,7 @@
-FROM fedora:32
+FROM centos:8
 
 RUN dnf install -b -y dnf-plugins-core && \
+    dnf copr enable -y networkmanager/NetworkManager-1.22 && \
     dnf copr enable -y nmstate/nmstate-0.2 && \
     dnf install -b -y nmstate iproute iputils && \
     dnf remove -y dnf-plugins-core && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:32
 
-RUN dnf install -y dnf-plugins-core && \
+RUN dnf install -b -y dnf-plugins-core && \
     dnf copr enable -y nmstate/nmstate-0.2 && \
-    dnf install -y nmstate iproute iputils && \
+    dnf install -b -y nmstate iproute iputils && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all
 

--- a/hack/cluster-sync-handler.sh
+++ b/hack/cluster-sync-handler.sh
@@ -17,7 +17,20 @@ function getNumberAvailable {
         echo ${numberAvailable:-0}
 }
 
+function consistently {
+    cmd=$@
+    retries=3
+    interval=1
+    cnt=1
+    while [[ $cnt -le $retries ]]; do
+        $cmd
+        sleep $interval
+        cnt=$(($cnt + 1))
+    done
+}
+
 function isOk {
+
         desiredNumberScheduled=$(getDesiredNumberScheduled $1)
         numberAvailable=$(getNumberAvailable $1)
 
@@ -32,7 +45,7 @@ function isOk {
 
 for i in {300..0}; do
     # We have to re-check desired number, sometimes takes some time to be filled in
-    if isOk nmstate-handler && isOk nmstate-handler-worker; then
+    if consistently isOk nmstate-handler && consistently isOk nmstate-handler-worker; then
        break
     fi
 

--- a/hack/flush-secondary-nics.sh
+++ b/hack/flush-secondary-nics.sh
@@ -20,7 +20,4 @@ for node in $($kubectl get nodes --no-headers | awk '{print $1}'); do
         	$ssh $node -- sudo nmcli con del $uuid
 	fi
     done
-    echo "$node: restoring resolv.conf config"
-    $ssh $node -- sudo dhclient -r $PRIMARY_NIC
-    $ssh $node -- sudo dhclient $PRIMARY_NIC
 done

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="0c3911794ad2b79a61a4bc7462c236251a73866f"
+commit="8c311c6ede0400b510aee4eeb37dac5068d92fff"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-organization=kubevirt
-commit="8c311c6ede0400b510aee4eeb37dac5068d92fff"
+organization=qinqon
+commit="k8s-centos8"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=qinqon
-commit="k8s-centos8"
+commit="k8s-1.17-fix-non-interactive-dnf"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci

--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -4,8 +4,8 @@ function install_nm_on_node() {
     node=$1
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
-    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
-    $SSH $node sudo -- yum install -y NetworkManager NetworkManager-ovs
+    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22
+    $SSH $node sudo -- yum install -y NetworkManager
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager
     echo "Check NetworkManager is working fine on node $node"

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -180,6 +180,44 @@ func defaultGw() (string, error) {
 	})
 }
 
+func runProbes() error {
+	defaultGw, err := defaultGw()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve default gw at runProbes")
+	}
+
+	currentState, err := nmstatectl.Show()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve currentState at runProbes")
+	}
+
+	// TODO: Make ping timeout configurable with a config map
+	pingOutput, err := ping(defaultGw, defaultGwProbeTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "error pinging external address after network reconfiguration -> output: %s, currentState: %s", pingOutput, currentState)
+	}
+
+	err = checkApiServerConnectivity(apiServerProbeTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "error checking api server connectivity after network reconfiguration -> currentState: %s", currentState)
+	}
+	return nil
+}
+
+func rollback(cause error) error {
+	err := nmstatectl.Rollback(cause)
+	if err != nil {
+		return errors.Wrap(err, "failed to do rollback")
+	}
+
+	// wait for system to settle after rollback
+	probesErr := runProbes()
+	if probesErr != nil {
+		return errors.Wrap(err, "failed running probes after rollback")
+	}
+	return nil
+}
+
 func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 	if len(string(desiredState.Raw)) == 0 {
 		return "Ignoring empty desired state", nil
@@ -200,7 +238,7 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 	// set
 	bridgesUpWithPorts, err := getBridgesUp(desiredState)
 	if err != nil {
-		return "", nmstatectl.Rollback(fmt.Errorf("error retrieving up bridges from desired state"))
+		return "", rollback(fmt.Errorf("error retrieving up bridges from desired state"))
 	}
 
 	commandOutput := ""
@@ -208,29 +246,13 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		outputVlanFiltering, err := applyVlanFiltering(bridge, ports)
 		commandOutput += fmt.Sprintf("bridge %s ports %v applyVlanFiltering command output: %s\n", bridge, ports, outputVlanFiltering)
 		if err != nil {
-			return commandOutput, nmstatectl.Rollback(err)
+			return commandOutput, rollback(err)
 		}
 	}
 
-	defaultGw, err := defaultGw()
+	err = runProbes()
 	if err != nil {
-		return commandOutput, nmstatectl.Rollback(err)
-	}
-
-	currentState, err := nmstatectl.Show()
-	if err != nil {
-		return "", nmstatectl.Rollback(err)
-	}
-
-	// TODO: Make ping timeout configurable with a config map
-	pingOutput, err := ping(defaultGw, defaultGwProbeTimeout)
-	if err != nil {
-		return pingOutput, nmstatectl.Rollback(fmt.Errorf("error pinging external address after network reconfiguration -> error: %v, currentState: %s", err, currentState))
-	}
-
-	err = checkApiServerConnectivity(apiServerProbeTimeout)
-	if err != nil {
-		return "", nmstatectl.Rollback(fmt.Errorf("error checking api server connectivity after network reconfiguration -> error: %v, currentState: %s", err, currentState))
+		return "", rollback(errors.Wrap(err, "failed runnig probes after network changes"))
 	}
 
 	commitOutput, err := nmstatectl.Commit()

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -185,10 +185,11 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		return "Ignoring empty desired state", nil
 	}
 
-	// commit timeout doubles the default gw ping probe timeout, to
+	// commit timeout doubles the default gw ping probe and check API server
+	// connectivity timeout, to
 	// ensure the Checkpoint is alive before rolling it back
 	// https://nmstate.github.io/cli_guide#manual-transaction-control
-	setOutput, err := nmstatectl.Set(desiredState, defaultGwProbeTimeout*2)
+	setOutput, err := nmstatectl.Set(desiredState, (defaultGwProbeTimeout+apiServerProbeTimeout)*2)
 	if err != nil {
 		return setOutput, err
 	}

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -23,6 +23,7 @@ var (
 const nmstateCommand = "nmstatectl"
 
 func nmstatectlWithInput(arguments []string, input string) (string, error) {
+	log.Info(fmt.Sprintf("cmd: %s, input: %s", strings.Join(arguments, " "), input))
 	cmd := exec.Command(nmstateCommand, arguments...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/test/e2e/get-bridge-vlans-flags-el8.sh
+++ b/test/e2e/get-bridge-vlans-flags-el8.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -xe
 
 node=$1
 connection=$2
@@ -6,6 +8,8 @@ vlan=$3
 vlans_out=/tmp/vlans.out
 
 ./kubevirtci/cluster-up/ssh.sh $node -- sudo bridge vlan show > $vlans_out
+
+dos2unix $vlans_out
 
 tags=$(grep $connection$ -A 1 $vlans_out |sed "s/\t/\n/g" | grep " $vlan " | sed "s/ $vlan *//")
 echo -n $tags

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -44,6 +44,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	prepare(t)
+
+	resetDesiredStateForNodes()
 })
 
 func TestMain(m *testing.M) {

--- a/test/e2e/simple_bridge_and_bond_test.go
+++ b/test/e2e/simple_bridge_and_bond_test.go
@@ -132,7 +132,7 @@ func matchingBond(expectedBond map[string]interface{}) types.GomegaMatcher {
 	)
 }
 
-var _ = FDescribe("NodeNetworkState", func() {
+var _ = Describe("NodeNetworkState", func() {
 	Context("when desiredState is configured", func() {
 		Context("with a linux bridge up with no ports", func() {
 			BeforeEach(func() {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -96,12 +96,26 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 //       to remove this
 func resetDesiredStateForNodes() {
 	By("Resetting nics state primary up and secondaries down")
-	states := map[string]string{
-		primaryNic:         "up",
-		firstSecondaryNic:  "down",
-		secondSecondaryNic: "down",
-	}
-	updateDesiredState(ethernetNicsState(states))
+	updateDesiredState(nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    type: ethernet
+    state: up
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+
+`, primaryNic, firstSecondaryNic, secondSecondaryNic)))
 	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -95,6 +95,7 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
 //       to remove this
 func resetDesiredStateForNodes() {
+	By("Resetting nics state primary up and secondaries down")
 	states := map[string]string{
 		primaryNic:         "up",
 		firstSecondaryNic:  "down",
@@ -286,6 +287,7 @@ func getVLANFlagsEventually(node string, connection string, vlan int) AsyncAsser
 		}
 
 		if !gjson.Valid(bridgeVlans) {
+			By("Get VLAN flags from non json complaint output")
 			// There is a bug [1] at centos8 and output is and invalid json
 			// so it parses the non json output
 			// [1] https://bugs.centos.org/view.php?id=16533
@@ -295,6 +297,7 @@ func getVLANFlagsEventually(node string, connection string, vlan int) AsyncAsser
 			Expect(err).ToNot(HaveOccurred())
 			return strings.Split(string(output), " ")
 		} else {
+			By("Get VLAN flags from json complaint output")
 			parsedBridgeVlans := gjson.Parse(bridgeVlans)
 
 			vlanFlagsFilter := fmt.Sprintf("%s.#(vlan==%d).flags", connection, vlan)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We couldn't use fedora:31 since nm 1.22 was missing there and it's a dependency for
nmstate-0.2, but we can isntall it from copr but for that we need to use centos8 image, also
is looks like f31 + 1.22 is no-no.

Also the following is implemented here:
- Also add the `-b` option is passed to `dnf install` to ensure that docker build fail in case of rpm install is skipped.
- Use fix a bug at client.go to use probe api timeout to at nmstatectl set command 
- Check client.go probes after rollback to wait for thinkgs to settle up.
- Disable dhcp at secondary nics at tests.
- Fix test to match specific bonding options (broken after nmstate upgrade)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
 NONE
```
