### PR TITLE
Add a validation webhook for policy changes

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -229,6 +229,17 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["v1alpha1","v1beta1"]
         resources: ["nodenetworkconfigurationpolicies", "nodenetworkconfigurationpolicies/status"]
+  - name: nodenetworkconfigurationpolicies-progress-validate.nmstate.io
+    clientConfig:
+      service:
+        name: {{template "handlerPrefix" .}}nmstate-webhook
+        namespace: {{ .HandlerNamespace }}
+        path: "/nodenetworkconfigurationpolicies-progress-validate"
+    rules:
+      - operations: ["UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["v1alpha1","v1beta1"]
+        resources: ["nodenetworkconfigurationpolicies"]
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -22,8 +22,8 @@ var (
 	log = logf.Log.WithName("policyconditions")
 )
 
-func setPolicyProgressing(conditions *nmstate.ConditionList, message string) {
-	log.Info("setPolicyProgressing")
+func SetPolicyProgressing(conditions *nmstate.ConditionList, message string) {
+	log.Info("SetPolicyProgressing")
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionDegraded,
 		corev1.ConditionUnknown,
@@ -38,8 +38,8 @@ func setPolicyProgressing(conditions *nmstate.ConditionList, message string) {
 	)
 }
 
-func setPolicySuccess(conditions *nmstate.ConditionList, message string) {
-	log.Info("setPolicySuccess")
+func SetPolicySuccess(conditions *nmstate.ConditionList, message string) {
+	log.Info("SetPolicySuccess")
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionDegraded,
 		corev1.ConditionFalse,
@@ -54,8 +54,8 @@ func setPolicySuccess(conditions *nmstate.ConditionList, message string) {
 	)
 }
 
-func setPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
-	log.Info("setPolicyNotMatching")
+func SetPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
+	log.Info("SetPolicyNotMatching")
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionDegraded,
 		corev1.ConditionFalse,
@@ -70,8 +70,8 @@ func setPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
 	)
 }
 
-func setPolicyFailedToConfigure(conditions *nmstate.ConditionList, message string) {
-	log.Info("setPolicyFailedToConfigure")
+func SetPolicyFailedToConfigure(conditions *nmstate.ConditionList, message string) {
+	log.Info("SetPolicyFailedToConfigure")
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionDegraded,
 		corev1.ConditionTrue,
@@ -147,20 +147,20 @@ func Update(cli client.Client, policyKey types.NamespacedName) error {
 
 		logger.Info(fmt.Sprintf("enactments count: %s", enactmentsCount))
 		if numberOfFinishedEnactments < numberOfNmstateNodes {
-			setPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateNodes))
+			SetPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateNodes))
 		} else {
 			if enactmentsCount.Matching() == 0 {
 				message := "Policy does not match any node"
-				setPolicyNotMatching(&policy.Status.Conditions, message)
+				SetPolicyNotMatching(&policy.Status.Conditions, message)
 			} else if enactmentsCount.Failed() > 0 || enactmentsCount.Aborted() > 0 {
 				message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCount.Failed(), enactmentsCount.Matching())
 				if enactmentsCount.Aborted() > 0 {
 					message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCount.Aborted())
 				}
-				setPolicyFailedToConfigure(&policy.Status.Conditions, message)
+				SetPolicyFailedToConfigure(&policy.Status.Conditions, message)
 			} else {
 				message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCount.Available(), enactmentsCount.Available())
-				setPolicySuccess(&policy.Status.Conditions, message)
+				SetPolicySuccess(&policy.Status.Conditions, message)
 			}
 		}
 

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyProgressing, "Policy is progressing 0/3 nodes finished"),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 0/3 nodes finished"),
 		}),
 		Entry("when all enactments are success then policy is success", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -180,7 +180,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicySuccess, "3/3 nodes successfully configured"),
