### PR TITLE
Add a DNS probe to check external connectivity

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -106,6 +106,9 @@ spec:
       # future nmstate/NM is in place.
       # https://github.com/nmstate/nmstate/pull/440
       hostNetwork: true
+      # Use Default to get node's DNS configuration [1]
+      # [1] https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+      dnsPolicy: Default
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 8 }}
       tolerations: {{ toYaml .HandlerTolerations | nindent 8 }}

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -442,6 +442,11 @@ func dhcpFlag(node string, name string) bool {
 	return gjson.ParseBytes(currentStateJSON(node)).Get(path).Bool()
 }
 
+func autoDNS(node string, name string) bool {
+	path := fmt.Sprintf("interfaces.#(name==\"%s\").ipv4.auto-dns", name)
+	return gjson.ParseBytes(currentStateJSON(node)).Get(path).Bool()
+}
+
 func ifaceInSlice(ifaceName string, names []string) bool {
 	for _, name := range names {
 		if ifaceName == name {


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Right now it uses one probe that pings the default gw after applying the desiredState,
this is problematic at systems where there is no default gw.

To fix that a new probe is added that do a DNS NS query to root-server.net it's a well know
name that is not going to disappear anytime soon.

To select what external connectivity probes it must run we run them before applying the config
and select the ones that work.

Closes #316 

**Special notes for your reviewer**:
The rollback test is still just breaking default gw, I need to add a test there that breaks DNS resolving somehow.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add DNS external connectivity probe, closes #316 
```
