### PR TITLE
[release-0.31] Disable metrics default behaviour

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -107,8 +107,9 @@ func main() {
 	}
 
 	mgrOptions := manager.Options{
-		Namespace:      namespace,
-		MapperProvider: apiutil.NewDiscoveryRESTMapper,
+		Namespace:          namespace,
+		MapperProvider:     apiutil.NewDiscoveryRESTMapper,
+		MetricsBindAddress: "0", // disable metrics
 	}
 
 	// We need to add LeaerElection for the webhook


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
By default the controller-runtime metrics will start up at
port 8080 for handler pod this is a problem since it's operating
on host networking so it's opening port 8080 directly at node, let's
just disable it and think about a solution in in the future in case
metrics are really needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Disable default metrics 
```
