### PR TITLE
Fix bonding e2e test

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -10,6 +10,7 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 )
 
+// TODO: When https://bugzilla.redhat.com/show_bug.cgi?id=1906307 is resolved, add firstSecondaryNic to the bond again
 func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
   - name: %s
@@ -25,8 +26,7 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
         primary: %s
       slaves:
         - %s
-        - %s
-`, bondName, primaryNic, primaryNic, firstSecondaryNic))
+`, bondName, primaryNic, primaryNic))
 }
 
 func bondAbsentWithPrimaryUp(bondName string) nmstate.State {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Based on https://www.kernel.org/doc/Documentation/networking/bonding.txt,
when adding a bond interface in active_backup mode, the
MAC address of the bond is derived from the first active slave iface
However, the first active slave iface is not the first in the list of
slaves defined in the policy and is random.

**Removed** one interface from the created bond and file BZ for nmstate:
https://bugzilla.redhat.com/show_bug.cgi?id=1906307

When resolved, we need to re-add the second iface to the bond


**Special notes for your reviewer**:
Reference from the doc above:
```
8.  Where does a bonding device get its MAC address from?
	When using slave devices that have fixed MAC addresses, or when
the fail_over_mac option is enabled, the bonding device's MAC address is
the MAC address of the active slave.
	For other configurations, if not explicitly configured (with
ifconfig or ip link), the MAC address of the bonding device is taken from
its first slave device.  This MAC address is then passed to all following
slaves and remains persistent (even if the first slave is removed) until
the bonding device is brought down or reconfigured.
```

**Release note**:

```release-note
NONE
```
