### PR TITLE
Reconcile populted NNCP if node is created or modified

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 
 			nodeNetworkConfigurationPolicy := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
 
-			predicate := watchPredicate
+			predicate := onCreateOrUpdateWithDifferentGeneration
 
 			Expect(predicate.
 				CreateFunc(event.CreateEvent{

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -1,31 +1,38 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 )
 
 var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]NodeSelector", func() {
-	nonexistentNodeSelector := map[string]string{"nonexistentKey": "nonexistentValue"}
-
+	testNodeSelector := map[string]string{"testKey": "testValue"}
 	Context("when policy is set with node selector not matching any nodes", func() {
 		BeforeEach(func() {
 			By(fmt.Sprintf("Set policy %s with not matching node selector", bridge1))
-			setDesiredStateWithPolicyAndNodeSelector(bridge1, linuxBrUp(bridge1), nonexistentNodeSelector)
+			setDesiredStateWithPolicyAndNodeSelector(bridge1, linuxBrUp(bridge1), testNodeSelector)
 			waitForAvailablePolicy(bridge1)
 		})
 
 		AfterEach(func() {
+			By(fmt.Sprintf("Deleteting linux bridge %s", bridge1))
 			setDesiredStateWithPolicy(bridge1, linuxBrAbsent(bridge1))
 			waitForAvailablePolicy(bridge1)
 			deletePolicy(bridge1)
 			resetDesiredStateForNodes()
+
+			By("Remove test label from node")
+			removeLabelsFromNode(nodes[0], testNodeSelector)
 		})
 
 		It("[test_id:3813]should not update any nodes and have false Matching state", func() {
@@ -63,5 +70,53 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 		})
+		Context("and we add the label to the node", func() {
+			BeforeEach(func() {
+				By("Add test label to node")
+				addLabelsToNode(nodes[0], testNodeSelector)
+			})
+			It("should apply the policy", func() {
+				enactmentConditionsStatusForPolicyEventually(nodes[0], bridge1).Should(ContainElement(
+					nmstate.Condition{
+						Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
+						Status: corev1.ConditionTrue,
+					}))
+				waitForAvailablePolicy(bridge1)
+				interfacesNameForNodeEventually(nodes[0]).Should(ContainElement(bridge1))
+			})
+		})
 	})
 })
+
+func addLabelsToNode(nodeName string, labelsToAdd map[string]string) {
+	node := corev1.Node{}
+	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to change labels")
+
+	if len(node.Labels) == 0 {
+		node.Labels = labelsToAdd
+	} else {
+		for k, v := range labelsToAdd {
+			node.Labels[k] = v
+		}
+	}
+	err = testenv.Client.Update(context.TODO(), &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with new labels")
+}
+
+func removeLabelsFromNode(nodeName string, labelsToRemove map[string]string) {
+	node := corev1.Node{}
+	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to remove labels")
+
+	if len(node.Labels) == 0 {
+		return
+	}
+
+	for k, _ := range labelsToRemove {
+		delete(node.Labels, k)
+	}
+
+	err = testenv.Client.Update(context.TODO(), &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with label delete")
+}


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Current kubernetes-nmstate version does not Reconcile already populated NNCPs
if Nodes are added to the cluster or node labels are modified. This PR force
Reconcile of all policies if a node is create or updated.

Since Reconcile functions already take care to checking node labels we choose
to simplify the implementation here just checking for Node Update not checking
if the update is for labels or if the labels are for this node, nmstate is declarative
so if if same version is re-apply it should not be a noop.

**Special notes for your reviewer**:

**Release note**:

```release-note
Reconcile NNCPs if nodes are created or updated.
```
