### PR TITLE
fix prepare-release.sh EOF

### DIFF
--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -31,7 +31,7 @@ EOF
 
 cat $release_notes >> version/description
 
-cat << EOF >> version/description
+cat << EOFF >> version/description
 
 # Installation
 
@@ -57,7 +57,7 @@ metadata:
   name: nmstate
 EOF
 \`\`\`
-EOF
+EOFF
 
 ${EDITOR:-vi} version/description
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind enhancement

**What this PR does / why we need it**:

The EOF used in the release template was caught instead of the one mean
to mark the end of the template.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
