### PR TITLE
Remove code directories from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,9 +16,6 @@ _kubevirtci
 kubevirtci
 
 # No need for source code is already compiled
-pkg
-cmd
-vendor
 docs
 
 # Test and infra


### PR DESCRIPTION
Remove pkg cmd and vendor from .dockerignore, as it causes builds
    with Docker and the build/Dockerfile.*openshift builds to fail.
    This is due to them being multistage builds.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
   Remove pkg cmd and vendor from .dockerignore, as it causes builds
    with Docker and the build/Dockerfile.*openshift builds to fail.
    This is due to them being multistage builds.
    
    The error is:
    
    Step 4/10 : RUN go build --mod=vendor -o build/_output/bin/manager main.go
    ---> Running in 946711c1028e
    go: inconsistent vendoring in /go/src/github.com/openshift/kubernetes-nmstate:
    
    This is caused by the vendor directory not being present. This does not affect
    Podman builds.
    
    The multistage builds need to have a complete picture, so we need
    to include these directories in the build context. This will allow the
    regular Dockerfiles to also be migrated to a multistage build approach,
    which is desirable.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
none
```
