### PR TITLE
Release v0.17.0

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,24 +1,11 @@
-v0.16.0
-
-Bump the support NetworkManager version to >= 1.22.
+v0.17.0
 
 Features:
-* Use centos8 nodes (#445)
-* Use centos8 base image (#443)
-* Upgrade operator sdk (#401)
-* bump NetworkManager requirements to 1.22 (#418)
+* Add consistently check at cluster-sync (#448)
+* use cluster scripts (#442)
 
 Bugs:
-* Stabilize master tests (#446)
-* Set nmstatectl 'set' timeout to (defaultGwProbe + apiServerProbe) * 2 (#444)
-* Change webhook port to 54874 (#420)
-* explicitly bring unavailable interfaces up (#422)
-* Upgrade operator sdk (#401)
-* remove user_setup (#419)
-* add missing variables configuring profiling (#414)
-
-Docs:
-* bump NetworkManager requirements to 1.22 (#418)
+* Upgrade kube-admission-webhook lib (#449), fixes race on startup
 
 ```
 docker pull HANDLER_IMAGE

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 var (
-	Version = "0.16.0"
+	Version = "0.17.0"
 )
 
 // * Force release after fixing release.sh


### PR DESCRIPTION
Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

0.16 has a bug when it sometimes fail to start the webhook. We need to release a new version and attach it to CNAO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
