### PR TITLE
Reduce calls to apiserver at nns updates

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -33,7 +33,7 @@ main() {
     make cluster-sync
 
     export E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml"
-    if [ $NMSTATE_PARALLEL_ROLLOUT == "true" ]; then
+    if [ "$NMSTATE_PARALLEL_ROLLOUT" == "true" ]; then
        E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='user-guide|nns|sequential'"
     else
        E2E_TEST_SUITE_ARGS="${E2E_TEST_SUITE_ARGS} -ginkgo.skip='parallel'"

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -19,7 +19,7 @@ package controllers
 
 import (
 	"context"
-	"time"
+	"regexp"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -32,22 +32,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
+	"github.com/nmstate/kubernetes-nmstate/pkg/node"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // Added for test purposes
-type NmstateUpdater func(client client.Client, node *corev1.Node, namespace client.ObjectKey) error
+type NmstateUpdater func(client client.Client, node *corev1.Node, namespace client.ObjectKey, observedStateRaw string) error
+type NmstatectlShow func() (string, error)
 
 var (
-	nodeRefresh    = 5 * time.Second
-	nmstateUpdater = nmstate.CreateOrUpdateNodeNetworkState
+	gcTimerRexp = regexp.MustCompile(` *gc-timer: *[0-9]*\n`)
 )
 
 // NodeReconciler reconciles a Node object
 type NodeReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	lastState      string
+	nmstateUpdater NmstateUpdater
+	nmstatectlShow NmstatectlShow
 }
 
 // Reconcile reads that state of the cluster for a Node object and makes changes based on the state read
@@ -56,12 +61,22 @@ type NodeReconciler struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *NodeReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("node", request.NamespacedName)
+	currentState, err := r.nmstatectlShow()
+	if err != nil {
+		// We cannot call nmstatectl show let's reconcile again
+		return ctrl.Result{}, err
+	}
+
+	// Reduce apiserver hits by checking node's network state with last one
+	if r.lastState != "" && !r.networkStateChanged(currentState) {
+		return ctrl.Result{RequeueAfter: node.NetworkStateRefresh}, err
+	} else {
+		r.Log.Info("Network configuration changed, updating NodeNetworkState")
+	}
 
 	// Fetch the Node instance
 	instance := &corev1.Node{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
+	err = r.Client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -72,14 +87,22 @@ func (r *NodeReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-	err = nmstateUpdater(r.Client, instance, request.NamespacedName)
+	err = r.nmstateUpdater(r.Client, instance, request.NamespacedName, currentState)
 	if err != nil {
 		err = errors.Wrap(err, "error at node reconcile creating NodeNetworkState")
+		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: nodeRefresh}, err
+
+	// Cache currentState after successfully storing it at NodeNetworkState
+	r.lastState = currentState
+
+	return ctrl.Result{RequeueAfter: node.NetworkStateRefresh}, nil
 }
 
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	r.nmstateUpdater = nmstate.CreateOrUpdateNodeNetworkState
+	r.nmstatectlShow = nmstatectl.Show
 
 	// By default all this functors return true so controller watch all events,
 	// but we only want to watch create/delete for current node.
@@ -102,4 +125,13 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Node{}).
 		WithEventFilter(onCreationForThisNode).
 		Complete(r)
+}
+
+func (r *NodeReconciler) networkStateChanged(currentState string) bool {
+	return removeDynamicAttributes(r.lastState) != removeDynamicAttributes(currentState)
+}
+
+func removeDynamicAttributes(state string) string {
+	// Remove attributes that make network state always different
+	return gcTimerRexp.ReplaceAllLiteralString(state, "")
 }

--- a/controllers/nodenetworkstate_controller.go
+++ b/controllers/nodenetworkstate_controller.go
@@ -1,0 +1,104 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeNetworkStateReconciler reconciles a NodeNetworkState object
+type NodeNetworkStateReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a NodeNetworkState object and makes changes based on the state read
+// and what is in the NodeNetworkState.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *NodeNetworkStateReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
+	// Fetch the Node instance
+	node := &corev1.Node{}
+	err := r.Client.Get(context.TODO(), request.NamespacedName, node)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Node is gone the NodeNetworkState delete event has being
+			// triggered by k8s garbage collector we don't need to
+			// re-create the NodeNetworkState
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	currentState, err := nmstatectl.Show()
+	if err != nil {
+		// We cannot call nmstatectl show let's reconcile again
+		return ctrl.Result{}, err
+	}
+
+	nmstate.CreateOrUpdateNodeNetworkState(r.Client, node, request.NamespacedName, currentState)
+	if err != nil {
+		err = errors.Wrap(err, "error at node reconcile creating NodeNetworkStateNetworkState")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeNetworkStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	// By default all this functors return true so controller watch all events,
+	// but we only want to watch delete for current node.
+	onDeleteForThisNode := predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return nmstate.EventIsForThisNode(deleteEvent.Meta)
+		},
+		UpdateFunc: func(event.UpdateEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&nmstatev1beta1.NodeNetworkState{}).
+		WithEventFilter(onDeleteForThisNode).
+		Complete(r)
+}

