### PR TITLE
Add an example policy of removing a bridge with eth port

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,6 +18,12 @@ toc_sticky: true
 {% include_absolute 'examples/bond-vlan.yaml' %}
 ```
 
+## Detach bridge port and restore eth configuration
+
+```yaml
+{% include_absolute 'examples/detach-bridge-port-and-restore-eth.yaml' %}
+```
+
 ## DHCP
 
 ```yaml

--- a/docs/examples/detach-bridge-port-and-restore-eth.yaml
+++ b/docs/examples/detach-bridge-port-and-restore-eth.yaml
@@ -1,0 +1,16 @@
+apiVersion: nmstate.io/v1beta1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: detach-bridge-port-and-restore-eth
+spec:
+  desiredState:
+    interfaces:
+    - name: br1
+      type: linux-bridge
+      state: absent
+    - name: eth1
+      type: ethernet
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true

--- a/test/e2e/handler/examples_test.go
+++ b/test/e2e/handler/examples_test.go
@@ -50,6 +50,12 @@ var _ = Describe("[user-guide] Examples", func() {
 			ifaceNames: []string{"br1"},
 		},
 		exampleSpec{
+			name:       "Detach bridge port and restore its configuration",
+			fileName:   "detach-bridge-port-and-restore-eth.yaml",
+			policyName: "detach-bridge-port-and-restore-eth",
+			ifaceNames: []string{"br1"},
+		},
+		exampleSpec{
 			name:       "OVS bridge",
 			fileName:   "ovs-bridge.yaml",
 			policyName: "ovs-bridge",


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
Provide an example of a policy that removes linux bridge connected to an ethernet interface.
The example demonstrates that with removal of the bridge, we need to explixitly enable
dhcp on the ethernet interface (or set static IP) in the same policy. 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
