### PR TITLE
Replace "slave" with "port" at e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nmstate/kubernetes-nmstate
 go 1.15
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/github-release/github-release v0.8.1
 	github.com/go-logr/logr v0.1.0

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -24,9 +24,9 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
       options:
         miimon: 140
         primary: %s
-      port:
+      %s:
         - %s
-`, bondName, primaryNic, primaryNic))
+`, bondName, primaryNic, portFieldName, primaryNic))
 }
 
 func bondAbsentWithPrimaryUp(bondName string) nmstate.State {

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -22,11 +22,11 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
     link-aggregation:
       mode: active-backup
       options:
-        miimon: 140
+        miimon: %s
         primary: %s
       %s:
         - %s
-`, bondName, primaryNic, portFieldName, primaryNic))
+`, bondName, fmt.Sprintf(miimonFormat, 140), primaryNic, portFieldName, primaryNic))
 }
 
 func bondAbsentWithPrimaryUp(bondName string) nmstate.State {

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -24,7 +24,7 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
       options:
         miimon: '140'
         primary: %s
-      slaves:
+      port:
         - %s
 `, bondName, primaryNic, primaryNic))
 }

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -22,7 +22,7 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
     link-aggregation:
       mode: active-backup
       options:
-        miimon: '140'
+        miimon: 140
         primary: %s
       port:
         - %s

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -36,6 +36,7 @@ var (
 	firstSecondaryNic    string
 	secondSecondaryNic   string
 	portFieldName        string
+	miimonFormat         string
 	nodesInterfacesState = make(map[string][]byte)
 	interfacesToIgnore   = []string{"flannel.1", "dummy0"}
 )
@@ -55,8 +56,10 @@ var _ = BeforeSuite(func() {
 
 	if version.IsNmstate(">= 1.0.0") {
 		portFieldName = "port"
+		miimonFormat = "%d"
 	} else {
 		portFieldName = "slaves"
+		miimonFormat = "'%d'"
 	}
 
 	By("Getting worker node list from cluster")

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	"github.com/nmstate/kubernetes-nmstate/test/environment"
+	"github.com/nmstate/kubernetes-nmstate/test/version"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	primaryNic           string
 	firstSecondaryNic    string
 	secondSecondaryNic   string
+	portFieldName        string
 	nodesInterfacesState = make(map[string][]byte)
 	interfacesToIgnore   = []string{"flannel.1", "dummy0"}
 )
@@ -50,6 +52,12 @@ var _ = BeforeSuite(func() {
 	secondSecondaryNic = environment.GetVarWithDefault("SECOND_SECONDARY_NIC", "eth2")
 
 	testenv.Start()
+
+	if version.IsNmstate(">= 1.0.0") {
+		portFieldName = "port"
+	} else {
+		portFieldName = "slaves"
+	}
 
 	By("Getting worker node list from cluster")
 	nodeList := corev1.NodeList{}

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -35,11 +35,11 @@ func bondUp(bondName string) nmstate.State {
     state: up
     link-aggregation:
       mode: active-backup
-      port:
+      %s:
         - %s
       options:
         miimon: 120
-`, bondName, firstSecondaryNic))
+`, bondName, portFieldName, firstSecondaryNic))
 }
 
 func brWithBondUp(bridgeName string, bondName string) nmstate.State {
@@ -49,7 +49,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
     state: up
     link-aggregation:
       mode: active-backup
-      port:
+      %s:
         - %s
       options:
         miimon: 120
@@ -62,7 +62,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
           enabled: false
       port:
         - name: %s
-`, bondName, firstSecondaryNic, bridgeName, bondName))
+`, bondName, portFieldName, firstSecondaryNic, bridgeName, bondName))
 }
 
 func bondUpWithEth1AndEth2(bondName string) nmstate.State {
@@ -79,10 +79,10 @@ func bondUpWithEth1AndEth2(bondName string) nmstate.State {
     mode: balance-rr
     options:
       miimon: 140
-    port:
+    %s:
     - %s
     - %s
-`, bondName, firstSecondaryNic, secondSecondaryNic))
+`, bondName, portFieldName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
@@ -99,7 +99,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
     mode: balance-rr
     options:
       miimon: 140
-    port:
+    %s:
     - %s
     - %s
 - name: %s.102
@@ -113,7 +113,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   vlan:
     base-iface: %s
     id: 102
-`, bondName, firstSecondaryNic, secondSecondaryNic, bondName, bondName))
+`, bondName, portFieldName, firstSecondaryNic, secondSecondaryNic, bondName, bondName))
 }
 
 var _ = Describe("NodeNetworkState", func() {

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -35,7 +35,7 @@ func bondUp(bondName string) nmstate.State {
     state: up
     link-aggregation:
       mode: active-backup
-      slaves:
+      port:
         - %s
       options:
         miimon: '120'
@@ -49,7 +49,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
     state: up
     link-aggregation:
       mode: active-backup
-      slaves:
+      port:
         - %s
       options:
         miimon: '120'
@@ -79,7 +79,7 @@ func bondUpWithEth1AndEth2(bondName string) nmstate.State {
     mode: balance-rr
     options:
       miimon: '140'
-    slaves:
+    port:
     - %s
     - %s
 `, bondName, firstSecondaryNic, secondSecondaryNic))
