### PR TITLE
Increase time waiting for enactment deletion

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -162,13 +162,21 @@ func deletePolicy(name string) {
 		return apierrors.IsNotFound(err)
 	}, 60*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Policy %s not deleted", name))
 
-	// Wait for enactments to be removed
+	// Wait for enactments to be removed calculate timeout taking into account
+	// the number of nodes, looks like it affect the time it takes to
+	// delete enactments
+	enactmentsDeleteTimeout := time.Duration(60+20*len(nodes)) * time.Second
 	for _, node := range nodes {
 		enactmentKey := nmstatev1alpha1.EnactmentKey(node, name)
 		Eventually(func() bool {
 			err := framework.Global.Client.Get(context.TODO(), enactmentKey, &nmstatev1alpha1.NodeNetworkConfigurationEnactment{})
+			// if we face an unexpected error do a failure since
+			// we don't know if enactment was deleted
+			if err != nil && !apierrors.IsNotFound(err) {
+				Fail(fmt.Sprintf("Unexpected error waitting for enactment deletion: %v", err))
+			}
 			return apierrors.IsNotFound(err)
-		}, 60*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Enactment %s not deleted", enactmentKey.Name))
+		}, enactmentsDeleteTimeout, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Enactment %s not deleted", enactmentKey.Name))
 	}
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
At big cluster it takes more time for enactments to be deleted after policy deletion, this increase e2e tests timeout taking into account the number of nodes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
