### PR TITLE
Remove POLARION_TEST_SUITE_PARAMS

### DIFF
--- a/hack/run-e2e-test-handler.sh
+++ b/hack/run-e2e-test-handler.sh
@@ -5,4 +5,4 @@ unset GOFLAGS && ${OPERATOR_SDK} test local ./test/e2e/handler \
 	--kubeconfig ${KUBECONFIG} \
 	--operator-namespace ${HANDLER_NAMESPACE} \
 	--no-setup \
-	--go-test-flags "${TEST_ARGS}  --test-suite-params=\"$POLARION_TEST_SUITE_PARAMS\""
+	--go-test-flags "${TEST_ARGS}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Remove POLARION_TEST_SUITE_PARAMS, the test at tier1 are going to use one parmeter so skipping spaces is not needed, also when https://github.com/kubevirt/qe-tools/pull/21 is merged tier1 will be run with multiple parameters separated by commas.
```
./test/e2e/openshift.cnv.workflow.sh \
    --polarion-custom-plannedin=2_4 \
    --polarion-execution=true \
    --polarion-project-id=CNV \
    --polarion-report-file=polarion_results.xml \
    --test-suite-params=env_tier=tier1
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
