### PR TITLE
Enable external ocp cluster-sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,24 @@ See [local virtualized cluster guide](docs/deployment-local-cluster.md) to learn
 how to deploy a cluster that can be used to try kubernetes-nmstate, run e2e
 tests and perform debugging.
 
+## External ocp cluster using custom container registry and repo
+
+Set the current env vars `KUBEVIRT_PROVIDER=external` and `KUBECONFIG` pointing
+to the k8s cluster config.
+
+After that you can follow "Local Kubernetes cluster" but using
+`DEV_IMAGE_REGISTRY` and `IMAGE_REPO` to specify where the dev
+containers are being pushed
+
+For example quay.io/foo/ is being used as the dev place for containers and
+want to deploy some changes at external cluster, following steps would be
+enough:
+
+```bash
+doker login -u foo quay.io
+make DEV_IMAGE_REGISTRY=quay.io IMAGE_REPO=foo cluster-sync
+```
+
 ## Building
 
 ```shell

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -57,7 +57,11 @@ function isOpenshift {
 
 function push() {
     if isExternal; then
-        make manifests push
+        if [[ ! -v DEV_IMAGE_REGISTRY ]]; then
+            echo "Missing DEV_IMAGE_REGISTRY variable"
+            return 1
+        fi
+        make IMAGE_REGISTRY=$DEV_IMAGE_REGISTRY manifests push
         return 0
     fi
     # Fetch registry port that can be used to upload images to the local kubevirtci cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement
/kind infraestructure

**What this PR does / why we need it**:
Right now is not possible to deploy with `make cluster-sync` to an external system k8s or ocp, this PR use the KUBEVIRT_PROVIDER=external to do so and using the selected IMAGE_REPO/IMAGE_REGISTRY as intermediate repo.

**Special notes for your reviewer**:

You need to login at selected IMAGE_REGISTRY and IMAGE_REPO

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allow `make cluster-sync` on external systems.
```
