### PR TITLE
Add api server probe timeout

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -185,10 +185,11 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		return "Ignoring empty desired state", nil
 	}
 
-	// commit timeout doubles the default gw ping probe timeout, to
+	// commit timeout doubles the default gw ping probe and check API server
+	// connectivity timeout, to
 	// ensure the Checkpoint is alive before rolling it back
 	// https://nmstate.github.io/cli_guide#manual-transaction-control
-	setOutput, err := nmstatectl.Set(desiredState, defaultGwProbeTimeout*2)
+	setOutput, err := nmstatectl.Set(desiredState, (defaultGwProbeTimeout+apiServerProbeTimeout)*2)
 	if err != nil {
 		return setOutput, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
At `nmstatectl set` we were using just the default gw probe timeout to set the `--timeout` value there we need to also use the api server probe timeout, since we don't want the checkpoint to dissappear after set so we can rollback in case of failures.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
