### PR TITLE
Adapt scc.yaml to ocp 4.5

### DIFF
--- a/deploy/openshift/scc.yaml
+++ b/deploy/openshift/scc.yaml
@@ -6,6 +6,10 @@ metadata:
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 allowHostNetwork: true
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
After deploying at ocp-4.5 we have found that our scc.yaml is not compatible with it, this PR
add the missing fields setting them to false.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Adapt scc.yaml to ocp-4.5
```
