### PR TITLE
Fix RBAC for secrets watching

### DIFF
--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -25,8 +25,20 @@ rules:
   resources:
   - secrets
   verbs:
-  - list
   - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
   - create
   - update
 - apiGroups:
@@ -97,6 +109,7 @@ rules:
   - get
   - create
   - update
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug


**What this PR does / why we need it**:
Master has a failure at logs [1] looks like CI is working fine since we don't check at TLS update
but we have to fix it, to do so we just put correct RBAC at secrets and events so pod can watch
the secrets and re-mount them.

[1] User "system:serviceaccount:nmstate:nmstate-handler" cannot create resource "events" in API group "" in the namespace "nmstate"' (will not retry!)


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
