### PR TITLE
Use centos8 nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ $(CLUSTER_DIR)/%: $(install_kubevirtci)
 	$(install_kubevirtci)
 
 cluster-prepare:
-	hack/install-ovs.sh
 	hack/install-nm.sh
 	hack/flush-secondary-nics.sh
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WHAT ?= ./pkg
 
 unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
 
-export KUBEVIRT_PROVIDER ?= k8s-1.17.0
+export KUBEVIRT_PROVIDER ?= k8s-1.17
 export KUBEVIRT_NUM_NODES ?= 1
 export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -15,7 +15,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17.0'
+    export KUBEVIRT_PROVIDER='k8s-1.17'
     export KUBEVIRT_NUM_NODES=2
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
@@ -27,7 +27,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_ARGS="-ginkgo.noColor" test/e2e
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-ginkgo.noColor " test/e2e
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/hack/cluster-sync-handler.sh
+++ b/hack/cluster-sync-handler.sh
@@ -17,7 +17,20 @@ function getNumberAvailable {
         echo ${numberAvailable:-0}
 }
 
+function consistently {
+    cmd=$@
+    retries=3
+    interval=1
+    cnt=1
+    while [[ $cnt -le $retries ]]; do
+        $cmd
+        sleep $interval
+        cnt=$(($cnt + 1))
+    done
+}
+
 function isOk {
+
         desiredNumberScheduled=$(getDesiredNumberScheduled $1)
         numberAvailable=$(getNumberAvailable $1)
 
@@ -32,7 +45,7 @@ function isOk {
 
 for i in {300..0}; do
     # We have to re-check desired number, sometimes takes some time to be filled in
-    if isOk nmstate-handler && isOk nmstate-handler-worker; then
+    if consistently isOk nmstate-handler && consistently isOk nmstate-handler-worker; then
        break
     fi
 

--- a/hack/cluster-sync-handler.sh
+++ b/hack/cluster-sync-handler.sh
@@ -30,7 +30,6 @@ function consistently {
 }
 
 function isOk {
-
         desiredNumberScheduled=$(getDesiredNumberScheduled $1)
         numberAvailable=$(getNumberAvailable $1)
 

--- a/hack/flush-secondary-nics.sh
+++ b/hack/flush-secondary-nics.sh
@@ -20,7 +20,4 @@ for node in $($kubectl get nodes --no-headers | awk '{print $1}'); do
         	$ssh $node -- sudo nmcli con del $uuid
 	fi
     done
-    echo "$node: restoring resolv.conf config"
-    $ssh $node -- sudo dhclient -r $PRIMARY_NIC
-    $ssh $node -- sudo dhclient $PRIMARY_NIC
 done

--- a/hack/install-kubevirtci.sh
+++ b/hack/install-kubevirtci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 organization=kubevirt
-commit="0c3911794ad2b79a61a4bc7462c236251a73866f"
+commit="95096c8189c8b620ddc1310e12388df2190e1cc8"
 
 script_dir=$(dirname "$(readlink -f "$0")")
 kubevirtci_dir=kubevirtci

--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -5,7 +5,7 @@ function install_nm_on_node() {
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
     $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
-    $SSH $node sudo -- yum install -y NetworkManager NetworkManager-ovs
+    $SSH $node sudo -- yum install -y NetworkManager
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager
     echo "Check NetworkManager is working fine on node $node"

--- a/hack/install-nm.sh
+++ b/hack/install-nm.sh
@@ -4,7 +4,7 @@ function install_nm_on_node() {
     node=$1
     # Use copr repository to get newer NetworkManager
     $SSH $node sudo -- yum install -y yum-plugin-copr
-    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22-git
+    $SSH $node sudo -- yum copr enable -y networkmanager/NetworkManager-1.22
     $SSH $node sudo -- yum install -y NetworkManager
     $SSH $node sudo -- systemctl daemon-reload
     $SSH $node sudo -- systemctl restart NetworkManager

--- a/test/e2e/get-bridge-vlans-flags-el8.sh
+++ b/test/e2e/get-bridge-vlans-flags-el8.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -xe
 
 node=$1
 connection=$2
@@ -6,6 +8,8 @@ vlan=$3
 vlans_out=/tmp/vlans.out
 
 ./kubevirtci/cluster-up/ssh.sh $node -- sudo bridge vlan show > $vlans_out
+
+dos2unix $vlans_out
 
 tags=$(grep $connection$ -A 1 $vlans_out |sed "s/\t/\n/g" | grep " $vlan " | sed "s/ $vlan *//")
 echo -n $tags


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It uses kubevirtci k8s-1.17 centos8 nodes for that we need update kubevirtci, install correct networkmanger version and adapt parts that are not compatible with centos8

**Special notes for your reviewer**:
Changes that will be done at follow up PRs to have centos8:
- test: Disable dhcp at secondary nics down 
- test: Matching bonding options
- test: Reset secondary nics at test suite start 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
