### PR TITLE
Disable webhooks

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,8 +38,10 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
-            - name: RUN_WEBHOOK_SERVER
-              value: ""
+            # FIXME: Communication to etcd not working at openshift, looks like
+            # related to caBundle
+            #- name: RUN_WEBHOOK_SERVER
+            #  value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -29,7 +29,7 @@ func expectConditionsUnknown(policy nmstatev1alpha1.NodeNetworkConfigurationPoli
 
 // We just check the labe at CREATE/UPDATE events since mutated data is already
 // check at unit test.
-var _ = Describe("Mutating Admission Webhook", func() {
+var _ = PDescribe("Mutating Admission Webhook [pending openshift not working]", func() {
 	Context("when policy is created", func() {
 		BeforeEach(func() {
 			// Make sure test policy is not there so


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There are openshift issues with webhook implementations could be related to
caBundle, let's disable it for now since the functionality they provide is
not critical, and investigate in parallel.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
