### PR TITLE
ci, Fix ci commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,10 @@ test/unit: $(GINKGO)
 	INTERFACES_FILTER="" NODE_NAME=node01 $(GINKGO) $(unit_test_args) $(WHAT)
 
 test-e2e-handler: $(GINKGO)
-	KUBECONFIG=$(shell ./cluster/kubeconfig.sh) $(GINKGO) $(e2e_test_args) ./test/e2e/handler ... -- $(E2E_TEST_SUITE_ARGS)
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/handler ... -- $(E2E_TEST_SUITE_ARGS)
 
 test-e2e-operator: manifests $(GINKGO)
-	KUBECONFIG=$(shell ./cluster/kubeconfig.sh) $(GINKGO) $(e2e_test_args) ./test/e2e/operator ... -- $(E2E_TEST_SUITE_ARGS)
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/operator ... -- $(E2E_TEST_SUITE_ARGS)
 
 test-e2e: test-e2e-operator test-e2e-handler
 

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -257,7 +257,7 @@ func interfaces(state nmstate.State) []interface{} {
 }
 
 func currentState(node string, currentStateYaml *nmstate.State) AsyncAssertion {
-	key := types.NamespacedName{Namespace: testenv.OperatorNamespace, Name: node}
+	key := types.NamespacedName{Name: node}
 	return Eventually(func() nmstate.RawState {
 		*currentStateYaml = nodeNetworkState(key).Status.CurrentState
 		return currentStateYaml.Raw
@@ -313,7 +313,7 @@ func interfacesForNode(node string) AsyncAssertion {
 func waitForNodeNetworkStateUpdate(node string) {
 	now := time.Now()
 	EventuallyWithOffset(1, func() time.Time {
-		key := types.NamespacedName{Namespace: testenv.OperatorNamespace, Name: node}
+		key := types.NamespacedName{Name: node}
 		nnsUpdateTime := nodeNetworkState(key).Status.LastSuccessfulUpdateTime
 		return nnsUpdateTime.Time
 	}, 4*time.Minute, 5*time.Second).Should(BeTemporally(">=", now), fmt.Sprintf("Node %s should have a fresh nns)", node))


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR fixes ci issues needed to run the repo in tier1 tests on [CNAO](https://github.com/kubevirt/cluster-network-addons-operator) repo

- **ci, Change ci Makefile commands use KUBECONFIG**
Currently test-e2e-handler and test-e2e-operator use explicit kubeconfig of the
knmstate repo. In order to run tier1 tests, we want to be able to use KUBECONFIG
set by external cluster.
Added KUBECONFIG var instead of explicit kubeconfig in ci makefile targets

- **ci, Remove usage of namespace in cluster scoped objects**
Currently we are using the namespace to find NodeNetworkState object
This is wrong, since this object is cluster scoped.
Removed the usage of the namespac when searching of NodeNetworkState objects

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
