### PR TITLE
Add Node webhook to reset NNCP Status

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -229,6 +229,18 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["v1alpha1","v1beta1"]
         resources: ["nodenetworkconfigurationpolicies", "nodenetworkconfigurationpolicies/status"]
+  - name: nodenetworkconfigurationpolicies-mutate-all.nmstate.io
+    clientConfig:
+      service:
+        name: {{template "handlerPrefix" .}}nmstate-webhook
+        namespace: {{ .HandlerNamespace }}
+        path: "/nodenetworkconfigurationpolicies-mutate-all"
+    rules:
+      - operations: ["UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["v1"]
+        resources: ["nodes"]
+
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/pkg/webhook/nodenetworkconfigurationpolicy/conditions.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/conditions.go
@@ -3,8 +3,6 @@ package nodenetworkconfigurationpolicy
 import (
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
@@ -31,24 +29,4 @@ func setConditionsUnknown(policy nmstatev1beta1.NodeNetworkConfigurationPolicy) 
 
 func atEmptyConditions(policy nmstatev1beta1.NodeNetworkConfigurationPolicy) bool {
 	return policy.Status.Conditions == nil || len(policy.Status.Conditions) == 0
-}
-
-func deleteConditionsHook() *webhook.Admission {
-	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				always,
-				deleteConditions,
-			)),
-	}
-}
-
-func setConditionsUnknownHook() *webhook.Admission {
-	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				atEmptyConditions,
-				setConditionsUnknown,
-			)),
-	}
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
@@ -42,7 +42,3 @@ func mutatePolicyHandler(neededMutationFor func(nmstatev1beta1.NodeNetworkConfig
 		return response
 	}
 }
-
-func always(nmstatev1beta1.NodeNetworkConfigurationPolicy) bool {
-	return true
-}

--- a/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
@@ -8,6 +8,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -41,4 +46,61 @@ func mutatePolicyHandler(neededMutationFor func(nmstatev1beta1.NodeNetworkConfig
 		log.Info(fmt.Sprintf("webhook response: %+v", response))
 		return response
 	}
+}
+
+func mutateAllPoliciesHandler(cli client.Client, neededMutationFor func(oldNode, newNode corev1.Node) bool, mutators ...mutator) admission.HandlerFunc {
+	log := logf.Log.WithName("webhook/nodenetworkconfigurationpolicy/mutatePolicyOnNodeModifiedHandler")
+	return func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+		oldNode, err := decodeNode(req.OldObject)
+		if err != nil {
+			log.Error(err, "failed decoding original node")
+			return admission.Allowed("")
+		}
+		newNode, err := decodeNode(req.Object)
+		if err != nil {
+			log.Error(err, "failed decoding new node")
+			return admission.Allowed("")
+		}
+		if !neededMutationFor(oldNode, newNode) {
+			return admission.Allowed("mutation not needed")
+		}
+
+		policyList := nmstatev1beta1.NodeNetworkConfigurationPolicyList{}
+		err = cli.List(context.TODO(), &policyList)
+		if err != nil {
+			log.Error(err, "failed listing all NodeNetworkConfigurationPolicies to reset their Status after node modified ")
+			return admission.Allowed("")
+		}
+
+		for _, policy := range policyList.Items {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err := cli.Get(context.TODO(), types.NamespacedName{Name: policy.Name}, &policy)
+				if err != nil {
+					return err
+				}
+				for _, mutate := range mutators {
+					policy = mutate(policy)
+				}
+				err = cli.Status().Update(context.TODO(), &policy)
+				if err != nil {
+					return err
+				}
+				return cli.Update(context.TODO(), &policy)
+			})
+			if err != nil {
+				log.Error(err, "failed mutating NNCP after a node change detected")
+			}
+		}
+
+		return admission.Allowed("")
+	}
+}
+
+func decodeNode(nodeObject runtime.RawExtension) (corev1.Node, error) {
+	node := corev1.Node{}
+	err := json.Unmarshal(nodeObject.Raw, &node)
+	if err != nil {
+		return node, errors.Wrapf(err, "failed decoding node: %s", string(nodeObject.Raw))
+	}
+	return node, nil
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/hooks.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/hooks.go
@@ -1,0 +1,42 @@
+package nodenetworkconfigurationpolicy
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+)
+
+func deleteConditionsHook() *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(
+			mutatePolicyHandler(
+				always,
+				deleteConditions,
+			)),
+	}
+}
+
+func setConditionsUnknownHook() *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(
+			mutatePolicyHandler(
+				atEmptyConditions,
+				setConditionsUnknown,
+			)),
+	}
+}
+
+func setTimestampAnnotationHook() *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(
+			mutatePolicyHandler(
+				always,
+				setTimestampAnnotation,
+			)),
+	}
+}
+
+func always(nmstatev1beta1.NodeNetworkConfigurationPolicy) bool {
+	return true
+}

