### PR TITLE
Use fmt.Sprintf format a ginkgo Should

### DIFF
--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -34,15 +35,15 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 				timeout := 3 * nmstatenode.NetworkStateRefresh
 				key := types.NamespacedName{Name: node}
 
-				obtainedStatus := shared.NodeNetworkStateStatus{}
 				Consistently(func() shared.NodeNetworkStateStatus {
-					obtainedStatus = nodeNetworkState(key).Status
-					return obtainedStatus
+					return nodeNetworkState(key).Status
 				}, timeout, time.Second).Should(MatchAllFields(Fields{
 					"CurrentState":             WithTransform(shared.State.String, Equal(originalNNS.Status.CurrentState.String())),
 					"LastSuccessfulUpdateTime": Equal(originalNNS.Status.LastSuccessfulUpdateTime),
 					"Conditions":               Equal(originalNNS.Status.Conditions),
-				}), "currentState diff: ", diff.LineDiff(originalNNS.Status.CurrentState.String(), obtainedStatus.CurrentState.String()))
+				}), func() string {
+					return fmt.Sprintf("currentState diff: \n%s", diff.LineDiff(originalNNS.Status.CurrentState.String(), nodeNetworkState(key).Status.CurrentState.String()))
+				})
 			}
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Ginkgo `Should` description allow to pass a string and some arguments but
the string has to follow Sprintf format. This change fix one test that
was not using "%s" expansion token at the string, also use the lazy
initialization mechanism to get the current after eventually is
finished.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