+			Policy: p(SetPolicySuccess, "3/3 nodes successfully configured"),
 		}),
 		Entry("when not all enactments are created is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -190,7 +190,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
-			Policy: p(setPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
 		}),
 		Entry("when enactments are progressing/success then policy is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -200,7 +200,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyProgressing, "Policy is progressing 2/3 nodes finished"),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 2/3 nodes finished"),
 		}),
 		Entry("when enactments are failed/progressing/success then policy is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -211,7 +211,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
-			Policy: p(setPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
 		}),
 		Entry("when all the enactments are at failing or success policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -221,7 +221,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyFailedToConfigure, "2/3 nodes failed to configure"),
+			Policy: p(SetPolicyFailedToConfigure, "2/3 nodes failed to configure"),
 		}),
 		Entry("when all the enactments are at failing policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -231,7 +231,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyFailedToConfigure, "3/3 nodes failed to configure"),
+			Policy: p(SetPolicyFailedToConfigure, "3/3 nodes failed to configure"),
 		}),
 		Entry("when no node matches policy node selector, policy state is not matching", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -241,7 +241,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyNotMatching, "Policy does not match any node"),
+			Policy: p(SetPolicyNotMatching, "Policy does not match any node"),
 		}),
 		Entry("when some enacments has unknown matching state policy state is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -251,7 +251,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicyProgressing, "Policy is progressing 1/3 nodes finished"),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 1/3 nodes finished"),
 		}),
 		Entry("when some enactments are from different profile it does no affect the profile status", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -263,7 +263,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
-			Policy: p(setPolicySuccess, "3/3 nodes successfully configured"),
+			Policy: p(SetPolicySuccess, "3/3 nodes successfully configured"),
 		}),
 		Entry("when a node does not run nmstate pod ignore it for policy conditions calculations", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
@@ -281,7 +281,7 @@ var _ = Describe("Policy Conditions", func() {
 				newNonNmstatePodAtNode(3),
 				newNonNmstatePodAtNode(4),
 			},
-			Policy: p(setPolicySuccess, "3/3 nodes successfully configured"),
+			Policy: p(SetPolicySuccess, "3/3 nodes successfully configured"),
 		}),
 	)
 })

--- a/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
@@ -7,7 +7,10 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -16,6 +19,7 @@ import (
 )
 
 type mutator func(nmstatev1beta1.NodeNetworkConfigurationPolicy) nmstatev1beta1.NodeNetworkConfigurationPolicy
