### PR TITLE
add installation guide to release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,7 @@ cluster-sync:
 
 $(description): version/description
 	mkdir -p $(dir $@)
-	sed "s#OPERATOR_IMAGE#$(OPERATOR_IMAGE)#" \
-		version/description > $@
+	cp version/description > $@
 
 prepare-patch: $(RELEASE_NOTES)
 	RELEASE_NOTES=$(RELEASE_NOTES) ./hack/prepare-release.sh patch

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -33,8 +33,29 @@ cat $release_notes >> version/description
 
 cat << EOF >> version/description
 
+# Installation
+
+First, install kubernetes-nmstate operator:
+
 \`\`\`
-docker pull OPERATOR_IMAGE
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/nmstate.io_nmstates_crd.yaml
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/namespace.yaml
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/service_account.yaml
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/role.yaml
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/role_binding.yaml
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$new_version/operator.yaml
+\`\`\`
+
+Once that's done, create an \`NMState\` CR, triggering deployment of
+kubernetes-nmstate handler:
+
+\`\`\`
+cat <<EOF | kubectl create -f -
+apiVersion: nmstate.io/v1alpha1
+kind: NMState
+metadata:
+  name: nmstate
+EOF
 \`\`\`
 EOF
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:

For people looking for installation guide per release in GitHub release
notes.

**Special notes for your reviewer**:

Dependent on https://github.com/nmstate/kubernetes-nmstate/pull/521.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
