### PR TITLE
Add Aborted conditionType for policy enactments

### DIFF
--- a/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/api/shared/nodenetworkconfigurationenactment_types.go
@@ -25,6 +25,7 @@ const (
 	NodeNetworkConfigurationEnactmentConditionFailing     ConditionType = "Failing"
 	NodeNetworkConfigurationEnactmentConditionProgressing ConditionType = "Progressing"
 	NodeNetworkConfigurationEnactmentConditionMatching    ConditionType = "Matching"
+	NodeNetworkConfigurationEnactmentConditionAborted     ConditionType = "Aborted"
 )
 
 var NodeNetworkConfigurationEnactmentConditionTypes = [...]ConditionType{
@@ -32,6 +33,7 @@ var NodeNetworkConfigurationEnactmentConditionTypes = [...]ConditionType{
 	NodeNetworkConfigurationEnactmentConditionFailing,
 	NodeNetworkConfigurationEnactmentConditionProgressing,
 	NodeNetworkConfigurationEnactmentConditionMatching,
+	NodeNetworkConfigurationEnactmentConditionAborted,
 }
 
 const (
@@ -40,6 +42,7 @@ const (
 	NodeNetworkConfigurationEnactmentConditionConfigurationProgressing         ConditionReason = "ConfigurationProgressing"
 	NodeNetworkConfigurationEnactmentConditionNodeSelectorNotMatching          ConditionReason = "NodeSelectorNotMatching"
 	NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching ConditionReason = "AllSelectorsMatching"
+	NodeNetworkConfigurationEnactmentConditionConfigurationAborted             ConditionReason = "ConfigurationAborted"
 )
 
 func EnactmentKey(node string, policy string) types.NamespacedName {

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -1,9 +1,5 @@
 package shared
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
 // NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicySpec struct {
 	// NodeSelector is a selector which must be true for the policy to be applied to the node.
@@ -28,10 +24,6 @@ type NodeNetworkConfigurationPolicyStatus struct {
 	// NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
 	// +optional
 	NodeRunningUpdate string `json:"nodeRunningUpdate,omitempty" optional:"true"`
-
-	// NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
-	// +optional
-	NodeUpdateStart *metav1.Time `json:"nodeUpdateStart,omitempty" optional:"true"`
 }
 
 const (

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -34,7 +34,7 @@ main() {
 
     export E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml"
     if [ $NMSTATE_PARALLEL_ROLLOUT == "true" ]; then
-       E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='user-guide|nns'"
+       E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='user-guide|nns|sequential'"
     else
        E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='parallel'"
     fi

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -80,10 +80,6 @@ spec:
               nodeRunningUpdate:
                 description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
                 type: string
-              nodeUpdateStart:
-                description: NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
-                format: date-time
-                type: string
             type: object
         type: object
     served: true
@@ -151,10 +147,6 @@ spec:
                 type: array
               nodeRunningUpdate:
                 description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
-                type: string
-              nodeUpdateStart:
-                description: NodeUpdateStart marks starting time of a node on a policy configuration when Parallel flag is false
-                format: date-time
                 type: string
             type: object
         type: object

--- a/pkg/enactmentstatus/conditions/conditions.go
+++ b/pkg/enactmentstatus/conditions/conditions.go
@@ -72,6 +72,14 @@ func (ec *EnactmentConditions) NotifyFailedToConfigure(failedErr error) {
 	}
 }
 
+func (ec *EnactmentConditions) NotifyAborted(failedErr error) {
+	ec.logger.Info("NotifyConfigurationAborted")
+	err := ec.updateEnactmentConditions(SetConfigurationAborted, failedErr.Error())
+	if err != nil {
+		ec.logger.Error(err, "Error notifying state ConfigurationAborted")
+	}
+}
+
 func (ec *EnactmentConditions) NotifySuccess() {
 	ec.logger.Info("NotifySuccess")
 	err := ec.updateEnactmentConditions(SetSuccess, "successfully reconciled")
@@ -123,6 +131,43 @@ func SetFailed(conditions *nmstate.ConditionList, reason nmstate.ConditionReason
 		reason,
 		"",
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured,
+		"",
+	)
+}
+
+func SetConfigurationAborted(conditions *nmstate.ConditionList, message string) {
+	SetAborted(conditions, nmstate.NodeNetworkConfigurationEnactmentConditionConfigurationAborted, message)
+}
+
+func SetAborted(conditions *nmstate.ConditionList, reason nmstate.ConditionReason, message string) {
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionFailing,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAvailable,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionProgressing,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+		corev1.ConditionTrue,
+		reason,
+		message,
+	)
 }
 
 func SetSuccess(conditions *nmstate.ConditionList, message string) {
@@ -140,6 +185,12 @@ func SetSuccess(conditions *nmstate.ConditionList, message string) {
 	)
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationEnactmentConditionProgressing,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
 		corev1.ConditionFalse,
 		nmstate.NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured,
 		"",
@@ -162,6 +213,12 @@ func SetProgressing(conditions *nmstate.ConditionList, message string) {
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationEnactmentConditionAvailable,
 		corev1.ConditionUnknown,
+		nmstate.NodeNetworkConfigurationEnactmentConditionConfigurationProgressing,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+		corev1.ConditionFalse,
 		nmstate.NodeNetworkConfigurationEnactmentConditionConfigurationProgressing,
 		"",
 	)
@@ -196,6 +253,12 @@ func SetNotMatching(conditions *nmstate.ConditionList, reason nmstate.ConditionR
 		reason,
 		message,
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+		corev1.ConditionFalse,
+		reason,
+		"",
+	)
 }
 
 func SetMatching(conditions *nmstate.ConditionList, message string) {
@@ -222,5 +285,11 @@ func SetMatching(conditions *nmstate.ConditionList, message string) {
 		corev1.ConditionTrue,
 		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
 		message,
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+		corev1.ConditionUnknown,
+		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
+		"",
 	)
 }

--- a/pkg/enactmentstatus/conditions/counter.go
+++ b/pkg/enactmentstatus/conditions/counter.go
@@ -46,6 +46,9 @@ func (c ConditionCount) available() CountByConditionStatus {
 func (c ConditionCount) matching() CountByConditionStatus {
 	return c[nmstate.NodeNetworkConfigurationEnactmentConditionMatching]
 }
+func (c ConditionCount) aborted() CountByConditionStatus {
+	return c[nmstate.NodeNetworkConfigurationEnactmentConditionAborted]
+}
 
 func (c CountByConditionStatus) true() int {
 	return c[corev1.ConditionTrue]
@@ -83,9 +86,15 @@ func (c ConditionCount) Matching() int {
 func (c ConditionCount) NotMatching() int {
 	return c.matching().false()
 }
+func (c ConditionCount) Aborted() int {
+	return c.aborted().true()
+}
+func (c ConditionCount) NotAborted() int {
+	return c.aborted().false()
+}
 
 func (c ConditionCount) String() string {
-	return fmt.Sprintf("{failed: %s, progressing: %s, available: %s, matching: %s}", c.failed(), c.progressing(), c.available(), c.matching())
+	return fmt.Sprintf("{failed: %s, progressing: %s, available: %s, matching: %s, aborted: %s}", c.failed(), c.progressing(), c.available(), c.matching(), c.aborted())
 }
 
 func (c CountByConditionStatus) String() string {

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -50,6 +50,10 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
 					Status: corev1.ConditionTrue,
 				},
+				nmstate.Condition{
+					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+					Status: corev1.ConditionFalse,
+				},
 			}
 			availableConditions := []nmstate.Condition{
 				nmstate.Condition{
@@ -67,6 +71,10 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				nmstate.Condition{
 					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
 					Status: corev1.ConditionTrue,
+				},
+				nmstate.Condition{
+					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+					Status: corev1.ConditionFalse,
 				},
 			}
 			var wg sync.WaitGroup
@@ -98,9 +106,31 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	})
 
 	Context("when applying invalid configuration", func() {
+		var failingEnactmentConditions = []interface{}{
+			shared.Condition{
+				Type:   shared.NodeNetworkConfigurationEnactmentConditionFailing,
+				Status: corev1.ConditionTrue,
+			},
+			shared.Condition{
+				Type:   shared.NodeNetworkConfigurationEnactmentConditionAvailable,
+				Status: corev1.ConditionFalse,
+			},
+			shared.Condition{
+				Type:   shared.NodeNetworkConfigurationEnactmentConditionProgressing,
+				Status: corev1.ConditionFalse,
+			},
+			shared.Condition{
+				Type:   shared.NodeNetworkConfigurationEnactmentConditionMatching,
+				Status: corev1.ConditionTrue,
+			},
+			shared.Condition{
+				Type:   shared.NodeNetworkConfigurationEnactmentConditionAborted,
+				Status: corev1.ConditionFalse,
+			},
+		}
+
 		BeforeEach(func() {
 			updateDesiredState(invalidConfig(bridge1))
-
 		})
 
 		AfterEach(func() {
@@ -110,25 +140,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			resetDesiredStateForNodes()
 		})
 
-		It("[test_id:3795]should have Failing ConditionType set to true", func() {
-			failingEnactmentConditions := []interface{}{
-				shared.Condition{
-					Type:   shared.NodeNetworkConfigurationEnactmentConditionFailing,
-					Status: corev1.ConditionTrue,
-				},
-				shared.Condition{
-					Type:   shared.NodeNetworkConfigurationEnactmentConditionAvailable,
-					Status: corev1.ConditionFalse,
-				},
-				shared.Condition{
-					Type:   shared.NodeNetworkConfigurationEnactmentConditionProgressing,
-					Status: corev1.ConditionFalse,
-				},
-				shared.Condition{
-					Type:   shared.NodeNetworkConfigurationEnactmentConditionMatching,
-					Status: corev1.ConditionTrue,
-				},
-			}
+		It("[test_id:3795][parallel] should have Failing ConditionType set to true", func() {
 			for _, node := range nodes {
 				By(fmt.Sprintf("Check %s failing state is reached", node))
 				enactmentConditionsStatusEventually(node).Should(ConsistOf(failingEnactmentConditions...), "should eventually reach failing conditions at enactments")
@@ -143,11 +155,81 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				node := nodes[i]
 				go func() {
 					defer wg.Done()
+					defer GinkgoRecover()
 					By(fmt.Sprintf("Check %s failing state is kept", node))
 					enactmentConditionsStatusConsistently(node).Should(ConsistOf(failingEnactmentConditions...), "should consistently keep failing conditions at enactments")
 				}()
 			}
 			wg.Wait()
+		})
+
+		It("[test_id:3795][sequential] should have one Failing the rest Aborted ConditionType set to true", func() {
+			var abortedEnactmentConditions = []interface{}{
+				shared.Condition{
+					Type:   shared.NodeNetworkConfigurationEnactmentConditionFailing,
+					Status: corev1.ConditionFalse,
+				},
+				shared.Condition{
+					Type:   shared.NodeNetworkConfigurationEnactmentConditionAvailable,
+					Status: corev1.ConditionFalse,
+				},
+				shared.Condition{
+					Type:   shared.NodeNetworkConfigurationEnactmentConditionProgressing,
+					Status: corev1.ConditionFalse,
+				},
+				shared.Condition{
+					Type:   shared.NodeNetworkConfigurationEnactmentConditionMatching,
+					Status: corev1.ConditionTrue,
+				},
+				shared.Condition{
+					Type:   shared.NodeNetworkConfigurationEnactmentConditionAborted,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			checkEnactmentCounts := func(policy string) {
+				failingConditions := 0
+				abortedConditions := 0
+				for _, node := range nodes {
+					conditionList := enactmentConditionsStatus(node, TestPolicy)
+					success, _ := ConsistOf(conditionList).Match(failingEnactmentConditions)
+					if success {
+						failingConditions++
+					}
+					success, _ = ConsistOf(conditionList).Match(abortedEnactmentConditions)
+					if success {
+						abortedConditions++
+					}
+				}
+				Expect(failingConditions).To(Equal(1), "one node only should have failing enactment")
+				Expect(abortedConditions).To(Equal(len(nodes)-1), "other nodes should have aborted enactment")
+			}
+
+			By("Check policy is at degraded state")
+			waitForDegradedTestPolicy()
+
+			By("Check there is one failing enactment and the rest are aborted")
+			checkEnactmentCounts(TestPolicy)
+
+			By("Check that the enactment stays in failing or aborted state")
+			var wg sync.WaitGroup
+			wg.Add(len(nodes))
+			for i, _ := range nodes {
+				node := nodes[i]
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					By(fmt.Sprintf("Check %s failing state is kept", node))
+					enactmentConditionsStatusConsistently(node).Should(
+						SatisfyAny(
+							ConsistOf(failingEnactmentConditions...),
+							ConsistOf(abortedEnactmentConditions...),
+						), "should consistently keep failing or aborted conditions at enactments")
+				}()
+			}
+			wg.Wait()
+
+			By("Check there is still one failing enactment and the rest are aborted")
+			checkEnactmentCounts(TestPolicy)
 		})
 	})
 })

--- a/test/e2e/handler/nncp_parallel_test.go
+++ b/test/e2e/handler/nncp_parallel_test.go
@@ -29,6 +29,10 @@ var _ = Describe("NNCP with parallel set to true", func() {
 				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
 				Status: corev1.ConditionTrue,
 			},
+			nmstate.Condition{
+				Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
+				Status: corev1.ConditionFalse,
+			},
 		}
 		BeforeEach(func() {
 			By("Create a policy")


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>



**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
When rolling out nncp sequentially, if a node fails to apply configuration
other nodes do not attempt to apply it and set their enactment condition to
Aborted.

Example:
We apply sequential `policy` in a 3 node cluster.
Assume the fist node that starts applying configuration is node01, then the result will look like:
```
$ kubectl get nnce
NAME            STATUS
node01.policy   FailedToConfigure
node02.policy   ConfigurationAborted
node03.policy   ConfigurationAborted
```
In other words, node01 has started applying and failed. Node02 and node03 noted that there is a node failing to apply `policy`
and instead of attempting to apply it too set their enactment status to `ConfigurationAborted`.

**Special notes for your reviewer**:

**Release note**:


```release-note
Added new conditionType Aborted used in sequential configuration rollout
```
