### PR TITLE
Refactor nodeSelector,tolerations,affinity template variables

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -23,13 +23,9 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-webhook
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        node-role.kubernetes.io/master: ""
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
+      affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
       containers:
         - name: nmstate-webhook
           args:
@@ -111,15 +107,9 @@ spec:
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
-      {{- range $key, $value := .HandlerNodeSelector }}
-      {{"  "}}{{- $key }}: {{  $value }}
-      {{- end}}
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .HandlerTolerations | nindent 8 }}
+      affinity: {{ toYaml .HandlerAffinity | nindent 8 }}
       containers:
         - name: nmstate-handler
           args:

--- a/pkg/render/yaml.go
+++ b/pkg/render/yaml.go
@@ -1,0 +1,20 @@
+package render
+
+import (
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// toYAML takes an interface, marshals it to yaml, and returns a string. It will
+// always return a string, even on marshal error (empty string).
+//
+// This is designed to be called from a template.
+func ToYaml(v interface{}) string {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		// Swallow errors inside of a template.
+		return ""
+	}
+	return strings.TrimSuffix(string(data), "\n")
+}


### PR DESCRIPTION
Refactor nodeSelector,tolerations,affinity template variables
so that these can be easily modified by cnao.
Added toYaml helper function to render template structs.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
