### PR TITLE
Reduce default gw probe traces

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -124,10 +124,18 @@ func defaultGw() (string, error) {
 		if err != nil {
 			return false, errors.Wrap(err, "failed retrieving current state to retrieve default gw")
 		}
+		defaultGwGjsonPath := "routes.running.#(destination==\"0.0.0.0/0\").next-hop-address"
 		defaultGw = gjsonCurrentState.
-			Get("routes.running.#(destination==\"0.0.0.0/0\").next-hop-address").String()
+			Get(defaultGwGjsonPath).String()
 		if defaultGw == "" {
-			log.Info("default gw missing", "state", gjsonCurrentState.String())
+			msg := "default gw missing"
+			defaultGwLog := log.WithValues("path", defaultGwGjsonPath)
+			defaultGwLogDebug := defaultGwLog.V(1)
+			if defaultGwLogDebug.Enabled() {
+				defaultGwLogDebug.Info(msg, "state", gjsonCurrentState.String())
+			} else {
+				defaultGwLog.Info(msg)
+			}
 			return false, nil
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Currectly kubernetes-nmstate prints the network state every time it does
not find the default gw when the probe is running, clearly this is too
verbose. To fix that this change in case of "-v=production" just print
the error and the gjson path used to find the default gw, in case of
"-v=debug" it also prints the network state.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
