### PR TITLE
Set nmstatectl 'set' timeout to (defaultGwProbe + apiServerProbe) * 2

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -185,10 +185,11 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		return "Ignoring empty desired state", nil
 	}
 
-	// commit timeout doubles the default gw ping probe timeout, to
+	// commit timeout doubles the default gw ping probe and check API server
+	// connectivity timeout, to
 	// ensure the Checkpoint is alive before rolling it back
 	// https://nmstate.github.io/cli_guide#manual-transaction-control
-	setOutput, err := nmstatectl.Set(desiredState, defaultGwProbeTimeout*2)
+	setOutput, err := nmstatectl.Set(desiredState, (defaultGwProbeTimeout+apiServerProbeTimeout)*2)
 	if err != nil {
 		return setOutput, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Set nmstatectl 'set' timeout to (defaultGwProbe + apiServerProbe) * 2

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
