### PR TITLE
Use correct crd name in clean script

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -27,7 +27,7 @@ function clean() {
     fi
 
     # Delete the CR only if the CRD is installed otherwise it will fail
-    if $kubectl get crds nmstate.io.nmstate; then
+    if $kubectl get crds nmstates.nmstate.io; then
         $kubectl delete --ignore-not-found -f deploy/crds/nmstate.io_v1alpha1_nmstate_cr.yaml
     fi
     $kubectl delete --ignore-not-found -f $MANIFESTS_DIR/operator.yaml


### PR DESCRIPTION
The clean script is using an incorrect name for the CRD. Fix that.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