+type validator func(nmstatev1beta1.NodeNetworkConfigurationPolicy, nmstatev1beta1.NodeNetworkConfigurationPolicy) []metav1.StatusCause
 
 func mutatePolicyHandler(neededMutationFor func(nmstatev1beta1.NodeNetworkConfigurationPolicy) bool, mutate mutator) admission.HandlerFunc {
 	log := logf.Log.WithName("webhook/nodenetworkconfigurationpolicy/mutator")
@@ -41,6 +45,46 @@ func mutatePolicyHandler(neededMutationFor func(nmstatev1beta1.NodeNetworkConfig
 		log.Info(fmt.Sprintf("webhook response: %+v", response))
 		return response
 	}
+}
+
+func validatePolicyHandler(cli client.Client, neededValidationFor func(nmstatev1beta1.NodeNetworkConfigurationPolicy, nmstatev1beta1.NodeNetworkConfigurationPolicy) bool, validators ...validator) admission.HandlerFunc {
+	log := logf.Log.WithName("webhook/nodenetworkconfigurationpolicy/validator")
+	return func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+		original := req.Object.Raw
+		policy := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
+		err := json.Unmarshal(original, &policy)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, "failed decoding policy: %s", string(original)))
+		}
+		currentPolicy := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
+		err = cli.Get(context.TODO(), types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}, &currentPolicy)
+		if err != nil && !apierrors.IsNotFound(err) {
+			errMsg := fmt.Sprintf("failed getting policy %s", string(original))
+			log.Error(err, errMsg)
+			return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, errMsg))
+		}
+
+		if !neededValidationFor(policy, currentPolicy) {
+			return admission.Allowed("validation not needed")
+		}
+
+		errCauses := []metav1.StatusCause{}
+		for _, validate := range validators {
+			errCauses = append(errCauses, validate(policy, currentPolicy)...)
+		}
+		if len(errCauses) > 0 {
+			return admission.Denied(handlePolicyCauses(errCauses, policy.Name))
+		}
+		return admission.Allowed("")
+	}
+}
+
+func handlePolicyCauses(causes []metav1.StatusCause, name string) string {
+	errMsg := fmt.Sprintf("failed to admit NodeNetworkConfigurationPolicy %s: ", name)
+	for _, cause := range causes {
+		errMsg += fmt.Sprintf("message: %s. ", cause.Message)
+	}
+	return errMsg
 }
 
 func always(nmstatev1beta1.NodeNetworkConfigurationPolicy) bool {

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -26,6 +26,7 @@ func Add(mgr manager.Manager, o certificate.Options) error {
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook()),
 		webhookserver.WithHook("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook()),
+		webhookserver.WithHook("/nodenetworkconfigurationpolicies-progress-validate", validatePolicyUpdateHook(mgr.GetClient())),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed creating new webhook server")

--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
@@ -1,0 +1,44 @@
+package nodenetworkconfigurationpolicy
+
+import (
+	"fmt"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+)
+
+func onPolicySpecChange(policy nmstatev1beta1.NodeNetworkConfigurationPolicy, currentPolicy nmstatev1beta1.NodeNetworkConfigurationPolicy) bool {
+	return !reflect.DeepEqual(policy.Spec, currentPolicy.Spec)
+}
+
+func validatePolicyNotInProgressHook(policy nmstatev1beta1.NodeNetworkConfigurationPolicy, currentPolicy nmstatev1beta1.NodeNetworkConfigurationPolicy) []metav1.StatusCause {
+	causes := []metav1.StatusCause{}
+	currentPolicyAvailableCondition := currentPolicy.Status.Conditions.Find(shared.NodeNetworkConfigurationPolicyConditionAvailable)
+
+	if currentPolicyAvailableCondition == nil ||
+		currentPolicyAvailableCondition.Reason == "" ||
+		currentPolicyAvailableCondition.Reason == shared.NodeNetworkConfigurationPolicyConditionConfigurationProgressing {
+		causes = append(causes, metav1.StatusCause{
+			Message: fmt.Sprintf("policy %s is still in progress", currentPolicy.Name),
+		})
+	}
+	return causes
+}
+
+func validatePolicyUpdateHook(cli client.Client) *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(
+			validatePolicyHandler(
+				cli,
+				onPolicySpecChange,
+				validatePolicyNotInProgressHook,
+			),
+		),
+	}
+}

