### PR TITLE
Add NMSTATE_PIN knob to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,20 @@ IMAGE_REGISTRY ?= quay.io
 IMAGE_REPO ?= nmstate
 NAMESPACE ?= nmstate
 
+NMSTATE_CURRENT_COPR_REPO=nmstate-0.3
+NM_CURRENT_COPR_REPO=NetworkManager-1.26
+
+NMSTATE_FUTURE_COPR_REPO=nmstate
+NM_FUTURE_COPR_REPO=NetworkManager-1.26
+
+ifeq ($(NMSTATE_PIN), future)
+	NMSTATE_COPR_REPO=$(NMSTATE_FUTURE_COPR_REPO)
+	NM_COPR_REPO=$(NM_FUTURE_COPR_REPO)
+else
+	NMSTATE_COPR_REPO=$(NMSTATE_CURRENT_COPR_REPO)
+	NM_COPR_REPO=$(NM_CURRENT_COPR_REPO)
+endif
+
 HANDLER_IMAGE_NAME ?= kubernetes-nmstate-handler
 HANDLER_IMAGE_TAG ?= latest
 HANDLER_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(HANDLER_IMAGE_NAME):$(HANDLER_IMAGE_TAG)
@@ -148,7 +162,7 @@ manager: $(GO)
 	$(GO) build -o $(BIN_DIR)/manager main.go
 
 handler: manager
-	$(IMAGE_BUILDER) build . -f build/Dockerfile -t ${HANDLER_IMAGE}
+	$(IMAGE_BUILDER) build . -f build/Dockerfile -t ${HANDLER_IMAGE} --build-arg NMSTATE_COPR_REPO=$(NMSTATE_COPR_REPO) --build-arg NM_COPR_REPO=$(NM_COPR_REPO)
 
 push-handler: handler
 	$(IMAGE_BUILDER) push $(HANDLER_IMAGE)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,10 @@
 FROM centos:8
-
+ARG NMSTATE_COPR_REPO
+ARG NM_COPR_REPO
 RUN dnf install -b -y dnf-plugins-core && \
-    dnf copr enable -y networkmanager/NetworkManager-1.26 && \
-    dnf copr enable -y nmstate/nmstate-0.3 && \
+    dnf copr enable -y networkmanager/$NM_COPR_REPO && \
+    dnf copr enable -y nmstate/$NMSTATE_COPR_REPO && \
+    dnf copr enable -y nmstate/nispor && \
     dnf install -b -y nmstate iproute iputils && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Future versions of nmstate/nm need to be tested to ensure that they
don't introduce something really incompatible with kubernetes-nmstate to
implement that a new "knob" is added to Makefile in the form of a
NMSTATE_PIN variable that will use future versions if content is
"future".

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
