### PR TITLE
Disable tier1 tests ssh strict host check

### DIFF
--- a/test/e2e/openshift.cnv.workflow.sh
+++ b/test/e2e/openshift.cnv.workflow.sh
@@ -17,7 +17,7 @@ if [ ! -f  $SSH ]; then
 #!/bin/bash
 node_name=\${1}
 node_ip=\$($KUBECTL get node \${node_name} --no-headers -o wide | awk '{print \$6}')
-ssh core@\${node_ip} -- \${@:3}
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@\${node_ip} -- \${@:3}
 EOF
     chmod +x ${SSH}
 fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
the tier1 tests script has to be non interfactive for that ssh.sh ignores host checking at this PR.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
