### PR TITLE
Block policy deletion until enactments are delete

### DIFF
--- a/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/pkg/apis/nmstate/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -74,11 +74,12 @@ func EnactmentKey(node string, policy string) types.NamespacedName {
 }
 
 func NewEnactment(nodeName string, policy NodeNetworkConfigurationPolicy) NodeNetworkConfigurationEnactment {
+	BlockOwnerAtDelete := true
 	enactment := NodeNetworkConfigurationEnactment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: EnactmentKey(nodeName, policy.Name).Name,
 			OwnerReferences: []metav1.OwnerReference{
-				{Name: policy.Name, Kind: policy.TypeMeta.Kind, APIVersion: policy.TypeMeta.APIVersion, UID: policy.UID},
+				{Name: policy.Name, Kind: policy.TypeMeta.Kind, APIVersion: policy.TypeMeta.APIVersion, UID: policy.UID, BlockOwnerDeletion: &BlockOwnerAtDelete},
 			},
 			// Associate policy with the enactment using labels
 			Labels: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind enhancement

**What this PR does / why we need it**:
This make policy deletion to wait until enactments are removed so we ensure that policy updated don't not find unexpected enactments.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Policy delete now waits for enactments to be deleted
```
