### PR TITLE
Filter calico interfaces from NNS

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -172,7 +172,7 @@ metadata:
   name: {{template "handlerPrefix" .}}nmstate-config
   namespace: {{ .HandlerNamespace }}
 data:
-  interfaces_filter: "veth*"
+  interfaces_filter: "{veth*,cali*}"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The NodeNeworkState is showing up calico interfaces but they are calico
implementation tails and kubernets-nmstate should not show or modify
them, also looks like it affects e2e tests on calico systems [1].

This change just filter them same as we do with veth.

[1] https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/727/pull-e2e-cluster-network-addons-operator-nmstate-functests/1347188092745814016

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Ignore calico intefaces from NodeNetworkState by default.
```
