### PR TITLE
Roll out configuration sequentially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ export KUBEVIRT_PROVIDER ?= k8s-1.19
 export KUBEVIRT_NUM_NODES ?= 2 # 1 master, 1 worker needed for e2e tests
 export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 
-export E2E_TEST_TIMEOUT ?= 40m
+export E2E_TEST_TIMEOUT ?= 60m
 
 e2e_test_args = -v -timeout=$(E2E_TEST_TIMEOUT) -slowSpecThreshold=60 $(E2E_TEST_ARGS)
 

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -16,7 +16,6 @@ type NodeNetworkConfigurationPolicySpec struct {
 	// The desired configuration of the policy
 	DesiredState State `json:"desiredState,omitempty"`
 
-	// +kubebuilder:validation:XPreserveUnknownFields
 	// When set to true, changes are applied to all nodes in parallel
 	// +optional
 	Parallel bool `json:"parallel,omitempty"`
@@ -26,11 +25,11 @@ type NodeNetworkConfigurationPolicySpec struct {
 type NodeNetworkConfigurationPolicyStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`
 
-	// NodeRunningUpdate field is used for serializing cluster nodes configuration
+	// NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
 	// +optional
 	NodeRunningUpdate string `json:"nodeRunningUpdate,omitempty" optional:"true"`
 
-	// NodeUpdateStart marks starting time of a node on a policy configuration
+	// NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
 	// +optional
 	NodeUpdateStart *metav1.Time `json:"nodeUpdateStart,omitempty" optional:"true"`
 }

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -1,5 +1,9 @@
 package shared
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicySpec struct {
 	// NodeSelector is a selector which must be true for the policy to be applied to the node.
@@ -11,11 +15,24 @@ type NodeNetworkConfigurationPolicySpec struct {
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// The desired configuration of the policy
 	DesiredState State `json:"desiredState,omitempty"`
+
+	// +kubebuilder:validation:XPreserveUnknownFields
+	// When set to true, changes are applied to all nodes in parallel
+	// +optional
+	Parallel bool `json:"parallel,omitempty"`
 }
 
 // NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicyStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`
+
+	// NodeRunningUpdate field is used for serializing cluster nodes configuration
+	// +optional
+	NodeRunningUpdate string `json:"nodeRunningUpdate,omitempty" optional:"true"`
+
+	// NodeUpdateStart marks starting time of a node on a policy configuration
+	// +optional
+	NodeUpdateStart *metav1.Time `json:"nodeUpdateStart,omitempty" optional:"true"`
 }
 
 const (

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -31,7 +31,15 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-noColor" E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml" test-e2e-handler
+
+    export E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml"
+    if [ $NMSTATE_PARALLEL_ROLLOUT == "true" ]; then
+       E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='user-guide|nns'"
+    else
+       E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='parallel'"
+    fi
+
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-noColor" test-e2e-handler
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -51,7 +51,6 @@ spec:
               parallel:
                 description: When set to true, changes are applied to all nodes in parallel
                 type: boolean
-                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -79,10 +78,10 @@ spec:
                   type: object
                 type: array
               nodeRunningUpdate:
-                description: NodeRunningUpdate field is used for serializing cluster nodes configuration
+                description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
                 type: string
               nodeUpdateStart:
-                description: NodeUpdateStart marks starting time of a node on a policy configuration
+                description: NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
                 format: date-time
                 type: string
             type: object
@@ -124,7 +123,6 @@ spec:
               parallel:
                 description: When set to true, changes are applied to all nodes in parallel
                 type: boolean
-                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -152,10 +150,10 @@ spec:
                   type: object
                 type: array
               nodeRunningUpdate:
-                description: NodeRunningUpdate field is used for serializing cluster nodes configuration
+                description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
                 type: string
               nodeUpdateStart:
-                description: NodeUpdateStart marks starting time of a node on a policy configuration
+                description: NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
                 format: date-time
                 type: string
             type: object

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -48,6 +48,10 @@ spec:
                   type: string
                 description: 'NodeSelector is a selector which must be true for the policy to be applied to the node. Selector which must match a node''s labels for the policy to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
+              parallel:
+                description: When set to true, changes are applied to all nodes in parallel
+                type: boolean
+                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -74,6 +78,13 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeRunningUpdate:
+                description: NodeRunningUpdate field is used for serializing cluster nodes configuration
+                type: string
+              nodeUpdateStart:
+                description: NodeUpdateStart marks starting time of a node on a policy configuration
+                format: date-time
+                type: string
             type: object
         type: object
     served: true
@@ -110,6 +121,10 @@ spec:
                   type: string
                 description: 'NodeSelector is a selector which must be true for the policy to be applied to the node. Selector which must match a node''s labels for the policy to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
+              parallel:
+                description: When set to true, changes are applied to all nodes in parallel
+                type: boolean
+                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -136,6 +151,13 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeRunningUpdate:
+                description: NodeRunningUpdate field is used for serializing cluster nodes configuration
+                type: string
+              nodeUpdateStart:
+                description: NodeUpdateStart marks starting time of a node on a policy configuration
+                format: date-time
+                type: string
             type: object
         type: object
     served: true

--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -9,11 +9,13 @@ routing on cluster nodes. The configuration is driven by two main object types,
 `NodeNetworkConfigurationEnactment` (Enactment).
 
 A Policy describes what is the desired network configuration on cluster nodes.
-It is created by used and applies cluster-wide. On the other hand, an Enactment
+It is created by users and applies cluster-wide. On the other hand, an Enactment
 is a read-only object that carries execution state of a Policy per each Node.
 
-Policies are applied on node via NetworkManager. Thanks to this, the
+Policies are applied on a node via NetworkManager. Thanks to this, the
 configuration is persistent on the node and survives reboots.
+
+Only one policy can be in progress at a time.
 
 ## Creating interfaces
 

--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -9,13 +9,14 @@ routing on cluster nodes. The configuration is driven by two main object types,
 `NodeNetworkConfigurationEnactment` (Enactment).
 
 A Policy describes what is the desired network configuration on cluster nodes.
-It is created by users and applies cluster-wide. On the other hand, an Enactment
-is a read-only object that carries execution state of a Policy per each Node.
+It is created by users and applies cluster-wide. User needs to ensure that only one policy is in progress
+at a time. Creating a new policy before existing one finishes has undefined behaviour.
+An Enactment, on the other hand, is a read-only object that carries execution state of a Policy per each Node.
 
 Policies are applied on a node via NetworkManager. Thanks to this, the
 configuration is persistent on the node and survives reboots.
 
-Only one policy can be in progress at a time.
+:warning: Only one policy can be in progress at a time.
 
 ## Creating interfaces
 

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -186,7 +186,7 @@ func Reset(cli client.Client, policyKey types.NamespacedName) error {
 		err = cli.Status().Update(context.TODO(), policy)
 		if err != nil {
 			if apierrors.IsConflict(err) {
-				logger.Info("conflict reseting policy conditions, retrying")
+				logger.Info("conflict resetting policy conditions, retrying")
 			} else {
 				logger.Error(err, "failed to reset policy conditions")
 			}

--- a/test/e2e/handler/conditions.go
+++ b/test/e2e/handler/conditions.go
@@ -75,7 +75,7 @@ func enactmentConditionsStatusConsistently(node string) AsyncAssertion {
 	return enactmentConditionsStatusForPolicyConsistently(node, TestPolicy)
 }
 
-// In case a condition does not exist create with Unknonw type, this way
+// In case a condition does not exist create with Unknown type, this way
 // is easier to just use gomega matchers to check in a homogenous way that
 // condition is not present or unknown.
 func policyConditionsStatus(policyName string) shared.ConditionList {

--- a/test/e2e/handler/examples_test.go
+++ b/test/e2e/handler/examples_test.go
@@ -17,7 +17,7 @@ type exampleSpec struct {
 // It only checks the top level API, hence it does not verify that the
 // configuration is indeed applied on nodes. That should be tested by dedicated
 // test suites for each feature.
-var _ = Describe("Examples", func() {
+var _ = Describe("[user-guide] Examples", func() {
 	beforeTestIfaceExample := func(fileName string) {
 		kubectlAndCheck("apply", "-f", fmt.Sprintf("docs/examples/%s", fileName))
 	}

--- a/test/e2e/handler/multiple_policies_for_same_node_test.go
+++ b/test/e2e/handler/multiple_policies_for_same_node_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -18,15 +17,15 @@ var _ = Describe("NodeNetworkState", func() {
 
 		BeforeEach(func() {
 			setDesiredStateWithPolicy(staticIpPolicy, ifaceUpWithStaticIP(firstSecondaryNic, ipAddress))
-			setDesiredStateWithPolicy(vlanPolicy, ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(staticIpPolicy)
+			setDesiredStateWithPolicy(vlanPolicy, ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(vlanPolicy)
 		})
 
 		AfterEach(func() {
 			setDesiredStateWithPolicy(staticIpPolicy, ifaceDownIPv4Disabled(firstSecondaryNic))
-			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(staticIpPolicy)
+			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(firstSecondaryNic, vlanId))
 			waitForAvailablePolicy(vlanPolicy)
 			deletePolicy(staticIpPolicy)
 			deletePolicy(vlanPolicy)

--- a/test/e2e/handler/nncp_parallel_test.go
+++ b/test/e2e/handler/nncp_parallel_test.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("NNCP with parallel set to true", func() {
+	Context("when applying a policy to matching nodes", func() {
+		progressConditions := []nmstate.Condition{
+			nmstate.Condition{
+				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionProgressing,
+				Status: corev1.ConditionTrue,
+			},
+			nmstate.Condition{
+				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAvailable,
+				Status: corev1.ConditionUnknown,
+			},
+			nmstate.Condition{
+				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionFailing,
+				Status: corev1.ConditionUnknown,
+			},
+			nmstate.Condition{
+				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
+				Status: corev1.ConditionTrue,
+			},
+		}
+		BeforeEach(func() {
+			node := nodes[0]
+			By("Create a policy")
+			updateDesiredState(linuxBrUp(bridge1))
+			By(fmt.Sprintf("Wait for %s progressing state reached", node))
+			enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
+		})
+		AfterEach(func() {
+			By("Remove the policy")
+			deletePolicy(TestPolicy)
+			By("Reset desired state at all nodes")
+			resetDesiredStateForNodes()
+		})
+		It("should be progressing on multiple nodes at the same time", func() {
+			if !parallelRollout {
+				Skip("Parallel rollout need to be enabled")
+			}
+			progressingEnactments := 0
+
+			var wg sync.WaitGroup
+			wg.Add(len(nodes))
+			for i, _ := range nodes {
+				node := nodes[i]
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
+				}()
+			}
+			wg.Wait()
+
+			for _, node := range nodes {
+				enactment := enactmentConditionsStatus(node, TestPolicy)
+				if enactment.Find(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing) != nil {
+					progressingEnactments++
+				}
+			}
+			By("Check that all node enactments turned progressing before others turned available")
+			Expect(progressingEnactments).Should(BeNumerically(">", 1))
+		})
+	})
+})

--- a/test/e2e/handler/nncp_parallel_test.go
+++ b/test/e2e/handler/nncp_parallel_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"sync"
 
 	. "github.com/onsi/ginkgo"
@@ -32,22 +31,18 @@ var _ = Describe("NNCP with parallel set to true", func() {
 			},
 		}
 		BeforeEach(func() {
-			node := nodes[0]
 			By("Create a policy")
 			updateDesiredState(linuxBrUp(bridge1))
-			By(fmt.Sprintf("Wait for %s progressing state reached", node))
-			enactmentConditionsStatusEventually(node).Should(ConsistOf(progressConditions))
 		})
 		AfterEach(func() {
+			By("Remove the bridge")
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			By("Remove the policy")
 			deletePolicy(TestPolicy)
 			By("Reset desired state at all nodes")
 			resetDesiredStateForNodes()
 		})
-		It("should be progressing on multiple nodes at the same time", func() {
-			if !parallelRollout {
-				Skip("Parallel rollout need to be enabled")
-			}
+		It("[parallel] should be progressing on multiple nodes", func() {
 			progressingEnactments := 0
 
 			var wg sync.WaitGroup
@@ -68,7 +63,7 @@ var _ = Describe("NNCP with parallel set to true", func() {
 					progressingEnactments++
 				}
 			}
-			By("Check that all node enactments turned progressing before others turned available")
+			By("Check that multiple enactments are progressing.")
 			Expect(progressingEnactments).Should(BeNumerically(">", 1))
 		})
 	})

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("NNS LastSuccessfulUpdateTime", func() {
+var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 	Context("when updating nns", func() {
 		It("timestamp should be changed", func() {
 			for _, node := range nodes {

--- a/test/e2e/handler/nodes_test.go
+++ b/test/e2e/handler/nodes_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]Nodes", func() {
+var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component][nns]Nodes", func() {
 	Context("when are up", func() {
 		It("should have NodeNetworkState with currentState for each node", func() {
 			for _, node := range nodes {

--- a/test/e2e/handler/user_guide_test.go
+++ b/test/e2e/handler/user_guide_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("Introduction", func() {
+var _ = Describe("[user-guide] Introduction", func() {
 	runConfiguration := func() {
 		kubectlAndCheck("apply", "-f", "docs/user-guide/bond0-eth1-eth2_up.yaml")
 		kubectlAndCheck("wait", "nncp", "bond0-eth1-eth2", "--for", "condition=Available", "--timeout", "2m")

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -33,8 +33,9 @@ const ReadInterval = 1 * time.Second
 const TestPolicy = "test-policy"
 
 var (
-	bridgeCounter = 0
-	bondConunter  = 0
+	bridgeCounter   = 0
+	bondConunter    = 0
+	parallelRollout = environment.GetBoolVarWithDefault("NMSTATE_PARALLEL_ROLLOUT", false)
 )
 
 func interfacesName(interfaces []interface{}) []string {
@@ -68,6 +69,7 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstate.
 		err := testenv.Client.Get(context.TODO(), key, &policy)
 		policy.Spec.DesiredState = desiredState
 		policy.Spec.NodeSelector = nodeSelector
+		policy.Spec.Parallel = parallelRollout
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return testenv.Client.Create(context.TODO(), &policy)

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"os"
+	"strconv"
 )
 
 func GetVarWithDefault(name string, defaultValue string) string {
@@ -10,4 +11,13 @@ func GetVarWithDefault(name string, defaultValue string) string {
 		value = defaultValue
 	}
 	return value
+}
+
+func GetBoolVarWithDefault(name string, defaultValue bool) bool {
+	value := os.Getenv(name)
+	boolValue, err := strconv.ParseBool(value)
+	if err != nil {
+		boolValue = defaultValue
+	}
+	return boolValue
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:

With this PR NNCPs are by default applied sequentially on cluster nodes. 
A new field is added to NNCP Spec: `Parallel`, which can be set to true
to roll out configuration in parallel, which was the previous behaviour.

Additionaly there are added two fields to NNCP Status: `NodeRunningUpdate`  and `NodeUpdateStart`, which contain node name and timestamp when a node started with configuration.

The `NodeRunningUpdate` serves as a mutex, nodes that fail to claim this field requeue the reconcile request and try again later.
When a node owning this field hasn't released it for longer than 5 minutes, other nodes assume that there is an issue and set their enactment state to `FailedToConfigure` (and don't attempt to retry anymore).


TODOs:
This PR introduces only basic functionality of the sequential rollout, there are several gaps that need to be covered in followup PRs:
- Webhook admitter, that prevents users to edit or create new NNCP, when existing NNCP is still in progress
- New enactment state `aborted`. In this PR, when a node doesn't manage to apply configuration in time, rest of the nodes set their state to `FailedToConfigure`, which is not accurate, because technically, they haven't tried. Instead, `aborted` state should be used to accurately inform user about the situation.
- There have been suggestions to allow user to define a number of nodes that are allowed to apply NNCP in parallel.
  We could instead of `Parallel` introduce something like a chunkSize, and instead of `nodeRunningUpdate` something like `nodeUpdateCapacity`which would effectively act as a semaphore instead of a mutex

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Roll out policy configuration sequentially by default.
```
