### PR TITLE
Pin nmstate to 0.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:31
 
 RUN sudo dnf install -y dnf-plugins-core && \
-    sudo dnf copr enable -y nmstate/nmstate-0.2 && \
+    sudo dnf copr enable -y nmstate/nmstate-0.1 && \
     sudo dnf install -y -b nmstate iproute iputils && \
     sudo dnf remove -y dnf-plugins-core && \
     sudo dnf clean all

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:31
 
 RUN sudo dnf install -y dnf-plugins-core && \
     sudo dnf copr enable -y nmstate/nmstate-0.2 && \
-    sudo dnf install -y nmstate iproute iputils && \
+    sudo dnf install -y -b nmstate iproute iputils && \
     sudo dnf remove -y dnf-plugins-core && \
     sudo dnf clean all
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We were installing nmstate-0.2 but this depends on NetworkManager 1.22 and we are not suppose to use that on release-0.15

It was not failing because when dnf install is run with multiple package if one is skipped it does not fail and do a fallback to best approach.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
