### PR TITLE
knmstate, docs: Remove docker caching

### DIFF
--- a/automation/check-patch.docs.sh
+++ b/automation/check-patch.docs.sh
@@ -6,11 +6,11 @@ baseurl="kubevirt-prow/pr-logs/pull/nmstate_kubernetes-nmstate/${PULL_NUMBER}/pu
 sed -i "s#^url:.*#url: \"$url\"#" docs/_config.yaml
 sed -i "s#^baseurl:.*#baseurl: \"$baseurl\"#" docs/_config.yaml
 
-# Build the docs
-docker build docs --build-arg BRANCH=${PULL_BASE_REF} -t kubernetes-nmstate-docs
+
+docker run -v $(pwd)/docs:/docs/ ruby make -C docs install check
 
 # Copy the docs to the artifacts
 mkdir -p $ARTIFACTS/gh-pages
-docker run -v $ARTIFACTS:/artifacts kubernetes-nmstate-docs cp -r docs/build/$baseurl /artifacts
+rsync -rt --links docs/build/$baseurl $ARTIFACTS/gh-pages
 
 echo "kubernetes-nmstate preview URL: ${url}/${baseurl}index.html"

--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -8,40 +8,33 @@
 
 image_registry=${IMAGE_REGISTRY:-quay.io}
 image_repo=${IMAGE_REPO:-nmstate}
-branch=${PULL_BASE_REF:-$(git rev-parse --abbrev-ref HEAD)}
-docs_source_branch=master
-docs_container=${image_registry}/${image_repo}/kubernetes-nmstate-docs:$docs_source_branch
 
-# Publish kubernets-nmstate containers
 source automation/check-patch.setup.sh
-(
+cd ${TMP_PROJECT_PATH}
+
+push_knmstate_containers() {
     cd ${TMP_PROJECT_PATH}
     make \
         IMAGE_REGISTRY=${image_registry}  \
         IMAGE_REPO=${image_repo} \
         push-handler \
         push-operator
-)
+}
 
-# We don't have a versioned docs webpage so we only update it from master and
-# not from release branches
-if [ "$branch" == $docs_source_branch ]; then
-
-    # Update kubernetes-nmstate documentation container
-    docker build docs --build-arg BRANCH=$docs_source_branch -t $docs_container
-    docker push $docs_container
-
-    # To pass user/password from automations, idea is taken from [1]
-    # [1] https://stackoverflow.com/questions/8536732/can-i-hold-git-credentials-in-environment-variables
-    git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
-
+publish_docs() {
     # Update gh-pages branch with the generated documentation
-    git checkout gh-pages --quiet
-    git rm -r --quiet *
-    docker run -v $(pwd):/gh-pages $docs_container bash -c "cp -r docs/build/kubernetes-nmstate/* /gh-pages"
-    git add -A
-    git commit -m "updated $(date +"%d.%m.%Y %H:%M:%S")"
-    git push --quiet
+    docker run -v $(pwd)/docs:/docs/ ruby make -C /docs install build
+    rm -rf /tmp/gh-pages
+    git clone --single-branch http://github.com/nmstate/kubernetes-nmstate -b gh-pages /tmp/gh-pages
+    rsync -rt --links --cvs-exclude docs/build/kubernetes-nmstate/* /tmp/gh-pages
+    (
+        cd /tmp/gh-pages
+        git add -A
+        git commit -m "updated $(date +"%d.%m.%Y %H:%M:%S")"
+        git push https://${GITHUB_USER}github.com/nmstate/kubernetes-nmstate gh-pages
+    )
     echo -e "\033[0;32mdemo updated $(date +"%d.%m.%Y %H:%M:%S")\033[0m"
-    git checkout $docs_source_branch --quiet
-fi
+}
+
+push_knmstate_containers
+publish_docs

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,0 @@
-ARG  BRANCH=master
-FROM quay.io/nmstate/kubernetes-nmstate-docs:${BRANCH}
-COPY Makefile Gemfile* /docs/
-RUN make -C docs install
-COPY . /docs/
-RUN make -C docs check

--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -5,7 +5,7 @@ title: "The Kubernetes NMState project"
 description: A declarative API for Kubernetes node network management
 name: "The Kubernetes NMState team"
 url: "https://nmstate.github.io"
-baseurl: "/kubernetes-nmstate"
+baseurl: "kubernetes-nmstate"
 logo: "assets/images/logo/fullcolor.png"
 markdown: kramdown
 repository: nmstate/kubernetes-nmstate


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
knmstate, docs: Don't cache builder

The current docs builder caching mechanism is implemented as a
container that use the FROM clausule from the same container that's
pretty wrong since you get never ending layers, let's just remove that
cache and think about it if it's necessary, we are talking about mintues.

**Special notes for your reviewer**:
Closes #637 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
