### PR TITLE
Add env vars for cert rotation knobs

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -58,6 +58,12 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+            - name: CA_ROTATE_INTERVAL
+              value: "8760h0m0s" # One Year
+            - name: CA_OVERLAP_INTERVAL
+              value: "8760h0m0s" # One Year
+            - name: CERT_ROTATE_INTERVAL
+              value: "4380h0m0s" # Half Year
           ports:
           - containerPort: 8443
             name: webhook-server

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -1,6 +1,11 @@
 package environment
 
-import "os"
+import (
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
 
 // IsOperator returns true when RUN_OPERATOR env var is present
 func IsOperator() bool {
@@ -22,4 +27,18 @@ func IsHandler() bool {
 // Returns node name runnig the pod
 func NodeName() string {
 	return os.Getenv("NODE_NAME")
+}
+
+func LookupAsDuration(varName string) (time.Duration, error) {
+	duration := time.Duration(0)
+	varValue, ok := os.LookupEnv(varName)
+	if !ok {
+		return duration, errors.Errorf("Failed to load %s from environment", varName)
+	}
+
+	duration, err := time.ParseDuration(varValue)
+	if err != nil {
+		return duration, errors.Wrapf(err, "Failed to convert %s value to time.Duration", varName)
+	}
+	return duration, nil
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -13,14 +13,7 @@ const (
 	webhookName = "nmstate"
 )
 
-func Add(namespace string, mgr manager.Manager) error {
-
-	certOptions := certificate.Options{
-		Namespace:        namespace,
-		WebhookName:      webhookName,
-		WebhookType:      certificate.MutatingWebhook,
-		CARotateInterval: certificate.OneYearDuration,
-	}
+func Add(mgr manager.Manager, o certificate.Options) error {
 
 	// We need two hooks, the update of nncp and nncp/status (it's a subresource) happends
 	// at different times, also if you modify status at nncp webhook it does not modify it
@@ -29,7 +22,7 @@ func Add(namespace string, mgr manager.Manager) error {
 	// 1.- User changes nncp desiredState so it triggers deleteConditionsHook()
 	// 2.- Since we have delete the condition the status-mutate webhook get called and
 	//     there we set conditions to Unknown this final result will be updated.
-	server, err := webhookserver.New(mgr.GetClient(), certOptions,
+	server, err := webhookserver.New(mgr.GetClient(), o,
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook()),

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,16 +1,18 @@
 package webhook
 
 import (
+	"github.com/qinqon/kube-admission-webhook/pkg/certificate"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(namespace string, m manager.Manager) error
+var AddToManagerFuncs []func(m manager.Manager, o certificate.Options) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(namespace string, m manager.Manager) error {
+func AddToManager(m manager.Manager, o certificate.Options) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(namespace, m); err != nil {
+		if err := f(m, o); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The latest kube-admission-webhook add three parameters to configure the following cert rotatin
properties:
- CARotateInterval
- CAOverlapInterval
- CertRotateInterval
Those are documented here https://pkg.go.dev/github.com/qinqon/kube-admission-webhook@v0.12.0/pkg/certificate?tab=doc#Options

This commit add three new env vars to handler pod "CA_ROTATE_INTERVAL", "CA_OVERLAP_INTERVAL", "CERT_ROTATE_INTERVAL" to pass
those valuea.

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
