### PR TITLE
Adapt to external k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ $(CLUSTER_DIR)/%: $(install_kubevirtci)
 	$(install_kubevirtci)
 
 cluster-prepare:
+	hack/label-workers.sh
 	hack/install-ovs.sh
 	hack/install-nm.sh
 	hack/flush-secondary-nics.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 IMAGE_REGISTRY ?= quay.io
 IMAGE_REPO ?= nmstate
+NAMESPACE ?= nmstate
 
 HANDLER_IMAGE_NAME ?= kubernetes-nmstate-handler
 HANDLER_IMAGE_SUFFIX ?=
@@ -21,13 +22,13 @@ export E2E_TEST_TIMEOUT ?= 40m
 e2e_test_args = -singleNamespace=true -test.v -test.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.v -ginkgo.slowSpecThreshold=60 $(E2E_TEST_ARGS)
 
 ifeq ($(findstring k8s,$(KUBEVIRT_PROVIDER)),k8s)
-export PRIMARY_NIC = eth0
-export FIRST_SECONDARY_NIC = eth1
-export SECOND_SECONDARY_NIC = eth2
+export PRIMARY_NIC ?= eth0
+export FIRST_SECONDARY_NIC ?= eth1
+export SECOND_SECONDARY_NIC ?= eth2
 else
-export PRIMARY_NIC = ens3
-export FIRST_SECONDARY_NIC = ens8
-export SECOND_SECONDARY_NIC = ens9
+export PRIMARY_NIC ?= ens3
+export FIRST_SECONDARY_NIC ?= ens8
+export SECOND_SECONDARY_NIC ?= ens9
 endif
 
 BIN_DIR = $(CURDIR)/build/_output/bin/
@@ -115,7 +116,7 @@ test/e2e: $(OPERATOR_SDK)
 	mkdir -p test_logs/e2e
 	unset GOFLAGS && $(OPERATOR_SDK) test local ./test/e2e \
 		--kubeconfig $(KUBECONFIG) \
