### PR TITLE
Stabilize master tests

### DIFF
--- a/test/e2e/bonding_default_interface_test.go
+++ b/test/e2e/bonding_default_interface_test.go
@@ -92,7 +92,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 
 		})
 
-		FIt("should successfully move default IP address on top of the bond", func() {
+		It("should successfully move default IP address on top of the bond", func() {
 			var (
 				expectedBond = interfaceByName(interfaces(boundUpWithPrimaryAndSecondary(bond1)), bond1)
 			)

--- a/test/e2e/bonding_default_interface_test.go
+++ b/test/e2e/bonding_default_interface_test.go
@@ -92,15 +92,14 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 
 		})
 
-		It("should successfully move default IP address on top of the bond", func() {
+		FIt("should successfully move default IP address on top of the bond", func() {
 			var (
-				expectedBond  = interfaceByName(interfaces(boundUpWithPrimaryAndSecondary(bond1)), bond1)
-				expectedSpecs = expectedBond["link-aggregation"].(map[string]interface{})
+				expectedBond = interfaceByName(interfaces(boundUpWithPrimaryAndSecondary(bond1)), bond1)
 			)
 
 			By("Checking that bond was configured and obtained the same IP address")
 			for _, node := range nodes {
-				verifyBondIsUpWithPrimaryNicIp(node, expectedBond, expectedSpecs, addressByNode[node])
+				verifyBondIsUpWithPrimaryNicIp(node, expectedBond, addressByNode[node])
 			}
 			// Restart only first node that it master if other node is restarted it will stuck in NotReady state
 			nodeToReboot := nodes[0]
@@ -108,20 +107,13 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			err := restartNode(nodeToReboot)
 			Expect(err).ToNot(HaveOccurred())
 			By(fmt.Sprintf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1))
-			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, expectedSpecs, addressByNode[nodeToReboot])
+			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, addressByNode[nodeToReboot])
 		})
 	})
 })
 
-func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interface{}, expectedSpecs map[string]interface{}, ip string) {
-	interfacesForNode(node).Should(ContainElement(SatisfyAll(
-		HaveKeyWithValue("name", expectedBond["name"]),
-		HaveKeyWithValue("type", expectedBond["type"]),
-		HaveKeyWithValue("state", expectedBond["state"]),
-		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
-		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-		HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{primaryNic, firstSecondaryNic}))),
-	)))
+func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interface{}, ip string) {
+	interfacesForNode(node).Should(ContainElement(matchingBond(expectedBond)))
 
 	Eventually(func() string {
 		return ipv4Address(node, bond1)

--- a/test/e2e/get-bridge-vlans-flags-el8.sh
+++ b/test/e2e/get-bridge-vlans-flags-el8.sh
@@ -9,7 +9,8 @@ vlans_out=/tmp/vlans.out
 
 ./kubevirtci/cluster-up/ssh.sh $node -- sudo bridge vlan show > $vlans_out
 
-dos2unix $vlans_out
+# Remove CR from output
+sed -i 's/\r$//' $vlans_out
 
 tags=$(grep $connection$ -A 1 $vlans_out |sed "s/\t/\n/g" | grep " $vlan " | sed "s/ $vlan *//")
 echo -n $tags

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -44,6 +44,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	prepare(t)
+
+	resetDesiredStateForNodes()
 })
 
 func TestMain(m *testing.M) {

--- a/test/e2e/simple_bridge_and_bond_test.go
+++ b/test/e2e/simple_bridge_and_bond_test.go
@@ -181,12 +181,7 @@ var _ = Describe("NodeNetworkState", func() {
 				)
 
 				for _, node := range nodes {
-					interfacesForNode(node).Should(ContainElement(SatisfyAll(
-						HaveKeyWithValue("name", expectedBond["name"]),
-						HaveKeyWithValue("type", expectedBond["type"]),
-						HaveKeyWithValue("state", expectedBond["state"]),
-						HaveKeyWithValue("link-aggregation", expectedBond["link-aggregation"]),
-					)))
+					interfacesForNode(node).Should(ContainElement(matchingBond(expectedBond)))
 				}
 			})
 		})
