### PR TITLE
Bump ruby listen package

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.2.1)
+    listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)


### PR DESCRIPTION
Listen 3.2.1 doesn't support ruby version >= 3.0

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Bumping listen package version to fix pull-kubernetes-nmstate-docs job:
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/nmstate_kubernetes-nmstate/675/pull-kubernetes-nmstate-docs/1347106423779102721

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
