### PR TITLE
Add missing test policy waits

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -65,15 +65,13 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			By(fmt.Sprintf("Reseting state of %s", firstSecondaryNic))
 			resetNicStateForNodes(firstSecondaryNic)
 			By(fmt.Sprintf("Creating %s on %s and %s", bond1, primaryNic, firstSecondaryNic))
-			updateDesiredState(boundUpWithPrimaryAndSecondary(bond1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(boundUpWithPrimaryAndSecondary(bond1))
 			By("Done configuring test")
 
 		})
 		AfterEach(func() {
 			By(fmt.Sprintf("Removing bond %s and configuring %s with dhcp", bond1, primaryNic))
-			updateDesiredState(bondAbsentWithPrimaryUp(bond1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(bondAbsentWithPrimaryUp(bond1))
 
 			By("Waiting until the node becomes ready again")
 			for _, node := range nodes {
@@ -121,7 +119,6 @@ func verifyBondIsUpWithPrimaryNicIp(node string, expectedBond map[string]interfa
 }
 
 func resetNicStateForNodes(nicName string) {
-	updateDesiredState(ethernetNicsUp(nicName))
-	waitForAvailableTestPolicy()
+	updateDesiredStateAndWait(ethernetNicsUp(nicName))
 	deletePolicy(TestPolicy)
 }

--- a/test/e2e/handler/examples_test.go
+++ b/test/e2e/handler/examples_test.go
@@ -30,8 +30,7 @@ var _ = Describe("Examples", func() {
 		deletePolicy(policyName)
 
 		for _, ifaceName := range ifaceNames {
-			updateDesiredState(interfaceAbsent(ifaceName))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(interfaceAbsent(ifaceName))
 		}
 
 		resetDesiredStateForNodes()

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -26,8 +26,7 @@ var _ = Describe("EnactmentCondition", func() {
 		})
 		AfterEach(func() {
 			By("Remove the bridge")
-			updateDesiredState(linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
@@ -105,8 +104,7 @@ var _ = Describe("EnactmentCondition", func() {
 
 		AfterEach(func() {
 			By("Remove the bridge")
-			updateDesiredState(linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
 		})

--- a/test/e2e/handler/nnce_desiredstate_test.go
+++ b/test/e2e/handler/nnce_desiredstate_test.go
@@ -6,8 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
-
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/pkg/apis/nmstate/v1alpha1"
 )
 
@@ -15,18 +13,11 @@ var _ = Describe("Enactment DesiredState", func() {
 	Context("when applying a policy to matching nodes", func() {
 		BeforeEach(func() {
 			By("Create a policy")
-			updateDesiredState(linuxBrUp(bridge1))
-			policyConditionsStatusEventually().Should(ContainElement(
-				nmstatev1alpha1.Condition{
-					Type:   nmstatev1alpha1.NodeNetworkConfigurationPolicyConditionAvailable,
-					Status: corev1.ConditionTrue,
-				},
-			))
+			updateDesiredStateAndWait(linuxBrUp(bridge1))
 		})
 		AfterEach(func() {
 			By("Remove the bridge")
-			updateDesiredState(linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
 		})

--- a/test/e2e/handler/nncp_cleanup_test.go
+++ b/test/e2e/handler/nncp_cleanup_test.go
@@ -15,24 +15,24 @@ import (
 
 var _ = Describe("NNCP cleanup", func() {
 
-	BeforeEach(func() {
-		By("Create a policy")
-		setDesiredStateWithPolicy(bridge1, linuxBrUp(bridge1))
-
-		By("Wait for policy to be ready")
-		waitForAvailablePolicy(bridge1)
-	})
-
-	AfterEach(func() {
-		updateDesiredState(linuxBrAbsent(bridge1))
-		waitForAvailableTestPolicy()
-		resetDesiredStateForNodes()
-	})
-
 	Context("when a policy is deleted", func() {
 		BeforeEach(func() {
+			By("Create a policy")
+			setDesiredStateWithPolicy(bridge1, linuxBrUp(bridge1))
+
+			By("Wait for policy to be ready")
+			waitForAvailablePolicy(bridge1)
+
+			By("Delete the policy")
 			deletePolicy(bridge1)
 		})
+
+		AfterEach(func() {
+			deletePolicy(bridge1)
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
+			resetDesiredStateForNodes()
+		})
+
 		It("should also delete nodes enactments", func() {
 			for _, node := range nodes {
 				Eventually(func() bool {

--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -42,8 +42,7 @@ var _ = Describe("rollback", func() {
 		AfterEach(func() {
 			By("Rename vlan-filtering.bak to vlan-filtering to leave it as it was")
 			runner.RunAtPods("mv", "/usr/local/bin/vlan-filtering.bak", "/usr/local/bin/vlan-filtering")
-			updateDesiredState(linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			resetDesiredStateForNodes()
 		})
 		It("should rollback failed state configuration", func() {

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -120,12 +120,10 @@ var _ = Describe("NodeNetworkState", func() {
 	Context("when desiredState is configured", func() {
 		Context("with a linux bridge up with no ports", func() {
 			BeforeEach(func() {
-				updateDesiredState(linuxBrUpNoPorts(bridge1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(linuxBrUpNoPorts(bridge1))
 			})
 			AfterEach(func() {
-				updateDesiredState(linuxBrAbsent(bridge1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 				}
@@ -140,12 +138,10 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 		Context("with a linux bridge up", func() {
 			BeforeEach(func() {
-				updateDesiredState(linuxBrUp(bridge1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(linuxBrUp(bridge1))
 			})
 			AfterEach(func() {
-				updateDesiredState(linuxBrAbsent(bridge1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 				}
@@ -164,12 +160,10 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 		Context("with a active-backup miimon 100 bond interface up", func() {
 			BeforeEach(func() {
-				updateDesiredState(bondUp(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondUp(bond1))
 			})
 			AfterEach(func() {
-				updateDesiredState(bondAbsent(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondAbsent(bond1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}
@@ -187,12 +181,10 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 		Context("with the bond interface as linux bridge port", func() {
 			BeforeEach(func() {
-				updateDesiredState(brWithBondUp(bridge1, bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(brWithBondUp(bridge1, bond1))
 			})
 			AfterEach(func() {
-				updateDesiredState(brAndBondAbsent(bridge1, bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(brAndBondAbsent(bridge1, bond1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
@@ -226,12 +218,10 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 		Context("with bond interface that has 2 eths as slaves", func() {
 			BeforeEach(func() {
-				updateDesiredState(bondUpWithEth1AndEth2(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondUpWithEth1AndEth2(bond1))
 			})
 			AfterEach(func() {
-				updateDesiredState(bondAbsent(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondAbsent(bond1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}
@@ -249,12 +239,10 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 		Context("with bond interface that has 2 eths as slaves and vlan tag on the bond", func() {
 			BeforeEach(func() {
-				updateDesiredState(bondUpWithEth1Eth2AndVlan(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondUpWithEth1Eth2AndVlan(bond1))
 			})
 			AfterEach(func() {
-				updateDesiredState(bondAbsent(bond1))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAndWait(bondAbsent(bond1))
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bond1))
 				}

--- a/test/e2e/handler/simple_ovs_bridge_test.go
+++ b/test/e2e/handler/simple_ovs_bridge_test.go
@@ -10,12 +10,10 @@ import (
 var _ = PDescribe("Simple OVS bridge [pending cause nmstate bug -> https://bugzilla.redhat.com/show_bug.cgi?id=1724901]", func() {
 	Context("when desiredState is configured with an ovs bridge up", func() {
 		BeforeEach(func() {
-			updateDesiredState(ovsBrUp(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ovsBrUp(bridge1))
 		})
 		AfterEach(func() {
-			updateDesiredState(ovsBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ovsBrAbsent(bridge1))
 			for _, node := range nodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}
@@ -33,12 +31,10 @@ var _ = PDescribe("Simple OVS bridge [pending cause nmstate bug -> https://bugzi
 	})
 	Context("when desiredState is configured with an ovs bridge with internal port up", func() {
 		BeforeEach(func() {
-			updateDesiredState(ovsbBrWithInternalInterface(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ovsbBrWithInternalInterface(bridge1))
 		})
 		AfterEach(func() {
-			updateDesiredState(ovsBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ovsBrAbsent(bridge1))
 			for _, node := range nodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}

--- a/test/e2e/handler/simple_vlan_and_ip_test.go
+++ b/test/e2e/handler/simple_vlan_and_ip_test.go
@@ -14,11 +14,10 @@ var _ = Describe("NodeNetworkState", func() {
 		)
 
 		BeforeEach(func() {
-			updateDesiredState(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 		})
 		AfterEach(func() {
-			updateDesiredState(vlanAbsent(firstSecondaryNic, vlanId))
+			updateDesiredStateAndWait(vlanAbsent(firstSecondaryNic, vlanId))
 			resetDesiredStateForNodes()
 		})
 		It("should have the vlan interface configured", func() {
@@ -34,20 +33,17 @@ var _ = Describe("NodeNetworkState", func() {
 			vlanId            = "102"
 		)
 		BeforeEach(func() {
-			updateDesiredState(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			for index, node := range nodes {
 				ipAddress := fmt.Sprintf(ipAddressTemplate, index)
 				By(fmt.Sprintf("applying static IP %s on node %s", ipAddress, node))
-				updateDesiredStateAtNode(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", firstSecondaryNic, vlanId), ipAddress))
-				waitForAvailableTestPolicy()
+				updateDesiredStateAtNodeAndWait(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", firstSecondaryNic, vlanId), ipAddress))
 			}
 
 		})
 
 		AfterEach(func() {
-			updateDesiredState(vlanAbsent(firstSecondaryNic, vlanId))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(vlanAbsent(firstSecondaryNic, vlanId))
 			resetDesiredStateForNodes()
 		})
 

--- a/test/e2e/handler/user_guide_test.go
+++ b/test/e2e/handler/user_guide_test.go
@@ -25,8 +25,7 @@ var _ = Describe("Introduction", func() {
 	// Policies are not deleted as a part of the tutorial, so we need additional function here
 	cleanupConfiguration := func() {
 		deletePolicy("vlan100")
-		updateDesiredState(interfaceAbsent("eth1.100"))
-		waitForAvailableTestPolicy()
+		updateDesiredStateAndWait(interfaceAbsent("eth1.100"))
 	}
 
 	runTroubleshooting := func() {

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -165,6 +165,9 @@ func deletePolicy(name string) {
 	policy := &nmstatev1alpha1.NodeNetworkConfigurationPolicy{}
 	policy.Name = name
 	err := framework.Global.Client.Delete(context.TODO(), policy)
+	if apierrors.IsNotFound(err) {
+		return
+	}
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	// Wait for policy to be removed

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -89,9 +89,19 @@ func updateDesiredState(desiredState nmstatev1alpha1.State) {
 	setDesiredStateWithPolicy(TestPolicy, desiredState)
 }
 
+func updateDesiredStateAndWait(desiredState nmstatev1alpha1.State) {
+	updateDesiredState(desiredState)
+	waitForAvailableTestPolicy()
+}
+
 func updateDesiredStateAtNode(node string, desiredState nmstatev1alpha1.State) {
 	nodeSelector := map[string]string{"kubernetes.io/hostname": node}
 	setDesiredStateWithPolicyAndNodeSelector(TestPolicy, desiredState, nodeSelector)
+}
+
+func updateDesiredStateAtNodeAndWait(node string, desiredState nmstatev1alpha1.State) {
+	updateDesiredStateAtNode(node, desiredState)
+	waitForAvailableTestPolicy()
 }
 
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -18,12 +18,10 @@ var _ = Describe("Mutating Admission Webhook", func() {
 			// Make sure test policy is not there so
 			// we exercise CREATE event
 			resetDesiredStateForNodes()
-			updateDesiredState(linuxBrUp(bridge1))
+			updateDesiredStateAndWait(linuxBrUp(bridge1))
 		})
 		AfterEach(func() {
-			waitForAvailableTestPolicy()
-			updateDesiredState(linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			resetDesiredStateForNodes()
 		})
 
@@ -37,7 +35,7 @@ var _ = Describe("Mutating Admission Webhook", func() {
 			)
 			BeforeEach(func() {
 				oldPolicy = nodeNetworkConfigurationPolicy(TestPolicy)
-				updateDesiredState(linuxBrAbsent(bridge1))
+				updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			})
 			It("should have an annotation with newer mutation timestamp", func() {
 				newPolicy := nodeNetworkConfigurationPolicy(TestPolicy)


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
/kind test

**What this PR does / why we need it**:
There were some missing policy condition wait this create
some race conditions at handler e2e test, this also add
two functions with the `AndWait` suffix to do the update + wait
at one line.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
