### PR TITLE
Ensure probes are run after success nmstatectl rollback

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -127,17 +127,18 @@ func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1alpha1.
 }
 
 func rollback(client client.Client, cause error) error {
-	err := nmstatectl.Rollback(cause)
+	message := fmt.Sprintf("rolling back desired state configuration: %s", cause)
+	err := nmstatectl.Rollback()
 	if err != nil {
-		return errors.Wrap(err, "failed to do rollback")
+		return errors.Wrap(err, message)
 	}
 
 	// wait for system to settle after rollback
 	probesErr := probe.RunAll(client)
 	if probesErr != nil {
-		return errors.Wrap(err, "failed running probes after rollback")
+		return errors.Wrap(errors.Wrap(err, "failed running probes after rollback"), message)
 	}
-	return nil
+	return errors.New(message)
 }
 
 func ApplyDesiredState(client client.Client, desiredState nmstatev1alpha1.State) (string, error) {

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -69,11 +69,10 @@ func Commit() (string, error) {
 	return nmstatectl([]string{"commit"})
 }
 
-func Rollback(cause error) error {
-	message := "rollback cause: %v"
+func Rollback() error {
 	_, err := nmstatectl([]string{"rollback"})
 	if err != nil {
-		return errors.Wrapf(err, message, cause)
+		return errors.Wrapf(err, "failed calling nmstatectl rollback")
 	}
-	return fmt.Errorf(message, cause)
+	return nil
 }


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Running some e2e test at release-0.15 branch just at workers with
3 nodes (1 master and 2 workers) [1] we found a defect at post rollback
probes, knmstate was always failing after calling nmstatectl rollback so
so post rollback probes were never executed.

[1] https://github.com/nmstate/kubernetes-nmstate/pull/465

Closes #482

**Special notes for your reviewer**:
Master PR to run e2e tests at workers (rollback test should be failing there) https://github.com/nmstate/kubernetes-nmstate/pull/483

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bug: post rollback probes were not being executed.
```