@@ -212,12 +207,7 @@ var _ = Describe("NodeNetworkState", func() {
 				)
 				for _, node := range nodes {
 					interfacesForNode(node).Should(SatisfyAll(
-						ContainElement(SatisfyAll(
-							HaveKeyWithValue("name", expectedBond["name"]),
-							HaveKeyWithValue("type", expectedBond["type"]),
-							HaveKeyWithValue("state", expectedBond["state"]),
-							HaveKeyWithValue("link-aggregation", expectedBond["link-aggregation"]),
-						)),
+						ContainElement(matchingBond(expectedBond)),
 						ContainElement(SatisfyAll(
 							HaveKeyWithValue("name", expectedBridge["name"]),
 							HaveKeyWithValue("type", expectedBridge["type"]),
@@ -249,19 +239,11 @@ var _ = Describe("NodeNetworkState", func() {
 			})
 			It("should have the bond interface with 2 slaves at currentState", func() {
 				var (
-					expectedBond  = interfaceByName(interfaces(bondUpWithEth1AndEth2(bond1)), bond1)
-					expectedSpecs = expectedBond["link-aggregation"].(map[string]interface{})
+					expectedBond = interfaceByName(interfaces(bondUpWithEth1AndEth2(bond1)), bond1)
 				)
 
 				for _, node := range nodes {
-					interfacesForNode(node).Should(ContainElement(SatisfyAll(
-						HaveKeyWithValue("name", expectedBond["name"]),
-						HaveKeyWithValue("type", expectedBond["type"]),
-						HaveKeyWithValue("state", expectedBond["state"]),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-						HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{firstSecondaryNic, secondSecondaryNic}))),
-					)))
+					interfacesForNode(node).Should(ContainElement(matchingBond(expectedBond)))
 				}
 			})
 		})
@@ -282,19 +264,11 @@ var _ = Describe("NodeNetworkState", func() {
 				var (
 					expectedBond        = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), bond1)
 					expectedVlanBond102 = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), fmt.Sprintf("%s.102", bond1))
-					expectedSpecs       = expectedBond["link-aggregation"].(map[string]interface{})
 				)
 
 				for _, node := range nodes {
 					interfacesForNode(node).Should(SatisfyAll(
-						ContainElement(SatisfyAll(
-							HaveKeyWithValue("name", expectedBond["name"]),
-							HaveKeyWithValue("type", expectedBond["type"]),
-							HaveKeyWithValue("state", expectedBond["state"]),
-							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("mode", expectedSpecs["mode"])),
-							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("options", expectedSpecs["options"])),
-							HaveKeyWithValue("link-aggregation", HaveKeyWithValue("slaves", ConsistOf([]string{firstSecondaryNic, secondSecondaryNic}))),
-						)),
+						ContainElement(matchingBond(expectedBond)),
 						ContainElement(SatisfyAll(
 							HaveKeyWithValue("name", expectedVlanBond102["name"]),
 							HaveKeyWithValue("type", expectedVlanBond102["type"]),

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -95,12 +95,27 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
 //       to remove this
 func resetDesiredStateForNodes() {
-	states := map[string]string{
-		primaryNic:         "up",
-		firstSecondaryNic:  "down",
-		secondSecondaryNic: "down",
-	}
-	updateDesiredState(ethernetNicsState(states))
+	By("Resetting nics state primary up and secondaries down")
+	updateDesiredState(nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    type: ethernet
+    state: up
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+
+`, primaryNic, firstSecondaryNic, secondSecondaryNic)))
 	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It fixes the e2e test so they are complaing with nmstate 0.2, now nmstate is exposing  more information on linux bonding so we have to match what we want there and also reseting interfaces was not quite working, we have for the reset at the beginning of the test suite and also disable dhcp con secondary nics.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
