### PR TITLE
Fix intermitent Status at NNCP sequencial rollout

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -50,6 +50,7 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
 	"github.com/nmstate/kubernetes-nmstate/pkg/policyconditions"
 	"github.com/nmstate/kubernetes-nmstate/pkg/selectors"
+	nncp "github.com/nmstate/kubernetes-nmstate/pkg/webhook/nodenetworkconfigurationpolicy"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -218,7 +219,10 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(request ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	policyconditions.Reset(r.Client, request.NamespacedName)
+	_, hasWebhookLabel := instance.ObjectMeta.Annotations[nncp.TimestampLabelKey]
+	if !hasWebhookLabel {
+		policyconditions.Reset(r.Client, request.NamespacedName)
+	}
 
 	err = r.initializeEnactment(*instance)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Reconcile always resets nncp status at the beginning.
This doesn't cause issue when applied in parallel, but
in case of sequential rollout, the nncp is missing status
information for the whole duration of a reconcile.

This PR addresses if by resetting only when not using webhook.
When using webhook, it handles status reset of nncp when new nncp 
is created/updated, so we don't need to reset in Reconcile.

The issue persists when not using webhook, but does not affect functionality.


**Special notes for your reviewer**:
None

**Release note**:

```release-note
NONE
```
