### PR TITLE
CNAO integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ HANDLER_IMAGE_SUFFIX ?=
 HANDLER_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(HANDLER_IMAGE_NAME)$(HANDLER_IMAGE_SUFFIX)
 HANDLER_IMAGE ?= $(IMAGE_REGISTRY)/$(HANDLER_IMAGE_FULL_NAME)
 
+NAMESPACE ?= nmstate
+PULL_POLICY ?= Always
+
 WHAT ?= ./pkg
 
 unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
@@ -96,7 +99,7 @@ gen-crds: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate crds
 
 manifests:
-	$(GO) run hack/render-manifests.go nmstate $(HANDLER_IMAGE) Always deploy/ $(manifests)
+	$(GO) run hack/render-manifests.go $(NAMESPACE) $(HANDLER_IMAGE) $(PULL_POLICY) deploy/ $(manifests)
 
 handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK) manifests
 	$(OPERATOR_SDK) build $(HANDLER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GO := $(GOBIN)/go
 
 LOCAL_REGISTRY ?= registry:5000
 
-manifests = build/_output/manifests
+export MANIFESTS_DIR ?= build/_output/manifests
 description = build/_output/description
 
 all: check handler
@@ -99,7 +99,7 @@ gen-crds: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate crds
 
 manifests:
-	$(GO) run hack/render-manifests.go $(NAMESPACE) $(HANDLER_IMAGE) $(PULL_POLICY) deploy/ $(manifests)
+	$(GO) run hack/render-manifests.go $(NAMESPACE) $(HANDLER_IMAGE) $(PULL_POLICY) deploy/ $(MANIFESTS_DIR)
 
 handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK) manifests
 	$(OPERATOR_SDK) build $(HANDLER_IMAGE)
@@ -152,7 +152,7 @@ release: manifests push-handler $(description) $(GITHUB_RELEASE) version/version
 	GITHUB_RELEASE=$(GITHUB_RELEASE) \
 	TAG=$(shell hack/version.sh) \
 				   hack/release.sh \
-						$(shell find $(manifests) -type f)
+						$(shell find $(MANIFESTS_DIR) -type f)
 
 vendor:
 	$(GO) mod tidy

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -4,22 +4,22 @@ set -ex
 
 echo 'Cleaning up ...'
 
-manifests_dir=build/_output/manifests
+MANIFESTS_DIR=build/_output/manifests
 kubectl=./cluster/kubectl.sh
 
-if [ ! -d $manifests_dir ]; then
+if [ ! -d $MANIFESTS_DIR ]; then
     exit 0
 fi
 
