### PR TITLE
Test active-backup bonding with primary interface

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -19,13 +19,14 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstatev1alpha1.State {
       dhcp: true
       enabled: true
     link-aggregation:
-      mode: balance-rr
+      mode: active-backup
       options:
         miimon: '140'
+        primary: %s
       slaves:
         - %s
         - %s
-`, bondName, primaryNic, firstSecondaryNic))
+`, bondName, primaryNic, primaryNic, firstSecondaryNic))
 }
 
 func bondAbsentWithPrimaryUp(bondName string) nmstatev1alpha1.State {


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug


**What this PR does / why we need it**:

Our functional tests of bonding configured as the default interface are
flaky. It may be due to the fact that sometimes we select different link
as the primary one, therefore get a different MAC, resulting in
different IP and broken node connectivity.

With this patch we switch the used mode to active-backup and explicitly
set the first NIC as the primary one. That should make sure that we
always start with the same active NIC and thus the same IP.

May be related to https://github.com/nmstate/kubernetes-nmstate/issues/569

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Stable primary link in bonding tests
```