--- a/pkg/webhook/nodenetworkconfigurationpolicy/hooks.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/hooks.go
@@ -1,6 +1,7 @@
 package nodenetworkconfigurationpolicy
 
 import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -13,6 +14,17 @@ func deleteConditionsHook() *webhook.Admission {
 			mutatePolicyHandler(
 				always,
 				deleteConditions,
+			)),
+	}
+}
+
+func deleteConditionsOnNodeLabelsModifiedHook(cli client.Client) *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(
+			mutateAllPoliciesHandler(cli,
+				onModifiedNodeLabels,
+				deleteConditions,
+				setTimestampAnnotation(TimestampAllPoliciesLabelKey),
 			)),
 	}
 }
@@ -32,7 +44,7 @@ func setTimestampAnnotationHook() *webhook.Admission {
 		Handler: admission.HandlerFunc(
 			mutatePolicyHandler(
 				always,
-				setTimestampAnnotation,
+				setTimestampAnnotation(TimestampPolicyLabelKey),
 			)),
 	}
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/node.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/node.go
@@ -1,0 +1,11 @@
+package nodenetworkconfigurationpolicy
+
+import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func onModifiedNodeLabels(oldNode, newNode corev1.Node) bool {
+	return !reflect.DeepEqual(oldNode.Labels, newNode.Labels)
+}

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -26,6 +26,7 @@ func Add(mgr manager.Manager, o certificate.Options) error {
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook()),
+		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate-all", deleteConditionsOnNodeLabelsModifiedHook(mgr.GetClient())),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed creating new webhook server")

--- a/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
@@ -8,14 +8,17 @@ import (
 )
 
 const (
-	TimestampLabelKey = "nmstate.io/webhook-mutating-timestamp"
+	TimestampPolicyLabelKey      = "nmstate.io/webhook-mutating-policy-timestamp"
+	TimestampAllPoliciesLabelKey = "nmstate.io/webhook-mutating-all-policies-timestamp"
 )
 
-func setTimestampAnnotation(policy nmstatev1beta1.NodeNetworkConfigurationPolicy) nmstatev1beta1.NodeNetworkConfigurationPolicy {
-	value := strconv.FormatInt(time.Now().UnixNano(), 10)
-	if policy.ObjectMeta.Annotations == nil {
-		policy.ObjectMeta.Annotations = map[string]string{}
+func setTimestampAnnotation(timestampKey string) func(nmstatev1beta1.NodeNetworkConfigurationPolicy) nmstatev1beta1.NodeNetworkConfigurationPolicy {
+	return func(policy nmstatev1beta1.NodeNetworkConfigurationPolicy) nmstatev1beta1.NodeNetworkConfigurationPolicy {
+		value := strconv.FormatInt(time.Now().UnixNano(), 10)
+		if policy.ObjectMeta.Annotations == nil {
+			policy.ObjectMeta.Annotations = map[string]string{}
+		}
+		policy.ObjectMeta.Annotations[timestampKey] = value
+		return policy
 	}
-	policy.ObjectMeta.Annotations[TimestampLabelKey] = value
-	return policy
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
@@ -4,9 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 )
 
@@ -21,14 +18,4 @@ func setTimestampAnnotation(policy nmstatev1beta1.NodeNetworkConfigurationPolicy
 	}
 	policy.ObjectMeta.Annotations[TimestampLabelKey] = value
 	return policy
-}
-
-func setTimestampAnnotationHook() *webhook.Admission {
-	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				always,
-				setTimestampAnnotation,
-			)),
-	}
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/timestamp_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/timestamp_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func expectTimestampAnnotationAtPolicy(policy nmstatev1beta1.NodeNetworkConfigurationPolicy, testStartTime time.Time) {
-	ExpectWithOffset(1, policy.ObjectMeta.Annotations).To(HaveKey(TimestampLabelKey))
-	annotation := policy.ObjectMeta.Annotations[TimestampLabelKey]
+	ExpectWithOffset(1, policy.ObjectMeta.Annotations).To(HaveKey(TimestampPolicyLabelKey))
+	annotation := policy.ObjectMeta.Annotations[TimestampPolicyLabelKey]
 	mutationTimestamp, err := strconv.ParseInt(annotation, 10, 64)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "mutation timestamp should have int64 value")
 	ExpectWithOffset(1, mutationTimestamp).To(BeNumerically(">", testStartTime.UnixNano()), "mutation timestamp should be updated by the webhook")

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -8,6 +8,7 @@ import (
 
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	nncpwebhook "github.com/nmstate/kubernetes-nmstate/pkg/webhook/nodenetworkconfigurationpolicy"
+	"github.com/nmstate/kubernetes-nmstate/test/node"
 )
 
 // We just check the labe at CREATE/UPDATE events since mutated data is already