@@ -99,7 +99,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
     mode: balance-rr
     options:
       miimon: '140'
-    slaves:
+    port:
     - %s
     - %s
 - name: %s.102
@@ -216,7 +216,7 @@ var _ = Describe("NodeNetworkState", func() {
 				}
 			})
 		})
-		Context("with bond interface that has 2 eths as slaves", func() {
+		Context("with bond interface that has 2 eths as ports", func() {
 			BeforeEach(func() {
 				updateDesiredStateAndWait(bondUpWithEth1AndEth2(bond1))
 			})
@@ -227,7 +227,7 @@ var _ = Describe("NodeNetworkState", func() {
 				}
 				resetDesiredStateForNodes()
 			})
-			It("should have the bond interface with 2 slaves at currentState", func() {
+			It("should have the bond interface with 2 ports at currentState", func() {
 				var (
 					expectedBond = interfaceByName(interfaces(bondUpWithEth1AndEth2(bond1)), bond1)
 				)
@@ -237,7 +237,7 @@ var _ = Describe("NodeNetworkState", func() {
 				}
 			})
 		})
-		Context("with bond interface that has 2 eths as slaves and vlan tag on the bond", func() {
+		Context("with bond interface that has 2 eths as ports and vlan tag on the bond", func() {
 			BeforeEach(func() {
 				updateDesiredStateAndWait(bondUpWithEth1Eth2AndVlan(bond1))
 			})
@@ -248,7 +248,7 @@ var _ = Describe("NodeNetworkState", func() {
 				}
 				resetDesiredStateForNodes()
 			})
-			It("should have the bond interface with 2 slaves at currentState", func() {
+			It("should have the bond interface with 2 ports at currentState", func() {
 				var (
 					expectedBond        = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), bond1)
 					expectedVlanBond102 = interfaceByName(interfaces(bondUpWithEth1Eth2AndVlan(bond1)), fmt.Sprintf("%s.102", bond1))

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -38,8 +38,8 @@ func bondUp(bondName string) nmstate.State {
       %s:
         - %s
       options:
-        miimon: 120
-`, bondName, portFieldName, firstSecondaryNic))
+        miimon: %s
+`, bondName, portFieldName, firstSecondaryNic, fmt.Sprintf(miimonFormat, 120)))
 }
 
 func brWithBondUp(bridgeName string, bondName string) nmstate.State {
@@ -52,7 +52,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
       %s:
         - %s
       options:
-        miimon: 120
+        miimon: %s
   - name: %s
     type: linux-bridge
     state: up
@@ -62,7 +62,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
           enabled: false
       port:
         - name: %s
-`, bondName, portFieldName, firstSecondaryNic, bridgeName, bondName))
+`, bondName, portFieldName, firstSecondaryNic, fmt.Sprintf(miimonFormat, 120), bridgeName, bondName))
 }
 
 func bondUpWithEth1AndEth2(bondName string) nmstate.State {
@@ -78,11 +78,11 @@ func bondUpWithEth1AndEth2(bondName string) nmstate.State {
   link-aggregation:
     mode: balance-rr
     options:
-      miimon: 140
+      miimon: %s
     %s:
     - %s
     - %s
-`, bondName, portFieldName, firstSecondaryNic, secondSecondaryNic))
+`, bondName, fmt.Sprintf(miimonFormat, 140), portFieldName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
@@ -98,7 +98,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   link-aggregation:
     mode: balance-rr
     options:
-      miimon: 140
+      miimon: %s
     %s:
     - %s
     - %s
@@ -113,7 +113,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   vlan:
     base-iface: %s
     id: 102
-`, bondName, portFieldName, firstSecondaryNic, secondSecondaryNic, bondName, bondName))
+`, bondName, fmt.Sprintf(miimonFormat, 140), portFieldName, firstSecondaryNic, secondSecondaryNic, bondName, bondName))
 }
 
 var _ = Describe("NodeNetworkState", func() {

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -38,7 +38,7 @@ func bondUp(bondName string) nmstate.State {
       port:
         - %s
       options:
-        miimon: '120'
+        miimon: 120
 `, bondName, firstSecondaryNic))
 }
 
@@ -52,7 +52,7 @@ func brWithBondUp(bridgeName string, bondName string) nmstate.State {
       port:
         - %s
       options:
-        miimon: '120'
+        miimon: 120
   - name: %s
     type: linux-bridge
     state: up
@@ -78,7 +78,7 @@ func bondUpWithEth1AndEth2(bondName string) nmstate.State {
   link-aggregation:
     mode: balance-rr
     options:
-      miimon: '140'
+      miimon: 140
     port:
     - %s
     - %s
@@ -98,7 +98,7 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   link-aggregation:
     mode: balance-rr
     options:
-      miimon: '140'
+      miimon: 140
     port:
     - %s
     - %s

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -210,7 +210,7 @@ func matchingBond(expectedBond map[string]interface{}) types.GomegaMatcher {
 		HaveKeyWithValue("state", expectedBond["state"]),
 		HaveKeyWithValue("link-aggregation", SatisfyAll(
 			HaveKeyWithValue("mode", expectedLinkAggregation["mode"]),
-			HaveKeyWithValue("slaves", ConsistOf(expectedLinkAggregation["slaves"])),
+			HaveKeyWithValue("port", ConsistOf(expectedLinkAggregation["port"])),
 			HaveKeyWithValue("options", HaveKeyWithValue("miimon", expectedOptions["miimon"])),
 		)),
 	)

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -210,7 +210,7 @@ func matchingBond(expectedBond map[string]interface{}) types.GomegaMatcher {
 		HaveKeyWithValue("state", expectedBond["state"]),
 		HaveKeyWithValue("link-aggregation", SatisfyAll(
 			HaveKeyWithValue("mode", expectedLinkAggregation["mode"]),
-			HaveKeyWithValue("port", ConsistOf(expectedLinkAggregation["port"])),
+			HaveKeyWithValue(portFieldName, ConsistOf(expectedLinkAggregation[portFieldName])),
 			HaveKeyWithValue("options", HaveKeyWithValue("miimon", expectedOptions["miimon"])),
 		)),
 	)

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -207,8 +207,8 @@ func deleteBridgeAtNodes(bridgeName string, ports ...string) []error {
 	By(fmt.Sprintf("Delete bridge %s", bridgeName))
 	_, errs := runner.RunAtNodes(nodes, "sudo", "ip", "link", "del", bridgeName)
 	for _, portName := range ports {
-		_, slaveErrors := runner.RunAtNodes(nodes, "sudo", "nmcli", "con", "delete", bridgeName+"-"+portName)
-		errs = append(errs, slaveErrors...)
+		_, portErrors := runner.RunAtNodes(nodes, "sudo", "nmcli", "con", "delete", bridgeName+"-"+portName)
+		errs = append(errs, portErrors...)
 	}
 	return errs
 }

--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -17,13 +17,25 @@ func nmstateHandlerPods() ([]string, error) {
 	return names, err
 }
 
+func runAtPod(pod string, arguments ...string) string {
+	exec := []string{"exec", "-n", testenv.OperatorNamespace, pod, "--"}
+	execArguments := append(exec, arguments...)
+	output, err := cmd.Kubectl(execArguments...)
+	ExpectWithOffset(2, err).ToNot(HaveOccurred())
+	return output
+}
+
 func runAtPods(pods []string, arguments ...string) {
 	for _, pod := range pods {
-		exec := []string{"exec", "-n", testenv.OperatorNamespace, pod, "--"}
-		execArguments := append(exec, arguments...)
-		_, err := cmd.Kubectl(execArguments...)
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
+		runAtPod(pod, arguments...)
 	}
+}
+
+func RunAtFirstHandlerPod(arguments ...string) string {
+	handlerPods, err := nmstateHandlerPods()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, handlerPods).ToNot(BeEmpty())
+	return runAtPod(handlerPods[0], arguments...)
 }
 
 func RunAtHandlerPods(arguments ...string) {

--- a/test/version/nmstate.go
+++ b/test/version/nmstate.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/nmstate/kubernetes-nmstate/test/runner"
+)
+
+var (
+	r = regexp.MustCompile(`nmstate-(.*)-.*`)
+)
+
+func IsNmstate(constraint string) bool {
+	rpmVersion := runner.RunAtFirstHandlerPod("rpm", "-qe", "nmstate")
+
+	By(fmt.Sprintf("Parsing nmstate version from rpm version %s", rpmVersion))
+	submatchResult := r.FindStringSubmatch(rpmVersion)
+	ExpectWithOffset(1, submatchResult).To(HaveLen(2))
+
+	nmstateVersion := r.FindStringSubmatch(rpmVersion)[1]
+	c, err := semver.NewConstraint(constraint)
+	Expect(err).ToNot(HaveOccurred())
+
+	v, err := semver.NewVersion(nmstateVersion)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Checking if nmstate version '%s' is '%s'", nmstateVersion, constraint))
+	return c.Check(v)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,6 +37,7 @@ github.com/MakeNowJust/heredoc
 # github.com/Masterminds/goutils v1.1.0
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
+## explicit
 github.com/Masterminds/semver
 # github.com/Masterminds/semver/v3 v3.1.0
 github.com/Masterminds/semver/v3


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Future version of nmstate is replacing some degrading terms like slave
with more neutral ones. This change replaace slave with ports to make
tests compatible with new version of nmstate.

**Special notes for your reviewer**:
Closes: #666
Closes: #674
Closes: #672 
Closes: #671 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
