### PR TITLE
Wait for fresh nns after reboot at test

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -11,7 +11,7 @@ teardown() {
     make cluster-down
     cp $(find . -name "*junit*.xml") $ARTIFACTS
     # Don't fail if there is no logs
-    cp ${E2E_LOGS}/*.log ${ARTIFACTS} || true
+    cp ${E2E_LOGS}/handler/*.log ${ARTIFACTS} || true
 }
 
 main() {

--- a/automation/check-patch.e2e-operator-k8s.sh
+++ b/automation/check-patch.e2e-operator-k8s.sh
@@ -11,7 +11,7 @@ teardown() {
     make cluster-down
     cp $(find . -name "*junit*.xml") $ARTIFACTS
     # Don't fail if there is no logs
-    cp ${E2E_LOGS}/*.log ${ARTIFACTS} || true
+    cp ${E2E_LOGS}/operator/*.log ${ARTIFACTS} || true
 }
 
 main() {

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -104,6 +104,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			By(fmt.Sprintf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot))
 			err := restartNode(nodeToReboot)
 			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("Wait for nns to be refreshed at %s", nodeToReboot))
+			waitForNodeNetworkStateUpdate(nodeToReboot)
+
 			By(fmt.Sprintf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1))
 			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, addressByNode[nodeToReboot])
 		})

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -142,6 +142,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				err := restartNode(nodeToReboot)
 				Expect(err).ToNot(HaveOccurred())
 
+				By(fmt.Sprintf("Wait for nns to be refreshed at %s", nodeToReboot))
+				waitForNodeNetworkStateUpdate(nodeToReboot)
+
+				By(fmt.Sprintf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot))
 				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot})
 			})
 		})

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -298,6 +298,16 @@ func interfacesForNode(node string) AsyncAssertion {
 	}, ReadTimeout, ReadInterval)
 }
 
+func waitForNodeNetworkStateUpdate(node string) {
+	now := time.Now()
+	EventuallyWithOffset(1, func() time.Time {
+		key := types.NamespacedName{Namespace: framework.Global.Namespace, Name: node}
+		nnsUpdateTime := nodeNetworkState(key).Status.LastSuccessfulUpdateTime
+		return nnsUpdateTime.Time
+	}, 4*time.Minute, 5*time.Second).Should(BeTemporally(">=", now), fmt.Sprintf("Node %s should have a fresh nns)", node))
+
+}
+
 func toUnstructured(y string) interface{} {
 	var u interface{}
 	err := yaml.Unmarshal([]byte(y), &u)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
/kind test

**What this PR does / why we need it**:
the default brindge and bond e2e tests were reading not
fresh nns after reboot, they have to check that update timestamp
is fresh enough to read information from there if not they will
face a false possitive.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
