### PR TITLE
test: Don't use 'sleep 5' at vlan-filtering script

### DIFF
--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
-	runner "github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
 func invalidConfig(bridgeName string) nmstatev1alpha1.State {
@@ -24,15 +23,8 @@ func invalidConfig(bridgeName string) nmstatev1alpha1.State {
 var _ = Describe("EnactmentCondition", func() {
 	Context("when applying valid config", func() {
 		BeforeEach(func() {
-			By("Add some sleep time to vlan-filtering")
-			runner.RunAtPods("cp", "/usr/local/bin/vlan-filtering", "/usr/local/bin/vlan-filtering.bak")
-			runner.RunAtPods("sed", "-i", "$ a\\sleep 5", "/usr/local/bin/vlan-filtering")
-			updateDesiredState(linuxBrUp(bridge1))
 		})
 		AfterEach(func() {
-			By("Restore original vlan-filtering")
-			runner.RunAtPods("mv", "/usr/local/bin/vlan-filtering.bak", "/usr/local/bin/vlan-filtering")
-
 			By("Remove the bridge")
 			updateDesiredState(linuxBrAbsent(bridge1))
 			waitForAvailableTestPolicy()
@@ -93,7 +85,12 @@ var _ = Describe("EnactmentCondition", func() {
 					enactmentConditionsStatusConsistently(node).Should(ConsistOf(availableConditions))
 				}()
 			}
+			// Run the policy after we set the nnce conditions assert so we
+			// make sure we catch progressing state.
+			updateDesiredState(linuxBrUp(bridge1))
+
 			wg.Wait()
+
 			By("Check policy is at available state")
 			waitForAvailableTestPolicy()
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The nnce e2e tests were adding a artifical 5 seconds delay by
adding a `sleep 5` command at vlan-filtering script from
kubernetes-nmstate-handler pod, this is very intrusive and
something can go wrong if AfterEach is not run.

To replace this mechanism, just starting the nnce conditions assert
just before applying the policy (they are running with goroutines) we
should be good enough to catch progressing condition.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
