### PR TITLE
Activate k8s reporter for handler e2e test

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -15,7 +15,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	//knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
+	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -68,7 +68,7 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	reporters := make([]Reporter, 0)
-	//reporters = append(reporters, knmstatereporter.New("test_logs/e2e/handler", testenv.OperatorNamespace, nodes))
+	reporters = append(reporters, knmstatereporter.New("test_logs/e2e/handler", testenv.OperatorNamespace, nodes))
 	if ginkgoreporters.Polarion.Run {
 		reporters = append(reporters, &ginkgoreporters.Polarion)
 	}

--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -110,6 +110,14 @@ func (r *KubernetesNMStateReporter) logDeviceStatus(testName string) {
 func (r *KubernetesNMStateReporter) Cleanup() {
 	// clean up artifacts from previous run
 	if r.artifactsDir != "" {
+		_, err := os.Stat(r.artifactsDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return
+			} else {
+				panic(err)
+			}
+		}
 		names, err := ioutil.ReadDir(r.artifactsDir)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The kubernetes e2e test reporter was activated for operator tests but
not for handler.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