--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
@@ -1,0 +1,75 @@
+package nodenetworkconfigurationpolicy
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/pkg/policyconditions"
+)
+
+func p(conditionsSetter func(*shared.ConditionList, string), message string) nmstatev1beta1.NodeNetworkConfigurationPolicy {
+	conditions := shared.ConditionList{}
+	conditionsSetter(&conditions, message)
+	return nmstatev1beta1.NodeNetworkConfigurationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testPolicy",
+		},
+		Status: shared.NodeNetworkConfigurationPolicyStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+var _ = Describe("NNCP Conditions Validation Admission Webhook", func() {
+	var testPolicy = nmstatev1beta1.NodeNetworkConfigurationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testPolicy",
+		},
+		Spec:   shared.NodeNetworkConfigurationPolicySpec{},
+		Status: shared.NodeNetworkConfigurationPolicyStatus{},
+	}
+	type ValidationWebhookCase struct {
+		policy           nmstatev1beta1.NodeNetworkConfigurationPolicy
+		currentPolicy    nmstatev1beta1.NodeNetworkConfigurationPolicy
+		validationFn     func(policy nmstatev1beta1.NodeNetworkConfigurationPolicy, current nmstatev1beta1.NodeNetworkConfigurationPolicy) []metav1.StatusCause
+		validationResult []metav1.StatusCause
+	}
+	DescribeTable("the NNCP conditions", func(v ValidationWebhookCase) {
+		validationResult := v.validationFn(v.policy, v.currentPolicy)
+		Expect(validationResult).To(Equal(v.validationResult))
+	},
+		Entry("current policy in progress", ValidationWebhookCase{
+			policy:        testPolicy,
+			currentPolicy: p(policyconditions.SetPolicyProgressing, ""),
+			validationFn:  validatePolicyNotInProgressHook,
+			validationResult: []metav1.StatusCause{
+				{
+					Message: "policy testPolicy is still in progress",
+				},
+			},
+		}),
+		Entry("current policy successfully configured", ValidationWebhookCase{
+			policy:           testPolicy,
+			currentPolicy:    p(policyconditions.SetPolicySuccess, ""),
+			validationFn:     validatePolicyNotInProgressHook,
+			validationResult: []metav1.StatusCause{},
+		}),
+		Entry("current policy not matching", ValidationWebhookCase{
+			policy:           testPolicy,
+			currentPolicy:    p(policyconditions.SetPolicyNotMatching, ""),
+			validationFn:     validatePolicyNotInProgressHook,
+			validationResult: []metav1.StatusCause{},
+		}),
+		Entry("current policy failed to configure", ValidationWebhookCase{
+			policy:           testPolicy,
+			currentPolicy:    p(policyconditions.SetPolicyFailedToConfigure, ""),
+			validationFn:     validatePolicyNotInProgressHook,
+			validationResult: []metav1.StatusCause{},
+		}),
+	)
+})

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -21,7 +21,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	Context("when policy is set with node selector not matching any nodes", func() {
 		BeforeEach(func() {
 			By(fmt.Sprintf("Set policy %s with not matching node selector", bridge1))
-			setDesiredStateWithPolicyAndNodeSelector(bridge1, linuxBrUp(bridge1), testNodeSelector)
+			setDesiredStateWithPolicyAndNodeSelectorEventually(bridge1, linuxBrUp(bridge1), testNodeSelector)
 			waitForAvailablePolicy(bridge1)
 		})
 

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -1,10 +1,13 @@
 package handler
 
 import (
+	"fmt"
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/util/retry"
 
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	nncpwebhook "github.com/nmstate/kubernetes-nmstate/pkg/webhook/nodenetworkconfigurationpolicy"
@@ -50,6 +53,27 @@ var _ = Describe("Mutating Admission Webhook", func() {
 
 				Expect(newConditionsMutation).To(BeNumerically(">", oldConditionsMutation), "mutation timestamp not updated")
 			})
+		})
+	})
+})
+
+var _ = Describe("Validation Admission Webhook", func() {
+	Context("When a policy is created and progressing", func() {
+		BeforeEach(func() {
+			By("Creating a policy without waiting for it to be available")
+			updateDesiredState(linuxBrUp(bridge1))
+		})
+		AfterEach(func() {
+			waitForAvailablePolicy(TestPolicy)
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
+			resetDesiredStateForNodes()
+		})
+		It("Should deny updating sequentially rolled out policy when it's in progress", func() {
+			By(fmt.Sprintf("Updating the policy %s", TestPolicy))
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				return setDesiredStateWithPolicyAndNodeSelector(TestPolicy, linuxBrUpNoPorts(bridge1), map[string]string{})
+			})
+			Expect(err).To(MatchError("admission webhook \"nodenetworkconfigurationpolicies-progress-validate.nmstate.io\" denied the request: failed to admit NodeNetworkConfigurationPolicy test-policy: message: policy test-policy is still in progress. "))
 		})
 	})
 })


### PR DESCRIPTION


Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
In this PR I have added a validation webhook that denies changing a policy, which is currently being 
sequentially rolled out.

This is denied because the result of changing such policy could end up inconsistent
on different nodes, caused by reconciling the nnce in different order.

**Special notes for your reviewer**:
There currently is an issue with CI:
The Docs lane fails due to ruby version incompatibility with listen package, [PR with fix](https://github.com/nmstate/kubernetes-nmstate/pull/676)

**Release note**:

```release-note
NONE
```