-		--namespace nmstate \
+		--namespace $(NAMESPACE) \
 		--no-setup \
 		--go-test-flags "$(e2e_test_args)"
 

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -13,7 +13,7 @@ teardown() {
 
 main() {
     export KUBEVIRT_PROVIDER='k8s-1.17.0'
-    export KUBEVIRT_NUM_NODES=2
+    export KUBEVIRT_NUM_NODES=3 # 1 master, 2 workers
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/hack/label-workers.sh
+++ b/hack/label-workers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+script_dir=$(dirname "$(readlink -f "$0")")
+kubectl=$script_dir/../kubevirtci/cluster-up/kubectl.sh
+number_of_nodes=$($kubectl get node  --no-headers |wc -l)
+
+if [ $number_of_nodes -eq 1 ]; then
+    label="node-role.kubernetes.io/master"
+else
+    label="!node-role.kubernetes.io/master"
+fi
+
+$kubectl label node -l $label node-role.kubernetes.io/worker=''

--- a/test/cmd/kubectl.go
+++ b/test/cmd/kubectl.go
@@ -1,5 +1,10 @@
 package cmd
 
+import (
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
+)
+
 func Kubectl(arguments ...string) (string, error) {
-	return Run("./kubevirtci/cluster-up/kubectl.sh", false, arguments...)
+	kubectl := environment.GetVarWithDefault("KUBECTL", "./kubevirtci/cluster-up/kubectl.sh")
+	return Run(kubectl, false, arguments...)
 }

--- a/test/e2e/check-bridge-has-vlans-el8.sh
+++ b/test/e2e/check-bridge-has-vlans-el8.sh
@@ -7,7 +7,7 @@ vlan_max=$4
 vlans_out=/tmp/vlans.out
 
 echo "Dumping bridge vlans to $vlans_out"
-./kubevirtci/cluster-up/ssh.sh $node -- sudo bridge vlan show > $vlans_out
+$(SSH) $node -- sudo bridge vlan show > $vlans_out
 
 echo "Checking vlan range $vlan_min-$vlan_max at $connection"
 for vlan in $(seq $vlan_min $vlan_max); do

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -98,7 +98,7 @@ func policyConditionsStatus(policyName string) nmstatev1alpha1.ConditionList {
 func policyConditionsStatusForPolicyEventually(policy string) AsyncAssertion {
 	return Eventually(func() nmstatev1alpha1.ConditionList {
 		return policyConditionsStatus(policy)
-	}, 180*time.Second, 1*time.Second)
+	}, 480*time.Second, 1*time.Second)
 }
 
 func policyConditionsStatusForPolicyConsistently(policy string) AsyncAssertion {

--- a/test/e2e/demos_test.go
+++ b/test/e2e/demos_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
 )
 
 func kubectlAndCheck(command ...string) {
@@ -17,7 +18,7 @@ func kubectlAndCheck(command ...string) {
 }
 
 func skipIfNotKubernetes() {
-	provider := getEnv("KUBEVIRT_PROVIDER", "k8s")
+	provider := environment.GetVarWithDefault("KUBEVIRT_PROVIDER", "k8s")
 	if !strings.Contains(provider, "k8s") {
 		Skip("Tutorials use interface naming that is available only on Kubernetes providers")
 	}

--- a/test/e2e/get-bridge-vlans-flags-el8.sh
+++ b/test/e2e/get-bridge-vlans-flags-el8.sh
@@ -5,7 +5,7 @@ connection=$2
 vlan=$3
 vlans_out=/tmp/vlans.out
 
-./kubevirtci/cluster-up/ssh.sh $node -- sudo bridge vlan show > $vlans_out
+$(SSH) $node -- sudo bridge vlan show > $vlans_out
 
 tags=$(grep $connection$ -A 1 $vlans_out |sed "s/\t/\n/g" | grep " $vlan " | sed "s/ $vlan *//")
 echo -n $tags

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,6 +20,7 @@ import (
 
 	apis "github.com/nmstate/kubernetes-nmstate/pkg/apis"
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
 	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
 )
 
@@ -49,18 +50,10 @@ var _ = BeforeSuite(func() {
 })
 
 func TestMain(m *testing.M) {
-	primaryNic = getEnv("PRIMARY_NIC", "eth0")
-	firstSecondaryNic = getEnv("FIRST_SECONDARY_NIC", "eth1")
-	secondSecondaryNic = getEnv("SECOND_SECONDARY_NIC", "eth2")
+	primaryNic = environment.GetVarWithDefault("PRIMARY_NIC", "eth0")
+	firstSecondaryNic = environment.GetVarWithDefault("FIRST_SECONDARY_NIC", "eth1")
+	secondSecondaryNic = environment.GetVarWithDefault("SECOND_SECONDARY_NIC", "eth2")
 	framework.MainEntry(m)
-}
-
-func getEnv(name string, defaultValue string) string {
-	value := os.Getenv(name)
-	if len(value) == 0 {
-		value = defaultValue
-	}
-	return value
 }
 
 func TestE2E(tapi *testing.T) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -62,7 +62,8 @@ func TestE2E(tapi *testing.T) {
 
 	By("Getting node list from cluster")
 	nodeList := corev1.NodeList{}
-	err := framework.Global.Client.List(context.TODO(), &nodeList, &dynclient.ListOptions{})
+	filterWorkers := dynclient.MatchingLabels{"node-role.kubernetes.io/worker": ""}
+	err := framework.Global.Client.List(context.TODO(), &nodeList, filterWorkers)
 	Expect(err).ToNot(HaveOccurred())
 	for _, node := range nodeList.Items {
 		nodes = append(nodes, node.Name)

--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -75,6 +75,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				node := nodes[i]
 				go func() {
 					defer wg.Done()
+					defer GinkgoRecover()
 					By(fmt.Sprintf("Check %s progressing state is reached", node))
 					enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
 

--- a/test/e2e/openshift.cnv.workflow.sh
+++ b/test/e2e/openshift.cnv.workflow.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -xe
+
+# Configure kubeconfig
+export KUBECONFIG=${KUBECONFIG:-$HOME/oc4/working/auth/kubeconfig}
+export KUBECTL=${KUBECTL:-oc}
+export NAMESPACE=${NAMESPACE:-openshift-cnv}
+export SSH=${SSH:-./ssh.sh}
+export PRIMARY_NIC=${PRIMARY_NIC:-ens3}
+export FIRST_SECONDARY_NIC=${FIRST_SECONDARY_NIC:-ens7}
+export SECOND_SECONDARY_NIC=${SECOND_SECONDARY_NIC:-ens8}
+export TIMEOUT=${TIMEOUT:-60m}
+
+if [ ! -f  $SSH ]; then
+    cat << EOF > ${SSH}
+#!/bin/bash
+node_name=\${1}
+node_ip=\$($KUBECTL get node \${node_name} --no-headers -o wide | awk '{print \$6}')
+ssh core@\${node_ip} -- \${@:3}
+EOF
+    chmod +x ${SSH}
+fi
+
+# Run workflow tests
+FOCUS_1='Nodes.*when.*are.*up.*and.*new.*interface.*is.*configured.*should.*update.*node.*network.*state.*with.*it'
+FOCUS_2='rollback.*when.*connectivity.*to.*default.*gw.*is.*lost.*after.*state.*configuration.*should.*rollback.*to.*a.*good.*gw.*configuration'
+FOCUS_3='NodeSelector.*when.*policy.*is.*set.*with.*node.*selector.*not.*matching.*any.*nodes.*should.*not.*update.*any.*nodes.*and.*have.*false.*Matching.*state'
+FOCUS_4='EnactmentCondition.*when.*applying.*valid.*config.*should.*go.*from.*Progressing.*to.*Available'
+make test/e2e E2E_TEST_TIMEOUT=${TIMEOUT} E2E_TEST_ARGS="-ginkgo.focus $FOCUS_1|$FOCUS_2|$FOCUS_3|$FOCUS_4" NAMESPACE=$NAMESPACE KUBECONFIG=$KUBECONFIG

--- a/test/e2e/openshift.cnv.workflow.sh
+++ b/test/e2e/openshift.cnv.workflow.sh
@@ -23,8 +23,5 @@ EOF
 fi
 
 # Run workflow tests
-FOCUS_1='Nodes.*when.*are.*up.*and.*new.*interface.*is.*configured.*should.*update.*node.*network.*state.*with.*it'
-FOCUS_2='rollback.*when.*connectivity.*to.*default.*gw.*is.*lost.*after.*state.*configuration.*should.*rollback.*to.*a.*good.*gw.*configuration'
-FOCUS_3='NodeSelector.*when.*policy.*is.*set.*with.*node.*selector.*not.*matching.*any.*nodes.*should.*not.*update.*any.*nodes.*and.*have.*false.*Matching.*state'
-FOCUS_4='EnactmentCondition.*when.*applying.*valid.*config.*should.*go.*from.*Progressing.*to.*Available'
-make test/e2e E2E_TEST_TIMEOUT=${TIMEOUT} E2E_TEST_ARGS="-ginkgo.focus $FOCUS_1|$FOCUS_2|$FOCUS_3|$FOCUS_4" NAMESPACE=$NAMESPACE KUBECONFIG=$KUBECONFIG
+focus='test_id:3796|test_id:3795|test_id:3813|test_id:3794|test_id:3793'
+make test/e2e E2E_TEST_TIMEOUT=${TIMEOUT} E2E_TEST_ARGS="-ginkgo.focus $focus" NAMESPACE=$NAMESPACE KUBECONFIG=$KUBECONFIG

--- a/test/e2e/openshift.cnv.workflow.sh
+++ b/test/e2e/openshift.cnv.workflow.sh
@@ -24,4 +24,4 @@ fi
 
 # Run workflow tests
 focus='test_id:3796|test_id:3795|test_id:3813|test_id:3794|test_id:3793'
-make test/e2e E2E_TEST_TIMEOUT=${TIMEOUT} E2E_TEST_ARGS="-ginkgo.focus $focus" NAMESPACE=$NAMESPACE KUBECONFIG=$KUBECONFIG
+make test/e2e E2E_TEST_TIMEOUT=${TIMEOUT} E2E_TEST_ARGS="-ginkgo.noColor -ginkgo.focus $focus" NAMESPACE=$NAMESPACE KUBECONFIG=$KUBECONFIG

--- a/test/e2e/prepare.go
+++ b/test/e2e/prepare.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +45,12 @@ func waitForDaemonSets(t *testing.T, kubeclient kubernetes.Interface, namespace 
 			return true, errors.Wrapf(err, "failed retrieving daemon sets for namespace %s", namespace)
 		}
 		for _, daemonset := range daemonsets.Items {
+			// we don't have the app=kubernetes-nmstate labels at daemonsets so we
+			// filter by name
+			if !strings.Contains(daemonset.Name, "nmstate") {
+				continue
+			}
+			By(fmt.Sprintf("Checking daemonset %s", daemonset.Name))
 			if daemonset.Status.DesiredNumberScheduled != daemonset.Status.NumberAvailable {
 				return false, nil
 			}

--- a/test/e2e/rollback_test.go
+++ b/test/e2e/rollback_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
 			Eventually(func() bool {
 				return dhcpFlag(nodes[0], primaryNic)
-			}, ReadTimeout, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
+			}, 480*time.Second, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
 
 			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
 			Consistently(func() bool {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -80,7 +80,8 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstatev
 }
 
 func setDesiredStateWithPolicy(name string, desiredState nmstatev1alpha1.State) {
-	setDesiredStateWithPolicyAndNodeSelector(name, desiredState, map[string]string{})
+	runAtWorkers := map[string]string{"node-role.kubernetes.io/worker": ""}
+	setDesiredStateWithPolicyAndNodeSelector(name, desiredState, runAtWorkers)
 }
 
 func updateDesiredState(desiredState nmstatev1alpha1.State) {

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -1,0 +1,13 @@
+package environment
+
+import (
+	"os"
+)
+
+func GetVarWithDefault(name string, defaultValue string) string {
+	value := os.Getenv(name)
+	if len(value) == 0 {
+		value = defaultValue
+	}
+	return value
+}

--- a/test/runner/node.go
+++ b/test/runner/node.go
@@ -4,12 +4,14 @@ import (
 	"strings"
 
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
 )
 
 func runAtNodeWithExtras(node string, quiet bool, command ...string) (string, error) {
 	ssh_command := []string{node, "--"}
 	ssh_command = append(ssh_command, command...)
-	output, err := cmd.Run("./kubevirtci/cluster-up/ssh.sh", quiet, ssh_command...)
+	ssh := environment.GetVarWithDefault("SSH", "./kubevirtci/cluster-up/ssh.sh")
+	output, err := cmd.Run(ssh, quiet, ssh_command...)
 	// Remove first two lines from output, ssh.sh add garbage there
 	outputLines := strings.Split(output, "\n")
 	if len(outputLines) > 2 {

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -21,6 +21,9 @@ func RunAtPods(arguments ...string) {
 	nmstatePods, err := nmstatePods()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	for _, nmstatePod := range nmstatePods {
+		if ! strings.Contains(nmstatePod, "worker") {
+			continue
+		}
 		exec := []string{"exec", "-n", framework.Global.Namespace, nmstatePod, "--"}
 		execArguments := append(exec, arguments...)
 		_, err := cmd.Kubectl(execArguments...)

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -11,7 +11,7 @@ import (
 )
 
 func nmstatePods() ([]string, error) {
-	output, err := cmd.Kubectl("get", "pod", "-n", framework.Global.Namespace, "--no-headers=true", "-o", "custom-columns=:metadata.name")
+	output, err := cmd.Kubectl("get", "pod", "-n", framework.Global.Namespace, "--no-headers=true", "-o", "custom-columns=:metadata.name", "-l", "app=kubernetes-nmstate")
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	names := strings.Split(strings.TrimSpace(output), "\n")
 	return names, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR add needed changes to test kubernetes-nmstate e2e tests at an external cluster, with kubernetes-nmstate being deployed as part of other deployments like HCO.

We have found a pair of bugs running this at external system:

- Calculate policy conditions counting nodes running nmstate pod.: - https://github.com/nmstate/kubernetes-nmstate/issues/473
- Race condition between rollback checks and Node state: https://github.com/nmstate/kubernetes-nmstate/issues/474
- Bad log at policy condition success: https://github.com/nmstate/kubernetes-nmstate/issues/475
- app label missing at daemonset : https://github.com/nmstate/kubernetes-nmstate/issues/476

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
