### PR TITLE
Count only nodes knmstate pods at policy conditions calculation

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -73,6 +73,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
   - nodes
   - namespaces
   verbs:


### PR DESCRIPTION
…alculation

Closes #473

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Sometimes some nodes are NotReady temporally while they are configured or they
are ready but nmstate pod is not running for some reason.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The nncp conditions calculations take now into account the nodes running nmstate pod instead of readiness
```
