### PR TITLE
Remove gc-timer at e2e tests when comparing NNS currentState

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -19,7 +19,6 @@ package controllers
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -34,16 +33,13 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 	"github.com/nmstate/kubernetes-nmstate/pkg/node"
+	"github.com/nmstate/kubernetes-nmstate/pkg/state"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // Added for test purposes
 type NmstateUpdater func(client client.Client, node *corev1.Node, namespace client.ObjectKey, observedStateRaw string) error
 type NmstatectlShow func() (string, error)
-
-var (
-	gcTimerRexp = regexp.MustCompile(` *gc-timer: *[0-9]*\n`)
-)
 
 // NodeReconciler reconciles a Node object
 type NodeReconciler struct {
@@ -128,10 +124,5 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *NodeReconciler) networkStateChanged(currentState string) bool {
-	return removeDynamicAttributes(r.lastState) != removeDynamicAttributes(currentState)
-}
-
-func removeDynamicAttributes(state string) string {
-	// Remove attributes that make network state always different
-	return gcTimerRexp.ReplaceAllLiteralString(state, "")
+	return state.RemoveDynamicAttributes(r.lastState) != state.RemoveDynamicAttributes(currentState)
 }

--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -1,0 +1,21 @@
+package state
+
+import (
+	"regexp"
+
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+var (
+	gcTimerRexp = regexp.MustCompile(` *gc-timer: *[0-9]*\n`)
+)
+
+func RemoveDynamicAttributes(state string) string {
+
+	// Remove attributes that make network state always different
+	return gcTimerRexp.ReplaceAllLiteralString(state, "")
+}
+
+func RemoveDynamicAttributesFromStruct(state shared.State) string {
+	return RemoveDynamicAttributes(state.String())
+}

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
@@ -32,7 +33,11 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 
 				Consistently(func() shared.NodeNetworkStateStatus {
 					return nodeNetworkState(key).Status
-				}, timeout, time.Second).Should(Equal(originalNNS.Status))
+				}, timeout, time.Second).Should(MatchAllFields(Fields{
+					"CurrentState":             WithTransform(shared.State.String, Equal(originalNNS.Status.CurrentState.String())),
+					"LastSuccessfulUpdateTime": Equal(originalNNS.Status.LastSuccessfulUpdateTime),
+					"Conditions":               Equal(originalNNS.Status.Conditions),
+				}))
 			}
 		})
 	})

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	nmstatenode "github.com/nmstate/kubernetes-nmstate/pkg/node"
+	"github.com/nmstate/kubernetes-nmstate/pkg/state"
 )
 
 var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
@@ -34,7 +35,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 				Consistently(func() shared.NodeNetworkStateStatus {
 					return nodeNetworkState(key).Status
 				}, timeout, time.Second).Should(MatchAllFields(Fields{
-					"CurrentState":             WithTransform(shared.State.String, Equal(originalNNS.Status.CurrentState.String())),
+					"CurrentState":             WithTransform(state.RemoveDynamicAttributesFromStruct, Equal(state.RemoveDynamicAttributes(originalNNS.Status.CurrentState.String()))),
 					"LastSuccessfulUpdateTime": Equal(originalNNS.Status.LastSuccessfulUpdateTime),
 					"Conditions":               Equal(originalNNS.Status.Conditions),
 				}))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

Closes #

**What this PR does / why we need it**:
When NNS current is compared the dynamic attributes has to be removed
for it to match like is already dont at controller.

Comparing directly the NNS Status struct print currentState as slice of
bytes that does not help to find differences, this change tranform the
obtained and expected to strings to make easier to find differences.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
