### PR TITLE
Add go dep at makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ gen-openapi: $(OPENAPI_GEN)
 gen-crds: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate crds
 
-manifests:
+manifests: $(GO)
 	$(GO) run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(NAMESPACE) -handler-image=$(HANDLER_IMAGE) -handler-pull-policy=$(PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK) manifests
@@ -165,7 +165,7 @@ release: manifests push-handler $(description) $(GITHUB_RELEASE) version/version
 				   hack/release.sh \
 						$(shell find $(MANIFESTS_DIR) -type f)
 
-vendor:
+vendor: $(GO)
 	$(GO) mod tidy
 	$(GO) mod vendor
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,3 @@ package version
 var (
 	Version = "0.18.0"
 )
-
-// * Force release after fixing release.sh
-// * Force release, prow has no remotes git push has to be done with repo


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
We are missing the $(GO) dep at some Makefile targets (vendor and manifests) apart from being wrong this breaks the release pipeline we have failint at `make manifests` target.

**Special notes for your reviewer**:
We will need to re-release after this using the old `version/description` 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