@@ -27,7 +28,7 @@ var _ = Describe("Mutating Admission Webhook", func() {
 
 		It("should have an annotation with mutation timestamp", func() {
 			policy := nodeNetworkConfigurationPolicy(TestPolicy)
-			Expect(policy.ObjectMeta.Annotations).To(HaveKey(nncpwebhook.TimestampLabelKey))
+			Expect(policy.ObjectMeta.Annotations).To(HaveKey(nncpwebhook.TimestampPolicyLabelKey))
 		})
 		Context("and we updated it", func() {
 			var (
@@ -39,16 +40,35 @@ var _ = Describe("Mutating Admission Webhook", func() {
 			})
 			It("should have an annotation with newer mutation timestamp", func() {
 				newPolicy := nodeNetworkConfigurationPolicy(TestPolicy)
-				Expect(newPolicy.ObjectMeta.Annotations).To(HaveKey(nncpwebhook.TimestampLabelKey))
+				Expect(newPolicy.ObjectMeta.Annotations).To(HaveKey(nncpwebhook.TimestampPolicyLabelKey))
 
-				oldAnnotation := oldPolicy.ObjectMeta.Annotations[nncpwebhook.TimestampLabelKey]
+				oldAnnotation := oldPolicy.ObjectMeta.Annotations[nncpwebhook.TimestampPolicyLabelKey]
 				oldConditionsMutation, err := strconv.ParseInt(oldAnnotation, 10, 64)
 				Expect(err).ToNot(HaveOccurred())
-				newAnnotation := newPolicy.ObjectMeta.Annotations[nncpwebhook.TimestampLabelKey]
+				newAnnotation := newPolicy.ObjectMeta.Annotations[nncpwebhook.TimestampPolicyLabelKey]
 				newConditionsMutation, err := strconv.ParseInt(newAnnotation, 10, 64)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(newConditionsMutation).To(BeNumerically(">", oldConditionsMutation), "mutation timestamp not updated")
+			})
+		})
+		Context("and we add a label to a node", func() {
+			var (
+				testLabel = map[string]string{
+					"testKey": "testValue",
+				}
+			)
+			BeforeEach(func() {
+				node.AddLabels(nodes[0], testLabel)
+			})
+			AfterEach(func() {
+				node.RemoveLabels(nodes[0], testLabel)
+			})
+			It("should have two annotations with timestamp", func() {
+				policy := nodeNetworkConfigurationPolicy(TestPolicy)
+				Expect(policy.ObjectMeta.Annotations).To(SatisfyAll(
+					HaveKey(nncpwebhook.TimestampAllPoliciesLabelKey),
+					HaveKey(nncpwebhook.TimestampPolicyLabelKey)))
 			})
 		})
 	})

--- a/test/node/labels.go
+++ b/test/node/labels.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"context"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+)
+
+func AddLabels(nodeName string, labelsToAdd map[string]string) {
+	node := corev1.Node{}
+	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to change labels")
+
+	if len(node.Labels) == 0 {
+		node.Labels = labelsToAdd
+	} else {
+		for k, v := range labelsToAdd {
+			node.Labels[k] = v
+		}
+	}
+	err = testenv.Client.Update(context.TODO(), &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with new labels")
+}
+
+func RemoveLabels(nodeName string, labelsToRemove map[string]string) {
+	node := corev1.Node{}
+	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to remove labels")
+
+	if len(node.Labels) == 0 {
+		return
+	}
+
+	for k, _ := range labelsToRemove {
+		delete(node.Labels, k)
+	}
+
+	err = testenv.Client.Update(context.TODO(), &node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with label delete")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
When the Node labels are changed the NNCPs get Reconciled again but the
NNCP Status is not reset until the reconcile cycle is reached. This
change add a webhook that reset the NNCP condition if node labels are
changed.

**Special notes for your reviewer**:
Code with Hooks has beeing moved to hooks.go and the Handlers to handler.go

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
