### PR TITLE
Correct the argument for template to release notes

### DIFF
--- a/hack/render-release-notes.sh
+++ b/hack/render-release-notes.sh
@@ -12,7 +12,7 @@ end() {
 trap end EXIT SIGINT SIGTERM SIGSTOP
 
 $RELEASE_NOTES \
-    --format go-template:$script_dir/release-notes.tmpl \
+    --go-template go-template:$script_dir/release-notes.tmpl \
     --release-version $new_version \
     --required-author "" \
     --github-org nmstate \


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
k8s release-notes cmd has change the argument name from --format to
--go-template, this change aligns the infra with that.

**Special notes for your reviewer**:
The release notes has being added manually to the current releases directly from the output of this PR https://github.com/nmstate/kubernetes-nmstate/releases.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
