### PR TITLE
Retry NNSs Status checking at e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/github-release/github-release v0.8.1
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/vendor/github.com/andreyvit/diff/.gitignore
+++ b/vendor/github.com/andreyvit/diff/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/andreyvit/diff/LICENSE
+++ b/vendor/github.com/andreyvit/diff/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Andrey Tarantsov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/andreyvit/diff/README.md
+++ b/vendor/github.com/andreyvit/diff/README.md
@@ -1,0 +1,28 @@
+# diff
+
+Quick'n'easy string diffing functions for Golang based on [github.com/sergi/go-diff](https://github.com/sergi/go-diff). Mainly for diffing strings in tests.
+
+See [the docs on GoDoc](https://godoc.org/github.com/andreyvit/diff).
+
+Get it:
+
+    go get -u github.com/andreyvit/diff
+
+Example:
+
+    import (
+        "strings"
+        "testing"
+        "github.com/andreyvit/diff"
+    )
+
+    const expected = `
+    ...
+    `
+
+    func TestFoo(t *testing.T) {
+        actual := Foo(...)
+        if a, e := strings.TrimSpace(actual), strings.TrimSpace(expected); a != e {
+            t.Errorf("Result not as expected:\n%v", diff.LineDiff(e, a))
+        }
+    }

--- a/vendor/github.com/andreyvit/diff/diff.go
+++ b/vendor/github.com/andreyvit/diff/diff.go
@@ -1,0 +1,128 @@
+package diff
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func diff(a, b string) []diffmatchpatch.Diff {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(a, b, true)
+	if len(diffs) > 2 {
+		diffs = dmp.DiffCleanupSemantic(diffs)
+		diffs = dmp.DiffCleanupEfficiency(diffs)
+	}
+	return diffs
+}
+
+// CharacterDiff returns an inline diff between the two strings, using (++added++) and (~~deleted~~) markup.
+func CharacterDiff(a, b string) string {
+	return diffsToString(diff(a, b))
+}
+
+func diffsToString(diffs []diffmatchpatch.Diff) string {
+	var buff bytes.Buffer
+	for _, diff := range diffs {
+		text := diff.Text
+		switch diff.Type {
+		case diffmatchpatch.DiffInsert:
+			buff.WriteString("(++")
+			buff.WriteString(text)
+			buff.WriteString("++)")
+		case diffmatchpatch.DiffDelete:
+			buff.WriteString("(~~")
+			buff.WriteString(text)
+			buff.WriteString("~~)")
+		case diffmatchpatch.DiffEqual:
+			buff.WriteString(text)
+		}
+	}
+	return buff.String()
+}
+
+// LineDiff returns a normal linewise diff between the two given strings.
+func LineDiff(a, b string) string {
+	return strings.Join(LineDiffAsLines(a, b), "\n")
+}
+
+// LineDiffAsLines returns the lines of a linewise diff between the two given strings.
+func LineDiffAsLines(a, b string) []string {
+	return diffsToPatchLines(diff(a, b))
+}
+
+type patchBuilder struct {
+	output        []string
+	oldLines      []string
+	newLines      []string
+	newLineBuffer bytes.Buffer
+	oldLineBuffer bytes.Buffer
+}
+
+func (b *patchBuilder) AddCharacters(text string, op diffmatchpatch.Operation) {
+	if op == diffmatchpatch.DiffInsert || op == diffmatchpatch.DiffEqual {
+		b.newLineBuffer.WriteString(text)
+	}
+	if op == diffmatchpatch.DiffDelete || op == diffmatchpatch.DiffEqual {
+		b.oldLineBuffer.WriteString(text)
+	}
+}
+func (b *patchBuilder) AddNewline(op diffmatchpatch.Operation) {
+	oldLine := b.oldLineBuffer.String()
+	newLine := b.newLineBuffer.String()
+
+	if op == diffmatchpatch.DiffEqual && (oldLine == newLine) {
+		b.FlushChunk()
+		b.output = append(b.output, " "+newLine)
+		b.oldLineBuffer.Reset()
+		b.newLineBuffer.Reset()
+	} else {
+		if op == diffmatchpatch.DiffDelete || op == diffmatchpatch.DiffEqual {
+			b.oldLines = append(b.oldLines, "-"+oldLine)
+			b.oldLineBuffer.Reset()
+		}
+		if op == diffmatchpatch.DiffInsert || op == diffmatchpatch.DiffEqual {
+			b.newLines = append(b.newLines, "+"+newLine)
+			b.newLineBuffer.Reset()
+		}
+	}
+}
+func (b *patchBuilder) FlushChunk() {
+	if b.oldLines != nil {
+		b.output = append(b.output, b.oldLines...)
+		b.oldLines = nil
+	}
+	if b.newLines != nil {
+		b.output = append(b.output, b.newLines...)
+		b.newLines = nil
+	}
+}
+func (b *patchBuilder) Flush() {
+	if b.oldLineBuffer.Len() > 0 && b.newLineBuffer.Len() > 0 {
+		b.AddNewline(diffmatchpatch.DiffEqual)
+	} else if b.oldLineBuffer.Len() > 0 {
+		b.AddNewline(diffmatchpatch.DiffDelete)
+	} else if b.newLineBuffer.Len() > 0 {
+		b.AddNewline(diffmatchpatch.DiffInsert)
+	}
+	b.FlushChunk()
+}
+
+func diffsToPatchLines(diffs []diffmatchpatch.Diff) []string {
+	b := new(patchBuilder)
+	b.output = make([]string, 0, len(diffs))
+
+	for _, diff := range diffs {
+		lines := strings.Split(diff.Text, "\n")
+		for idx, line := range lines {
+			if idx > 0 {
+				b.AddNewline(diff.Type)
+			}
+			b.AddCharacters(line, diff.Type)
+		}
+	}
+
+	b.Flush()
+	return b.output
+}

--- a/vendor/github.com/andreyvit/diff/doc.go
+++ b/vendor/github.com/andreyvit/diff/doc.go
@@ -1,0 +1,2 @@
+// diff provides quick and easy string diffing functions based on github.com/sergi/go-diff, mainly for diffing strings in tests
+package diff

--- a/vendor/github.com/andreyvit/diff/trim.go
+++ b/vendor/github.com/andreyvit/diff/trim.go
@@ -1,0 +1,19 @@
+package diff
+
+import (
+	"strings"
+)
+
+// TrimLines applies TrimSpace to each string in the given array.
+func TrimLines(input []string) []string {
+	result := make([]string, 0, len(input))
+	for _, el := range input {
+		result = append(result, strings.TrimSpace(el))
+	}
+	return result
+}
+
+// TrimLinesInString applies TrimSpace to each line in the given string, and returns the new trimmed string. Empty lines are not removed.
+func TrimLinesInString(input string) string {
+	return strings.Join(TrimLines(strings.Split(strings.TrimSpace(input), "\n")), "\n")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,6 +74,9 @@ github.com/Microsoft/hcsshim/osversion
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
+## explicit
+github.com/andreyvit/diff
 # github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6
 github.com/antihax/optional
 # github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Sometimes the currentState get changed by the system so NNS status get
refreshed, there is a test checking that NNS Status is not updated if
not needed, so in those cases the test is retried.

Example of network changes detected 
```
[nns] NNS LastSuccessfulUpdateTime
/tmp/knmstate/kubernetes-nmstate/test/e2e/handler/nns_update_timestamp_test.go:17
  when network configuration hasn't change
  /tmp/knmstate/kubernetes-nmstate/test/e2e/handler/nns_update_timestamp_test.go:28
    should not be updated [It]
    /tmp/knmstate/kubernetes-nmstate/test/e2e/handler/nns_update_timestamp_test.go:29

    Failed after 0.008s.
    Expected
        <string>: NodeNetworkStateStatus
    to match fields: {
    .CurrentState:
    	Expected
    	    <string>: "...on: fe80::/..."
    	to equal               |
    	    <string>: "...on: fd10:24..."
    .LastSuccessfulUpdateTime:
    	Expected
    	    <v1.Time>: {
    	        Time: 2021-01-14T13:36:40Z,
    	    }
    	to equal
    	    <v1.Time>: {
    	        Time: 2021-01-14T13:35:40Z,
    	    }
    }
    
```


**Special notes for your reviewer**:
Closes #670 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
