### PR TITLE
Use centos8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,7 @@
-FROM fedora:32
+FROM centos:8
 
 RUN dnf install -b -y dnf-plugins-core && \
+    dnf copr enable -y networkmanager/NetworkManager-1.22 && \
     dnf copr enable -y nmstate/nmstate-0.2 && \
     dnf install -b -y nmstate iproute iputils && \
     dnf remove -y dnf-plugins-core && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:32
 
-RUN dnf install -y dnf-plugins-core && \
+RUN dnf install -b -y dnf-plugins-core && \
     dnf copr enable -y nmstate/nmstate-0.2 && \
-    dnf install -y nmstate iproute iputils && \
+    dnf install -b -y nmstate iproute iputils && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We couldn't use fedora:31 since nm 1.22 was missing there and it's a dependency for
nmstate-0.2, but we can install it from copr but for that we need to use centos8 image, also
is looks like f31 + 1.22 is no-no. 

Also add the -b option is passed to dnf install to ensure that docker build fail in case of rpm install is skipped.

**Special notes for your reviewer**:
e2e tests are still broken since k8s nodes and knmstate container are very different, I will fix that at follow up PRs, this just fix make handler so we can build it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
