### PR TITLE
Disable metrics default behaviour

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,8 +64,7 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, logType string
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	var logType string
 	flag.StringVar(&logType, "v", "production", "Log type (debug/production).")
 	flag.Parse()
 
@@ -85,7 +84,8 @@ func main() {
 	}
 
 	ctrlOptions := ctrl.Options{
-		Scheme: scheme,
+		Scheme:             scheme,
+		MetricsBindAddress: "0", // disable metrics
 	}
 
 	// We need to add LeaerElection for the webhook


### PR DESCRIPTION


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
By default the controller-runtime metrics will start up at
port 8080 for handler pod this is a problem since it's operating
on host networking so it's opening port 8080 directly at node, let's
just disable it and think about a solution in in the future in case
metrics are really needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Disable default metrics on port 8080
```
