### PR TITLE
Fix NNCE condition Reset function

### DIFF
--- a/pkg/enactmentstatus/conditions/conditions.go
+++ b/pkg/enactmentstatus/conditions/conditions.go
@@ -83,7 +83,7 @@ func (ec *EnactmentConditions) NotifySuccess() {
 func (ec *EnactmentConditions) Reset() {
 	ec.logger.Info("Reset")
 	err := ec.updateEnactmentConditions(func(conditionList *nmstate.ConditionList, message string) {
-		conditionList = &nmstate.ConditionList{}
+		*conditionList = nil
 	}, "")
 	if err != nil {
 		ec.logger.Error(err, "Error resetting conditions")


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

/kind bug

**What this PR does / why we need it**:

All parameters are passed by value in Go.
Thus when a pointer is passed to a function by a parameter, changing the pointer has no effect outside the function.
The enactmentConditions Reset function didn't actually reset the enactment conditions, which caused a race condition
in situation when user updates existing policy, and the updated policy has a nodeSelector that doesn't match at least one node.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
