### PR TITLE
Add git name and user at publish.sh

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -30,8 +30,10 @@ publish_docs() {
     (
         cd /tmp/gh-pages
         git add -A
+        git config user.name $GITHUB_USER
+        git config user.email $GITHUB_EMAIL
         git commit -m "updated $(date +"%d.%m.%Y %H:%M:%S")"
-        git push https://${GITHUB_USER}github.com/nmstate/kubernetes-nmstate gh-pages
+        git push https://${GITHUB_USER}@github.com/nmstate/kubernetes-nmstate gh-pages
     )
     echo -e "\033[0;32mdemo updated $(date +"%d.%m.%Y %H:%M:%S")\033[0m"
 }


### PR DESCRIPTION
The prow publish job [1] is on commiting since there is no git user email
configured, this change do similar to kubevirtci [2] and adds the
kubevirtbot name and email.

[1] https://storage.googleapis.com/kubevirt-prow/logs/publish-kubernetes-nmstate/1331559224613801984/build-log.txt
[2] https://github.com/kubevirt/kubevirtci/blob/master/publish.sh#L29-L30

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:
Depends on https://github.com/kubevirt/project-infra/pull/734

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
