### PR TITLE
Introduce a prefix for manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ HANDLER_IMAGE_NAME ?= kubernetes-nmstate-handler
 HANDLER_IMAGE_SUFFIX ?=
 HANDLER_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(HANDLER_IMAGE_NAME)$(HANDLER_IMAGE_SUFFIX)
 HANDLER_IMAGE ?= $(IMAGE_REGISTRY)/$(HANDLER_IMAGE_FULL_NAME)
+HANDLER_PREFIX ?=
 
 NAMESPACE ?= nmstate
 PULL_POLICY ?= Always
@@ -100,7 +101,7 @@ gen-crds: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate crds
 
 manifests:
-	$(GO) run hack/render-manifests.go $(NAMESPACE) $(HANDLER_IMAGE) $(PULL_POLICY) deploy/ $(MANIFESTS_DIR)
+	$(GO) run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(NAMESPACE) -handler-image=$(HANDLER_IMAGE) -handler-pull-policy=$(PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK) manifests
 	$(OPERATOR_SDK) build $(HANDLER_IMAGE) --image-builder $(IMAGE_BUILDER)

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Namespace }}
+  name: {{ .HandlerNamespace }}
   labels:
-    name: {{ .Namespace }}
+    name: {{ .HandlerNamespace }}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,24 +1,25 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 spec:
   selector:
     matchLabels:
-      name: nmstate-handler
+      name: {{template "handlerPrefix" .}}nmstate-handler
   template:
     metadata:
       labels:
         app: kubernetes-nmstate
-        name: nmstate-handler
+        name: {{template "handlerPrefix" .}}nmstate-handler
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
-      serviceAccountName: nmstate-handler
+      serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector:
         beta.kubernetes.io/arch: amd64
         node-role.kubernetes.io/master: ""
@@ -31,8 +32,8 @@ spec:
           args:
           - --v=production
           # Replace this with the built image name
-          image: {{ .NMStateHandlerImage }}
-          imagePullPolicy: {{ .ImagePullPolicy }}
+          image: {{ .HandlerImage }}
+          imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
           - kubernetes-nmstate
           env:
@@ -45,7 +46,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "nmstate-handler"
+              value: "{{template "handlerPrefix" .}}nmstate-handler"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -53,7 +54,7 @@ spec:
             - name: INTERFACES_FILTER
               valueFrom:
                 configMapKeyRef:
-                  name: nmstate-config
+                  name: {{template "handlerPrefix" .}}nmstate-config
                   key: interfaces_filter
             - name: WEBHOOK_PORT
               value: "54874"
@@ -75,23 +76,23 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nmstate-handler-worker
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler-worker
+  namespace: {{ .HandlerNamespace }}
 spec:
   selector:
     matchLabels:
-      name: nmstate-handler-worker
+      name: {{template "handlerPrefix" .}}nmstate-handler-worker
   template:
     metadata:
       labels:
         app: kubernetes-nmstate
-        name: nmstate-handler-worker
+        name: {{template "handlerPrefix" .}}nmstate-handler-worker
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
-      serviceAccountName: nmstate-handler
+      serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -108,8 +109,8 @@ spec:
           args:
             - --v=production
           # Replace this with the built image name
-          image: {{ .NMStateHandlerImage }}
-          imagePullPolicy: {{ .ImagePullPolicy }}
+          image: {{ .HandlerImage }}
+          imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
             - kubernetes-nmstate
           env:
@@ -120,7 +121,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "nmstate-handler"
+              value: "{{template "handlerPrefix" .}}nmstate-handler"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -128,7 +129,7 @@ spec:
             - name: INTERFACES_FILTER
               valueFrom:
                 configMapKeyRef:
-                  name: nmstate-config
+                  name: {{template "handlerPrefix" .}}nmstate-config
                   key: interfaces_filter
             - name: ENABLE_PROFILER
               value: "False"
@@ -148,16 +149,16 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nmstate-config
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-config
+  namespace: {{ .HandlerNamespace }}
 data:
   interfaces_filter: "veth*"
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: nmstate-webhook
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-webhook
+  namespace: {{ .HandlerNamespace }}
   labels:
     app: kubernetes-nmstate
 spec:
@@ -166,20 +167,20 @@ spec:
     - port: 443
       targetPort: 54874
   selector:
-    name: nmstate-handler
+    name: {{template "handlerPrefix" .}}nmstate-handler
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: nmstate
+  name: {{template "handlerPrefix" .}}nmstate
   labels:
     app: kubernetes-nmstate
 webhooks:
   - name: nodenetworkconfigurationpolicies-mutate.nmstate.io
     clientConfig:
       service:
-        name: nmstate-webhook
-        namespace: {{ .Namespace }}
+        name: {{template "handlerPrefix" .}}nmstate-webhook
+        namespace: {{ .HandlerNamespace }}
         path: "/nodenetworkconfigurationpolicies-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -189,8 +190,8 @@ webhooks:
   - name: nodenetworkconfigurationpolicies-status-mutate.nmstate.io
     clientConfig:
       service:
-        name: nmstate-webhook
-        namespace: {{ .Namespace }}
+        name: {{template "handlerPrefix" .}}nmstate-webhook
+        namespace: {{ .HandlerNamespace }}
         path: "/nodenetworkconfigurationpolicies-status-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -200,8 +201,8 @@ webhooks:
   - name: nodenetworkconfigurationpolicies-timestamp-mutate.nmstate.io
     clientConfig:
       service:
-        name: nmstate-webhook
-        namespace: {{ .Namespace }}
+        name: {{template "handlerPrefix" .}}nmstate-webhook
+        namespace: {{ .HandlerNamespace }}
         path: "/nodenetworkconfigurationpolicies-timestamp-mutate"
     rules:
       - operations: ["CREATE", "UPDATE"]

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,10 +1,11 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 rules:
 - apiGroups:
   - ""
@@ -47,8 +48,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 rules:
 - apiGroups:
   - certificates.k8s.io

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,28 +1,29 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 subjects:
 - kind: ServiceAccount
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 roleRef:
   kind: Role
-  name: nmstate-handler
+  name: {{template "handlerPrefix" .}}nmstate-handler
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 subjects:
 - kind: ServiceAccount
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
 roleRef:
   kind: ClusterRole
-  name: nmstate-handler
+  name: {{template "handlerPrefix" .}}nmstate-handler
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,8 +1,9 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: nmstate-handler
-  namespace: {{ .Namespace }}
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
   labels:
     nmstate.io: ""


### PR DESCRIPTION
In order to keep one operator from removing the resources of a
different operator, introduce a prefix that will add an additional
namespace to the resources.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Puts a prefix, if specified, in front of certain resources in order to keep them separate from possibly existing resources installed by a different operator.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
