### PR TITLE
Policy rollout in chunks of custom size

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -12,18 +12,21 @@ type NodeNetworkConfigurationPolicySpec struct {
 	// The desired configuration of the policy
 	DesiredState State `json:"desiredState,omitempty"`
 
-	// When set to true, changes are applied to all nodes in parallel
+	// Percentage of matching cluster nodes that may apply policy configuration concurrently.
+	// If not specified, policy is applied one node at a time.
+	// Value of 0 means all nodes apply policy in parallel,
+	// Value of n, n > 1 means that up to n% of cluster nodes may apply policy configuration concurrently.
 	// +optional
-	Parallel bool `json:"parallel,omitempty"`
+	ChunkSize *int `json:"chunkSize,omitempty"`
 }
 
 // NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicyStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty" optional:"true"`
 
-	// NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
+	// NodeChunkCapacity is used as a semaphore to synchronize nodes applying policy configuration
 	// +optional
-	NodeRunningUpdate string `json:"nodeRunningUpdate,omitempty" optional:"true"`
+	NodeChunkCapacity int `json:"nodeChunkCapacity,omitempty" optional:"true"`
 }
 
 const (

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -39,6 +39,9 @@ spec:
           spec:
             description: NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
             properties:
+              chunkSize:
+                description: Percentage of matching cluster nodes that may apply policy configuration concurrently. If not specified, policy is applied one node at a time. Value of 0 means all nodes apply policy in parallel, Value of n, n > 1 means that up to n% of cluster nodes may apply policy configuration concurrently.
+                type: integer
               desiredState:
                 description: The desired configuration of the policy
                 type: object
@@ -48,9 +51,6 @@ spec:
                   type: string
                 description: 'NodeSelector is a selector which must be true for the policy to be applied to the node. Selector which must match a node''s labels for the policy to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
-              parallel:
-                description: When set to true, changes are applied to all nodes in parallel
-                type: boolean
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -77,9 +77,9 @@ spec:
                   - type
                   type: object
                 type: array
-              nodeRunningUpdate:
-                description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
-                type: string
+              nodeChunkCapacity:
+                description: NodeChunkCapacity is used as a semaphore to synchronize nodes applying policy configuration
+                type: integer
             type: object
         type: object
     served: true
@@ -107,6 +107,9 @@ spec:
           spec:
             description: NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
             properties:
+              chunkSize:
+                description: Percentage of matching cluster nodes that may apply policy configuration concurrently. If not specified, policy is applied one node at a time. Value of 0 means all nodes apply policy in parallel, Value of n, n > 1 means that up to n% of cluster nodes may apply policy configuration concurrently.
+                type: integer
               desiredState:
                 description: The desired configuration of the policy
                 type: object
@@ -116,9 +119,6 @@ spec:
                   type: string
                 description: 'NodeSelector is a selector which must be true for the policy to be applied to the node. Selector which must match a node''s labels for the policy to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
-              parallel:
-                description: When set to true, changes are applied to all nodes in parallel
-                type: boolean
             type: object
           status:
             description: NodeNetworkConfigurationPolicyStatus defines the observed state of NodeNetworkConfigurationPolicy
@@ -145,9 +145,9 @@ spec:
                   - type
                   type: object
                 type: array
-              nodeRunningUpdate:
-                description: NodeRunningUpdate field is used for serializing cluster nodes configuration when Parallel flag is false
-                type: string
+              nodeChunkCapacity:
+                description: NodeChunkCapacity is used as a semaphore to synchronize nodes applying policy configuration
+                type: integer
             type: object
         type: object
     served: true

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -15,7 +15,7 @@ const (
 
 func Add(mgr manager.Manager, o certificate.Options) error {
 
-	// We need two hooks, the update of nncp and nncp/status (it's a subresource) happends
+	// We need two hooks, the update of nncp and nncp/status (it's a subresource) happens
 	// at different times, also if you modify status at nncp webhook it does not modify it
 	// you need at nncp/status webhook that will catch that and do the final modifications.
 	// So this works this way:

--- a/test/e2e/handler/upgrade_test.go
+++ b/test/e2e/handler/upgrade_test.go
@@ -24,7 +24,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy upgrade", func() {
 				Spec: nmstate.NodeNetworkConfigurationPolicySpec{
 					DesiredState: linuxBrUp(bridge1),
 					NodeSelector: map[string]string{"node-role.kubernetes.io/worker": ""},
-					Parallel:     parallelRollout,
+					ChunkSize:    &chunkSize,
 				},
 			}
 			Expect(testenv.Client.Create(context.TODO(), &policy)).To(Succeed(), "should success creating a v1alpha1 nncp")

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -33,9 +33,9 @@ const ReadInterval = 1 * time.Second
 const TestPolicy = "test-policy"
 
 var (
-	bridgeCounter   = 0
-	bondConunter    = 0
-	parallelRollout = environment.GetBoolVarWithDefault("NMSTATE_PARALLEL_ROLLOUT", false)
+	bridgeCounter = 0
+	bondConunter  = 0
+	chunkSize     = environment.GetIntVarWithDefault("NMSTATE_CHUNK_SIZE", 1)
 )
 
 func interfacesName(interfaces []interface{}) []string {
@@ -69,7 +69,7 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstate.
 		err := testenv.Client.Get(context.TODO(), key, &policy)
 		policy.Spec.DesiredState = desiredState
 		policy.Spec.NodeSelector = nodeSelector
-		policy.Spec.Parallel = parallelRollout
+		policy.Spec.ChunkSize = &chunkSize
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return testenv.Client.Create(context.TODO(), &policy)

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -13,11 +13,11 @@ func GetVarWithDefault(name string, defaultValue string) string {
 	return value
 }
 
-func GetBoolVarWithDefault(name string, defaultValue bool) bool {
-	value := os.Getenv(name)
-	boolValue, err := strconv.ParseBool(value)
+func GetIntVarWithDefault(name string, defaultValue int) int {
+	valueStr := os.Getenv(name)
+	value, err := strconv.ParseInt(valueStr, 10, 64)
 	if err != nil {
-		boolValue = defaultValue
+		return defaultValue
 	}
-	return boolValue
+	return int(value)
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
This PR changes policy spec parallel to a more versatile
chunkSize, which allows user to define how many percent of nodes are allowed
to apply a policy configuration at a time.

chunkSize == 0: all (matching) cluster nodes apply policy in parallel
chinkSize == n ; n > 0:  up to `n` percent of matching nodes apply policy in parallel

If not set, policy is applied sequentially one node at a time.

**Special notes for your reviewer**:
the env variable `NMSTATE_PARALLEL_ROLLOUT` is changed to `NMSTATE_CHUNK_SIZE`
To get this PR through CI, we need to:
1. add `export NMSTATE_CHUNK_SIZE` (so both env vars are temporarily exported)
2. merge this PR
3. remove `export NMSTATE_PARALLEL_ROLLOUT` which is no longer used  

**Please ignore** commit `Add Aborted conditionType for policy enactments`, this is part of another PR and will be removed from this PR when it's merged

**Release note**:

```release-note
Changed policy field `parallel` to `chunkSize`
```
