### PR TITLE
WIP enable OVS tests again

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -12,11 +12,18 @@ if [[ "$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$$ ]]; then \
 fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ k8s- ]]; then
+    echo 'Install Open vSwitch on nodes'
+    for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
+        ./cluster/cli.sh ssh ${node} sudo -- yum install -y http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-devel-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/dpdk/17.11/3.el7/x86_64/dpdk-17.11-3.el7.x86_64.rpm
+        ./cluster/cli.sh ssh ${node} sudo -- systemctl daemon-reload
+        ./cluster/cli.sh ssh ${node} sudo -- systemctl restart openvswitch
+    done
+
     echo 'Install NetworkManager on nodes'
     for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
         ./cluster/cli.sh ssh ${node} sudo -- yum install -y yum-plugin-copr
         ./cluster/cli.sh ssh ${node} sudo -- yum copr enable -y networkmanager/NetworkManager-1.22
-        ./cluster/cli.sh ssh ${node} sudo -- yum install -y NetworkManager
+        ./cluster/cli.sh ssh ${node} sudo -- yum install -y NetworkManager NetworkManager-ovs
         ./cluster/cli.sh ssh ${node} sudo -- systemctl daemon-reload
         ./cluster/cli.sh ssh ${node} sudo -- systemctl restart NetworkManager
         echo "Check NetworkManager is working fine on node $node"

--- a/test/e2e/simple_ovs_bridge_test.go
+++ b/test/e2e/simple_ovs_bridge_test.go
@@ -5,9 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//FIXME: OVS bridge functionality at nmstate is unstable
-//       let's activate this again when that is fix
-var _ = PDescribe("Simple OVS bridge [pending cause nmstate bug -> https://bugzilla.redhat.com/show_bug.cgi?id=1724901]", func() {
+var _ = Describe("Simple OVS bridge", func() {
 	Context("when desiredState is configured with an ovs bridge up", func() {
 		BeforeEach(func() {
 			updateDesiredState(ovsBrUp(bridge1))


### PR DESCRIPTION
**What this PR does / why we need it**:

Now with the OVS issues fixed on NetworkManager 1.22, we can start testing it again.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Reintroduce OVS support.
```
