### PR TITLE
Run e2e test at workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WHAT ?= ./pkg
 unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
 
 export KUBEVIRT_PROVIDER ?= k8s-1.17
-export KUBEVIRT_NUM_NODES ?= 1
+export KUBEVIRT_NUM_NODES ?= 2 # 1 master, 1 worker needed for e2e tests
 export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 
 export E2E_TEST_TIMEOUT ?= 40m

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -16,7 +16,7 @@ teardown() {
 
 main() {
     export KUBEVIRT_PROVIDER='k8s-1.17'
-    export KUBEVIRT_NUM_NODES=2
+    export KUBEVIRT_NUM_NODES=3 # 1 master, 2 workers
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -1,6 +1,6 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
 
-KUBEVIRTCI_VERSION='b06adadeffcbb425c15e0388250e5211db0eae49'
+KUBEVIRTCI_VERSION='0c35d765924aecc540fed9bf44937db760618b1a'
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -98,7 +98,7 @@ func policyConditionsStatus(policyName string) nmstatev1alpha1.ConditionList {
 func policyConditionsStatusForPolicyEventually(policy string) AsyncAssertion {
 	return Eventually(func() nmstatev1alpha1.ConditionList {
 		return policyConditionsStatus(policy)
-	}, 180*time.Second, 1*time.Second)
+	}, 480*time.Second, 1*time.Second)
 }
 
 func policyConditionsStatusForPolicyConsistently(policy string) AsyncAssertion {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -69,7 +69,8 @@ func TestE2E(tapi *testing.T) {
 
 	By("Getting node list from cluster")
 	nodeList := corev1.NodeList{}
-	err := framework.Global.Client.List(context.TODO(), &nodeList, &dynclient.ListOptions{})
+	filterWorkers := dynclient.MatchingLabels{"node-role.kubernetes.io/worker": ""}
+	err := framework.Global.Client.List(context.TODO(), &nodeList, filterWorkers)
 	Expect(err).ToNot(HaveOccurred())
 	for _, node := range nodeList.Items {
 		nodes = append(nodes, node.Name)

--- a/test/e2e/nnce_conditions_test.go
+++ b/test/e2e/nnce_conditions_test.go
@@ -75,6 +75,7 @@ var _ = Describe("EnactmentCondition", func() {
 				node := nodes[i]
 				go func() {
 					defer wg.Done()
+					defer GinkgoRecover()
 					By(fmt.Sprintf("Check %s progressing state is reached", node))
 					enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
 

--- a/test/e2e/prepare.go
+++ b/test/e2e/prepare.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +45,12 @@ func waitForDaemonSets(t *testing.T, kubeclient kubernetes.Interface, namespace 
 			return true, errors.Wrapf(err, "failed retrieving daemon sets for namespace %s", namespace)
 		}
 		for _, daemonset := range daemonsets.Items {
+			// we don't have the app=kubernetes-nmstate labels at daemonsets so we
+			// filter by name
+			if !strings.Contains(daemonset.Name, "nmstate") {
+				continue
+			}
+			By(fmt.Sprintf("Checking daemonset %s", daemonset.Name))
 			if daemonset.Status.DesiredNumberScheduled != daemonset.Status.NumberAvailable {
 				return false, nil
 			}

--- a/test/e2e/rollback_test.go
+++ b/test/e2e/rollback_test.go
@@ -81,7 +81,7 @@ var _ = Describe("rollback", func() {
 			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
 			Eventually(func() bool {
 				return dhcpFlag(nodes[0], primaryNic)
-			}, ReadTimeout, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
+			}, 480*time.Second, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
 
 			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
 			Consistently(func() bool {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -81,7 +81,8 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstatev
 }
 
 func setDesiredStateWithPolicy(name string, desiredState nmstatev1alpha1.State) {
-	setDesiredStateWithPolicyAndNodeSelector(name, desiredState, map[string]string{})
+	runAtWorkers := map[string]string{"node-role.kubernetes.io/worker": ""}
+	setDesiredStateWithPolicyAndNodeSelector(name, desiredState, runAtWorkers)
 }
 
 func updateDesiredState(desiredState nmstatev1alpha1.State) {

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -21,6 +21,9 @@ func RunAtPods(arguments ...string) {
 	nmstatePods, err := nmstatePods()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	for _, nmstatePod := range nmstatePods {
+		if ! strings.Contains(nmstatePod, "worker") {
+			continue
+		}
 		exec := []string{"exec", "-n", framework.Global.Namespace, nmstatePod, "--"}
 		execArguments := append(exec, arguments...)
 		_, err := cmd.Kubectl(execArguments...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
At release-0.15 branch we are starting to test for external system and running e2e tests only at workers, this PR do this at master so we discover same issues that we have found there.

https://github.com/nmstate/kubernetes-nmstate/pull/465

**Special notes for your reviewer**:
The rollback test is expected to fail, so we fix it at master on the product not the test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The e2e tests now run at workers and skipping master.
```
