### PR TITLE
Jitter the nns refresh period

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -71,7 +71,7 @@ func (r *NodeReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 
 	// Reduce apiserver hits by checking node's network state with last one
 	if r.lastState.String() == currentState.String() {
-		return ctrl.Result{RequeueAfter: node.NetworkStateRefresh}, err
+		return ctrl.Result{RequeueAfter: node.NetworkStateRefreshWithJitter()}, err
 	} else {
 		r.Log.Info("Network configuration changed, updating NodeNetworkState")
 	}
@@ -98,7 +98,7 @@ func (r *NodeReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// Cache currentState after successfully storing it at NodeNetworkState
 	r.lastState = currentState
 
-	return ctrl.Result{RequeueAfter: node.NetworkStateRefresh}, nil
+	return ctrl.Result{RequeueAfter: node.NetworkStateRefreshWithJitter()}, nil
 }
 
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Node controller reconcile", func() {
 				Name: existingNodeName,
 			},
 		}
+		expectRequeueAfterIsSetWithNetworkStateRefresh = func(result ctrl.Result) {
+			ExpectWithOffset(1, result.RequeueAfter).To(BeNumerically("~", nmstatenode.NetworkStateRefresh, float64(nmstatenode.NetworkStateRefresh)*nmstatenode.NetworkStateRefreshMaxFactor))
+		}
 	)
 	BeforeEach(func() {
 		reconciler = NodeReconciler{}
@@ -109,7 +112,7 @@ routes:
 		It("should not call nmstateUpdater and return a Result with RequeueAfter set", func() {
 			result, err := reconciler.Reconcile(request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{RequeueAfter: nmstatenode.NetworkStateRefresh}))
+			expectRequeueAfterIsSetWithNetworkStateRefresh(result)
 		})
 	})
 	Context("when node is not found", func() {
@@ -161,7 +164,7 @@ routes:
 			It("should call nmstateUpdater and return a Result with RequeueAfter set (trigger re-reconciliation)", func() {
 				result, err := reconciler.Reconcile(request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: nmstatenode.NetworkStateRefresh}))
+				expectRequeueAfterIsSetWithNetworkStateRefresh(result)
 				obtainedNNS := nmstatev1beta1.NodeNetworkState{}
 				err = cl.Get(context.TODO(), types.NamespacedName{Name: existingNodeName}, &obtainedNNS)
 				Expect(err).ToNot(HaveOccurred())
@@ -193,7 +196,7 @@ routes:
 			It("should return a Result with RequeueAfter set (trigger re-reconciliation)", func() {
 				result, err := reconciler.Reconcile(request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{RequeueAfter: nmstatenode.NetworkStateRefresh}))
+				expectRequeueAfterIsSetWithNetworkStateRefresh(result)
 			})
 		})
 	})

--- a/pkg/node/constants.go
+++ b/pkg/node/constants.go
@@ -1,9 +1,0 @@
-package node
-
-import (
-	"time"
-)
-
-const (
-	NetworkStateRefresh = time.Minute
-)

--- a/pkg/node/refresh.go
+++ b/pkg/node/refresh.go
@@ -1,0 +1,18 @@
+package node
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	NetworkStateRefresh          = time.Minute
+	NetworkStateRefreshMaxFactor = 0.1
+)
+
+// NodeNetworkStateRefreshWithJitter add some jitter to to the refresh rate so it does
+// not hit apiserver at the same time.
+func NetworkStateRefreshWithJitter() time.Duration {
+	return wait.Jitter(NetworkStateRefresh, NetworkStateRefreshMaxFactor)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Refreshing NNS at the same time on all the nodes can hit apiserver hard,
let's jitter it a little so refreshing is distributed over time.


**Special notes for your reviewer**:
This will reduce the impact of https://github.com/nmstate/kubernetes-nmstate/issues/684

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Jitter the nns refresh period
```