--- a/main.go
+++ b/main.go
@@ -158,6 +158,14 @@ func main() {
 			setupLog.Error(err, "unable to create NodeNetworkConfigurationPolicy controller", "controller", "NMState")
 			os.Exit(1)
 		}
+		if err = (&controllers.NodeNetworkStateReconciler{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("NodeNetworkState"),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create NodeNetworkState controller", "controller", "NMState")
+			os.Exit(1)
+		}
 	}
 
 	setProfiler()

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -52,7 +52,7 @@ func nmstatectl(arguments []string) (string, error) {
 	return nmstatectlWithInput(arguments, "")
 }
 
-func Show(arguments ...string) (string, error) {
+func Show() (string, error) {
 	return nmstatectl([]string{"show"})
 }
 

--- a/pkg/node/constants.go
+++ b/pkg/node/constants.go
@@ -1,0 +1,9 @@
+package node
+
+import (
+	"time"
+)
+
+const (
+	NetworkStateRefresh = 5 * time.Second
+)

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -6,23 +6,60 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	nmstatenode "github.com/nmstate/kubernetes-nmstate/pkg/node"
 )
 
 var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
-	Context("when updating nns", func() {
-		It("timestamp should be changed", func() {
-			for _, node := range nodes {
-				key := types.NamespacedName{Name: node}
-				originalTime := nodeNetworkState(key).Status.LastSuccessfulUpdateTime
-
+	var (
+		originalNNSs map[string]nmstatev1beta1.NodeNetworkState
+	)
+	BeforeEach(func() {
+		originalNNSs = map[string]nmstatev1beta1.NodeNetworkState{}
+		for _, node := range allNodes {
+			key := types.NamespacedName{Name: node}
+			originalNNSs[node] = nodeNetworkState(key)
+		}
+	})
+	Context("when network configuration hasn't change", func() {
+		It("should not be updated", func() {
+			for node, originalNNS := range originalNNSs {
 				// Give enough time for the NNS to be updated (3 interval times)
-				timeout := time.Duration(5*3) * time.Second
+				timeout := 3 * nmstatenode.NetworkStateRefresh
+				key := types.NamespacedName{Name: node}
+
+				Consistently(func() shared.NodeNetworkStateStatus {
+					return nodeNetworkState(key).Status
+				}, timeout, time.Second).Should(Equal(originalNNS.Status))
+			}
+		})
+	})
+	Context("when network configuration changed", func() {
+		BeforeEach(func() {
+			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrUp(bridge1))
+			waitForAvailableTestPolicy()
+		})
+		AfterEach(func() {
+			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrAbsent(bridge1))
+			waitForAvailableTestPolicy()
+			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, resetPrimaryAndSecondaryNICs())
+			waitForAvailableTestPolicy()
+			deletePolicy(TestPolicy)
+		})
+		It("should be updated", func() {
+			for node, originalNNS := range originalNNSs {
+				// Give enough time for the NNS to be updated (3 interval times)
+				timeout := 3 * nmstatenode.NetworkStateRefresh
+				key := types.NamespacedName{Name: node}
 
 				Eventually(func() time.Time {
 					updatedTime := nodeNetworkState(key).Status.LastSuccessfulUpdateTime
 					return updatedTime.Time
-				}, timeout, 1*time.Second).Should(BeTemporally(">", originalTime.Time))
+				}, timeout, time.Second).Should(BeTemporally(">", originalNNS.Status.LastSuccessfulUpdateTime.Time))
 			}
 		})
 	})
+
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
The node controller refresh NNSs every 5 seconds at every Reconcile it
do three things, GET Node, call nmstatectl show and UPDATE NNS, this is
too much of apiserver traffic and end up with big cpu usage. This change
reduce the calls to GET and UPDATE by comparing current network state
with last retrieved network state and if they differ then it do them.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Refresh NNS only if needed.
```
