### PR TITLE
Ignore logo files in whitespace.sh script

### DIFF
--- a/hack/whitespace.sh
+++ b/hack/whitespace.sh
@@ -9,7 +9,7 @@
 set -e
 
 function format() {
-    git ls-files | grep -v "^vendor/" | xargs sed --follow-symlinks -i 's/[[:space:]]*$//'
+    git ls-files | grep -v "^vendor/" | grep -v "logo/" | xargs sed --follow-symlinks -i 's/[[:space:]]*$//'
 }
 
 function check() {


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Running `make format` changes logo files, adding grep
filter to ignore these.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
