### PR TITLE
Makefile: remove build dependency on generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,15 @@ gen-openapi: $(OPENAPI_GEN)
 gen-crds: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) generate crds
 
+check-gen: generate
+	./hack/check-gen.sh
+
+generate: gen-openapi gen-k8s gen-crds
+
 manifests: $(GO)
 	$(GO) run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
-handler: gen-openapi gen-k8s gen-crds $(OPERATOR_SDK)
+handler: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) build $(HANDLER_IMAGE) --image-builder $(IMAGE_BUILDER)
 push-handler: handler
 	$(IMAGE_BUILDER) push $(HANDLER_IMAGE)
@@ -194,6 +199,8 @@ tools-vendoring:
 	push-handler \
 	test/unit \
 	test/e2e \
+	generate \
+	check-gen \
 	cluster-up \
 	cluster-down \
 	cluster-sync-handler \

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -20,6 +20,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make handler
 

--- a/automation/check-patch.e2e-ocp.sh
+++ b/automation/check-patch.e2e-ocp.sh
@@ -20,6 +20,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make handler
 

--- a/automation/check-patch.e2e-okd.sh
+++ b/automation/check-patch.e2e-okd.sh
@@ -23,6 +23,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make handler
 

--- a/automation/check-patch.e2e-operator-k8s.sh
+++ b/automation/check-patch.e2e-operator-k8s.sh
@@ -20,6 +20,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make operator
 

--- a/automation/check-patch.e2e-operator-ocp.sh
+++ b/automation/check-patch.e2e-operator-ocp.sh
@@ -20,6 +20,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make operator
 

--- a/automation/check-patch.e2e-operator-okd.sh
+++ b/automation/check-patch.e2e-operator-okd.sh
@@ -23,6 +23,9 @@ main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    # Let's fail fast if generated files differ
+    make check-gen
+
     # Let's fail fast if it's not compiling
     make operator
 

--- a/hack/check-gen.sh
+++ b/hack/check-gen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xe
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "It seems like you need to run 'make generate'. Please run it and commit the changes"
+    git status --porcelain
+    exit 1
+fi

--- a/vendor/github.com/gobuffalo/envy/.env
+++ b/vendor/github.com/gobuffalo/envy/.env
@@ -1,5 +1,0 @@
-# This is a comment
-# We can use equal or colon notation
-DIR: root
-FLAVOUR: none
-INSIDE_FOLDER=false


### PR DESCRIPTION
If generated files are not checked in when they should be, a diff
between a built image and what is in the repo could occur. This would
not be desirable. So, remove the Makefile dependency, and add a check
script that makes sure that what is commited to the repo is the same
as what should be committed.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--  Thanks for sending a pull request! -->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
It removes the dependency of building the handler on generating files.

It would be undesirable for files to get generated at build time, and not be committed to the repo. It opens the possibility that a released container image would contain code that is not in the commit it was derived from. So, now, before the e2e tests, we check that files would not be generated. If they would be, then fail the e2e tests fast.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
