### PR TITLE
Add node ready state probe

### DIFF
--- a/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
+++ b/pkg/controller/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_controller.go
@@ -197,7 +197,7 @@ func (r *ReconcileNodeNetworkConfigurationPolicy) Reconcile(request reconcile.Re
 	enactmentConditions.NotifyMatching()
 
 	enactmentConditions.NotifyProgressing()
-	nmstateOutput, err := nmstate.ApplyDesiredState(instance.Spec.DesiredState)
+	nmstateOutput, err := nmstate.ApplyDesiredState(r.client, instance.Spec.DesiredState)
 	if err != nil {
 		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s, %v", nmstateOutput, err)
 

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -13,17 +13,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	yaml "sigs.k8s.io/yaml"
-
-	"github.com/tidwall/gjson"
 
 	"github.com/gobwas/glob"
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
+	"github.com/nmstate/kubernetes-nmstate/pkg/probe"
 )
 
 var (
@@ -129,96 +126,6 @@ func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1alpha1.
 	return nil
 }
 
-func ping(target string, timeout time.Duration) (string, error) {
-	output := ""
-	return output, wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		cmd := exec.Command("ping", "-c", "1", target)
-		var outputBuffer bytes.Buffer
-		cmd.Stdout = &outputBuffer
-		cmd.Stderr = &outputBuffer
-		err := cmd.Run()
-		output = fmt.Sprintf("cmd output: '%s'", outputBuffer.String())
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func checkApiServerConnectivity(timeout time.Duration) error {
-	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		// Create new custom client to bypass cache [1]
-		// [1] https://github.com/operator-framework/operator-sdk/blob/master/doc/user/client.md#non-default-client
-		config, err := config.GetConfig()
-		if err != nil {
-			return false, errors.Wrap(err, "getting config")
-		}
-		// Since we are going to retrieve Nodes default schema is good
-		// enough, also align timeout with poll
-		config.Timeout = timeout
-		client, err := client.New(config, client.Options{})
-		if err != nil {
-			log.Error(err, "failed to creating new custom client")
-			return false, nil
-		}
-		err = client.Get(context.TODO(), types.NamespacedName{Name: metav1.NamespaceDefault}, &corev1.Namespace{})
-		if err != nil {
-			log.Error(err, "failed reaching the apiserver")
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func defaultGw() (string, error) {
-	defaultGw := ""
-	return defaultGw, wait.PollImmediate(1*time.Second, defaultGwRetrieveTimeout, func() (bool, error) {
-		observedStateRaw, err := nmstatectl.Show()
-		if err != nil {
-			log.Error(err, fmt.Sprintf("failed retrieving current state"))
-			return false, nil
-		}
-
-		currentState, err := yaml.YAMLToJSON([]byte(observedStateRaw))
-		if err != nil {
-			return false, errors.Wrap(err, "failed to convert current state to JSON")
-		}
-
-		defaultGw = gjson.ParseBytes(currentState).
-			Get("routes.running.#(destination==\"0.0.0.0/0\").next-hop-address").String()
-		if defaultGw == "" {
-			log.Info("default gw missing", "state", string(currentState))
-			return false, nil
-		}
-
-		return true, nil
-	})
-}
-
-func runProbes() error {
-	defaultGw, err := defaultGw()
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve default gw at runProbes")
-	}
-
-	currentState, err := nmstatectl.Show()
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve currentState at runProbes")
-	}
-
-	// TODO: Make ping timeout configurable with a config map
-	pingOutput, err := ping(defaultGw, defaultGwProbeTimeout)
-	if err != nil {
-		return errors.Wrapf(err, "error pinging external address after network reconfiguration -> output: %s, currentState: %s", pingOutput, currentState)
-	}
-
-	err = checkApiServerConnectivity(apiServerProbeTimeout)
-	if err != nil {
-		return errors.Wrapf(err, "error checking api server connectivity after network reconfiguration -> currentState: %s", currentState)
-	}
-	return nil
-}
-
 func rollback(cause error) error {
 	err := nmstatectl.Rollback(cause)
 	if err != nil {
@@ -226,7 +133,7 @@ func rollback(cause error) error {
 	}
 
 	// wait for system to settle after rollback
-	probesErr := runProbes()
+	probesErr := probe.RunAll()
 	if probesErr != nil {
 		return errors.Wrap(err, "failed running probes after rollback")
 	}
@@ -265,7 +172,7 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		}
 	}
 
-	err = runProbes()
+	err = probe.RunAll()
 	if err != nil {
 		return "", rollback(errors.Wrap(err, "failed runnig probes after network changes"))
 	}

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -126,21 +126,21 @@ func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1alpha1.
 	return nil
 }
 
-func rollback(cause error) error {
+func rollback(client client.Client, cause error) error {
 	err := nmstatectl.Rollback(cause)
 	if err != nil {
 		return errors.Wrap(err, "failed to do rollback")
 	}
 
 	// wait for system to settle after rollback
-	probesErr := probe.RunAll()
+	probesErr := probe.RunAll(client)
 	if probesErr != nil {
 		return errors.Wrap(err, "failed running probes after rollback")
 	}
 	return nil
 }
 
-func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
+func ApplyDesiredState(client client.Client, desiredState nmstatev1alpha1.State) (string, error) {
 	if len(string(desiredState.Raw)) == 0 {
 		return "Ignoring empty desired state", nil
 	}
@@ -160,7 +160,7 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 	// set
 	bridgesUpWithPorts, err := getBridgesUp(desiredState)
 	if err != nil {
-		return "", rollback(fmt.Errorf("error retrieving up bridges from desired state"))
+		return "", rollback(client, fmt.Errorf("error retrieving up bridges from desired state"))
 	}
 
 	commandOutput := ""
@@ -168,13 +168,13 @@ func ApplyDesiredState(desiredState nmstatev1alpha1.State) (string, error) {
 		outputVlanFiltering, err := applyVlanFiltering(bridge, ports)
 		commandOutput += fmt.Sprintf("bridge %s ports %v applyVlanFiltering command output: %s\n", bridge, ports, outputVlanFiltering)
 		if err != nil {
-			return commandOutput, rollback(err)
+			return commandOutput, rollback(client, err)
 		}
 	}
 
-	err = probe.RunAll()
+	err = probe.RunAll(client)
 	if err != nil {
-		return "", rollback(errors.Wrap(err, "failed runnig probes after network changes"))
+		return "", rollback(client, errors.Wrap(err, "failed runnig probes after network changes"))
 	}
 
 	commitOutput, err := nmstatectl.Commit()

--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -1,0 +1,123 @@
+package probe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
+)
+
+var (
+	log = logf.Log.WithName("probe")
+)
+
+const (
+	defaultGwRetrieveTimeout = 120 * time.Second
+	defaultGwProbeTimeout    = 120 * time.Second
+	apiServerProbeTimeout    = 120 * time.Second
+)
+
+func ping(target string, timeout time.Duration) (string, error) {
+	output := ""
+	return output, wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		cmd := exec.Command("ping", "-c", "1", target)
+		var outputBuffer bytes.Buffer
+		cmd.Stdout = &outputBuffer
+		cmd.Stderr = &outputBuffer
+		err := cmd.Run()
+		output = fmt.Sprintf("cmd output: '%s'", outputBuffer.String())
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func checkApiServerConnectivity(timeout time.Duration) error {
+	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		// Create new custom client to bypass cache [1]
+		// [1] https://github.com/operator-framework/operator-sdk/blob/master/doc/user/client.md#non-default-client
+		config, err := config.GetConfig()
+		if err != nil {
+			return false, errors.Wrap(err, "getting config")
+		}
+		// Since we are going to retrieve Nodes default schema is good
+		// enough, also align timeout with poll
+		config.Timeout = timeout
+		client, err := client.New(config, client.Options{})
+		if err != nil {
+			log.Error(err, "failed to creating new custom client")
+			return false, nil
+		}
+		err = client.Get(context.TODO(), types.NamespacedName{Name: metav1.NamespaceDefault}, &corev1.Namespace{})
+		if err != nil {
+			log.Error(err, "failed reaching the apiserver")
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func defaultGw() (string, error) {
+	defaultGw := ""
+	return defaultGw, wait.PollImmediate(1*time.Second, defaultGwRetrieveTimeout, func() (bool, error) {
+		observedStateRaw, err := nmstatectl.Show()
+		if err != nil {
+			log.Error(err, fmt.Sprintf("failed retrieving current state"))
+			return false, nil
+		}
+
+		currentState, err := yaml.YAMLToJSON([]byte(observedStateRaw))
+		if err != nil {
+			return false, errors.Wrap(err, "failed to convert current state to JSON")
+		}
+
+		defaultGw = gjson.ParseBytes(currentState).
+			Get("routes.running.#(destination==\"0.0.0.0/0\").next-hop-address").String()
+		if defaultGw == "" {
+			log.Info("default gw missing", "state", string(currentState))
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+func RunAll() error {
+	defaultGw, err := defaultGw()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve default gw at runProbes")
+	}
+
+	currentState, err := nmstatectl.Show()
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve currentState at runProbes")
+	}
+
+	// TODO: Make ping timeout configurable with a config map
+	pingOutput, err := ping(defaultGw, defaultGwProbeTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "error pinging external address after network reconfiguration -> output: %s, currentState: %s", pingOutput, currentState)
+	}
+
+	err = checkApiServerConnectivity(apiServerProbeTimeout)
+	if err != nil {
+		return errors.Wrapf(err, "error checking api server connectivity after network reconfiguration -> currentState: %s", currentState)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a race condition between rollback and node ready state, since we are counting ready nodes to calculate policy conditions.

This PR add a new probe that check/wait for the node to be ready after desired state is apply and rollback otherwise (and also check back node ready) if is not ready.

Closes #474

**Special notes for your reviewer**:
It also contains at different commit a little refactoring that moves all the probes we use at `pkg/probe` module.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
After desiredState is apply handler will wait for node to be ready in case the config change that.
```
