### PR TITLE
Merge eth1 and eth2 NNCPS in user guide into one

### DIFF
--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -343,7 +343,7 @@ kubectl apply -f eth1-eth2_up.yaml
 Wait for the Policy to get applied:
 
 ```shell
-kubectl wait nncp eth1 eth2 --for condition=Available --timeout 2m
+kubectl wait nncp eth1-eth2 --for condition=Available --timeout 2m
 ```
 
 Both NICs are now back up and with assigned IPs:

--- a/docs/user-guide/eth1-eth2_up.yaml
+++ b/docs/user-guide/eth1-eth2_up.yaml
@@ -2,7 +2,7 @@
 apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: eth1
+  name: eth1-eth2
 spec:
   desiredState:
     interfaces:
@@ -12,14 +12,6 @@ spec:
       ipv4:
         dhcp: true
         enabled: true
----
-apiVersion: nmstate.io/v1beta1
-kind: NodeNetworkConfigurationPolicy
-metadata:
-  name: eth2
-spec:
-  desiredState:
-    interfaces:
     - name: eth2
       type: ethernet
       state: up


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
After introducing parallel and sequential policy application
we decided to allow only one sequentially applied policy to be
in progress at a time.
This example in user guide wasn't updated to follow this.

Instead of creating two policies, one for configuring `eth1` and one `eth2` interface, I'm
placing the configuration to one policy. 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
