### PR TITLE
Add abiltity to specify which image builder to use in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ HANDLER_IMAGE ?= $(IMAGE_REGISTRY)/$(HANDLER_IMAGE_FULL_NAME)
 
 NAMESPACE ?= nmstate
 PULL_POLICY ?= Always
+IMAGE_BUILDER ?= docker
 
 WHAT ?= ./pkg
 
@@ -102,9 +103,9 @@ manifests:
 	$(GO) run hack/render-manifests.go $(NAMESPACE) $(HANDLER_IMAGE) $(PULL_POLICY) deploy/ $(MANIFESTS_DIR)
 
 handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK) manifests
-	$(OPERATOR_SDK) build $(HANDLER_IMAGE)
+	$(OPERATOR_SDK) build $(HANDLER_IMAGE) --image-builder $(IMAGE_BUILDER)
 push-handler: handler
-	docker push $(HANDLER_IMAGE)
+	$(IMAGE_BUILDER) push $(HANDLER_IMAGE)
 
 test/unit: $(GINKGO)
 	INTERFACES_FILTER="" NODE_NAME=node01 $(GINKGO) $(unit_test_args) $(WHAT)


### PR DESCRIPTION
By setting IMAGE_BUILDER=podman, one can use podman instead of the
default docker as the image builder and pusher.

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds the ability to specify which image builder one would like to use. The default remains docker, but allows for a podman workflow.
**Special notes for your reviewer**:
If you run, e.g., make push-handler IMAGE_BUILDER=podman, it will use podman instead of docker.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
