### PR TITLE
Stabilize 0.15 tests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -44,6 +44,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	prepare(t)
+
+	resetDesiredStateForNodes()
 })
 
 func TestMain(m *testing.M) {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -95,12 +95,27 @@ func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
 //       to remove this
 func resetDesiredStateForNodes() {
-	states := map[string]string{
-		primaryNic:         "up",
-		firstSecondaryNic:  "down",
-		secondSecondaryNic: "down",
-	}
-	updateDesiredState(ethernetNicsState(states))
+	By("Resetting nics state primary up and secondaries down")
+	updateDesiredState(nmstatev1alpha1.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    type: ethernet
+    state: up
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+  - name: %s
+    type: ethernet
+    state: down
+    ipv4:
+      dhcp: false
+    ipv6:
+      dhcp: false
+
+`, primaryNic, firstSecondaryNic, secondSecondaryNic)))
 	waitForAvailableTestPolicy()
 	deletePolicy(TestPolicy)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The release-0.15 branch was missing some test stabilization commits from the PR https://github.com/nmstate/kubernetes-nmstate/pull/446, this PR add the pair of missing commits about disable dhcp at secondary nics it was interfering with secondary nics reset:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