-$kubectl delete --ignore-not-found -f $manifests_dir/operator.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkstates_crd.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/namespace.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/service_account.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/role.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/role_binding.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/operator.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/nmstate.io_nodenetworkstates_crd.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/namespace.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/service_account.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/role.yaml
+$kubectl delete --ignore-not-found -f $MANIFESTS_DIR/role_binding.yaml
 
 if [[ "$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$ ]]; then
-    $kubectl delete --ignore-not-found -f $manifests_dir/scc.yaml
+    $kubectl delete --ignore-not-found -f $MANIFESTS_DIR/scc.yaml
 fi

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -4,14 +4,22 @@ set -ex
 
 echo 'Cleaning up ...'
 
+manifests_dir=build/_output/manifests
 kubectl=./cluster/kubectl.sh
-manifests_dir=deploy
 
-$kubectl delete --ignore-not-found -f $manifests_dir/
-$kubectl delete --ignore-not-found -f $manifests_dir/crds/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/crds/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
-$kubectl delete --ignore-not-found -f $manifests_dir/crds/nmstate.io_nodenetworkstates_crd.yaml
+if [ ! -d $manifests_dir ]; then
+    exit 0
+fi
+
+$kubectl delete --ignore-not-found -f $manifests_dir/operator.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/nmstate.io_nodenetworkstates_crd.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/namespace.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/service_account.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/role.yaml
+$kubectl delete --ignore-not-found -f $manifests_dir/role_binding.yaml
 
 if [[ "$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$ ]]; then
-    $kubectl delete --ignore-not-found -f $manifests_dir/openshift/
+    $kubectl delete --ignore-not-found -f $manifests_dir/scc.yaml
 fi

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -59,8 +59,6 @@ function deploy() {
         registry=localhost:$(./cluster/cli.sh ports registry | tr -d '\r')
     fi
 
-    manifests_dir=build/_output/manifests
-
     # Build new handler image from local sources and push it to the kubevirtci cluster
     IMAGE_REGISTRY=${registry} make push-handler
 
@@ -71,19 +69,19 @@ function deploy() {
         while ! $kubectl get securitycontextconstraints; do
             sleep 1
         done
-        $kubectl apply -f ${manifests_dir}/scc.yaml
+        $kubectl apply -f ${MANIFESTS_DIR}/scc.yaml
     fi
 
 
     # Deploy all needed manifests
-    $kubectl apply -f $manifests_dir/namespace.yaml
-    $kubectl apply -f $manifests_dir/service_account.yaml
-    $kubectl apply -f $manifests_dir/role.yaml
-    $kubectl apply -f $manifests_dir/role_binding.yaml
-    $kubectl apply -f $manifests_dir/nmstate.io_nodenetworkstates_crd.yaml
-    $kubectl apply -f $manifests_dir/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
-    $kubectl apply -f $manifests_dir/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
-    $kubectl apply -f $manifests_dir/operator.yaml
+    $kubectl apply -f $MANIFESTS_DIR/namespace.yaml
+    $kubectl apply -f $MANIFESTS_DIR/service_account.yaml
+    $kubectl apply -f $MANIFESTS_DIR/role.yaml
+    $kubectl apply -f $MANIFESTS_DIR/role_binding.yaml
+    $kubectl apply -f $MANIFESTS_DIR/nmstate.io_nodenetworkstates_crd.yaml
+    $kubectl apply -f $MANIFESTS_DIR/nmstate.io_nodenetworkconfigurationpolicies_crd.yaml
+    $kubectl apply -f $MANIFESTS_DIR/nmstate.io_nodenetworkconfigurationenactments_crd.yaml
+    $kubectl apply -f $MANIFESTS_DIR/operator.yaml
 }
 
 function wait_ready() {

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nmstate
+  name: {{ .Namespace }}
   labels:
-    name: nmstate
+    name: {{ .Namespace }}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
@@ -31,8 +31,8 @@ spec:
           args:
           - --v=production
           # Replace this with the built image name
-          image: REPLACE_IMAGE
-          imagePullPolicy: Always
+          image: {{ .NMStateHandlerImage }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
           command:
           - kubernetes-nmstate
           env:
@@ -76,7 +76,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nmstate-handler-worker
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
@@ -108,8 +108,8 @@ spec:
           args:
             - --v=production
           # Replace this with the built image name
-          image: REPLACE_IMAGE
-          imagePullPolicy: Always
+          image: {{ .NMStateHandlerImage }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
           command:
             - kubernetes-nmstate
           env:
@@ -149,7 +149,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nmstate-config
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 data:
   interfaces_filter: "veth*"
 ---
@@ -157,7 +157,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nmstate-webhook
-  namespace: nmstate
+  namespace: {{ .Namespace }}
   labels:
     app: kubernetes-nmstate
 spec:
@@ -179,7 +179,7 @@ webhooks:
     clientConfig:
       service:
         name: nmstate-webhook
-        namespace: nmstate
+        namespace: {{ .Namespace }}
         path: "/nodenetworkconfigurationpolicies-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -190,7 +190,7 @@ webhooks:
     clientConfig:
       service:
         name: nmstate-webhook
-        namespace: nmstate
+        namespace: {{ .Namespace }}
         path: "/nodenetworkconfigurationpolicies-status-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -201,7 +201,7 @@ webhooks:
     clientConfig:
       service:
         name: nmstate-webhook
-        namespace: nmstate
+        namespace: {{ .Namespace }}
         path: "/nodenetworkconfigurationpolicies-timestamp-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -48,7 +48,7 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 rules:
 - apiGroups:
   - certificates.k8s.io

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -3,11 +3,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 subjects:
 - kind: ServiceAccount
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 roleRef:
   kind: Role
   name: nmstate-handler
@@ -17,11 +17,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 subjects:
 - kind: ServiceAccount
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
 roleRef:
   kind: ClusterRole
   name: nmstate-handler

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: nmstate-handler
-  namespace: nmstate
+  namespace: {{ .Namespace }}
   labels:
     nmstate.io: ""

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+func exitWithError(err error, cause string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "render-manifests.go: error: %v\n", errors.Wrapf(err, cause, args))
+	os.Exit(1)
+}
+
+func main() {
+	type Inventory struct {
+		Namespace           string
+		NMStateHandlerImage string
+		ImagePullPolicy     string
+	}
+
+	inventory := Inventory{
+		Namespace:           os.Args[1],
+		NMStateHandlerImage: os.Args[2],
+		ImagePullPolicy:     os.Args[3],
+	}
+	inputDir := os.Args[4]
+	outputDir := os.Args[5]
+
+	// Clean up output dir so we don't have old files.
+	err := os.RemoveAll(outputDir)
+	if err != nil {
+		exitWithError(err, "failed cleaning up output dir %s", outputDir)
+	}
+
+	err = os.MkdirAll(outputDir, 0755)
+	if err != nil {
+		exitWithError(err, "failed to create output dir %s", outputDir)
+	}
+
+	tmpl, err := template.ParseGlob(path.Join(inputDir, "*.yaml"))
+	if err != nil {
+		exitWithError(err, "failed parsing top dir manifests at %s", inputDir)
+	}
+
+	tmpl, err = tmpl.ParseGlob(path.Join(inputDir, "*/*.yaml"))
+	if err != nil {
+		exitWithError(err, "failed parsing sub dir manifests at %s", inputDir)
+	}
+
+	for _, t := range tmpl.Templates() {
+		outputFile := path.Join(outputDir, t.Name())
+		f, err := os.Create(outputFile)
+		if err != nil {
+			exitWithError(err, "failed creating expanded template %s", outputFile)
+		}
+
+		err = t.Execute(f, inventory)
+		if err != nil {
+			exitWithError(err, "failed expanding template %s", tmpl)
+		}
+	}
+}

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -21,6 +21,11 @@ func main() {
 		ImagePullPolicy     string
 	}
 
+	if len(os.Args) < 6 {
+		fmt.Fprintf(os.Stderr, "usage: go run render-manifests.go [namespace] [image] [pull-policy] [input-dir] [output-dir]\n")
+		os.Exit(1)
+	}
+
 	inventory := Inventory{
 		Namespace:           os.Args[1],
 		NMStateHandlerImage: os.Args[2],


### PR DESCRIPTION
Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR use go template formant from CNAO so it's easier to take directly the manifests from here and use it there instead of manual copying it.

It also make cluster-sync more robust by implementing consistently and eventually with timeout/interval mechanism.

Also update kubevirtci to remove transient error about hostname not set by dhclient yet.

Closes #125
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
