### PR TITLE
Skip linux-bridge filtering if no "bridge" section

### DIFF
--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -30,7 +30,16 @@ func FilterOut(currentState shared.State) (shared.State, error) {
 }
 
 func filterOutRoutes(kind string, state map[string]interface{}, interfacesFilterGlob glob.Glob) {
-	routes := state["routes"].(map[string]interface{})
+	routesRaw, hasRoutes := state["routes"]
+	if !hasRoutes {
+		return
+	}
+
+	routes, ok := routesRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
 	routesByKind := routes[kind].([]interface{})
 
 	if routesByKind == nil {
@@ -58,9 +67,24 @@ func filterOutDynamicAttributes(iface map[string]interface{}) {
 		return
 	}
 
-	bridge := iface["bridge"].(map[string]interface{})
+	bridgeRaw, hasBridge := iface["bridge"]
+	if !hasBridge {
+		return
+	}
+	bridge, ok := bridgeRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
 
-	options := bridge["options"].(map[string]interface{})
+	optionsRaw, hasOptions := bridge["options"]
+	if !hasOptions {
+		return
+	}
+	options, ok := optionsRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
 	delete(options, "gc-timer")
 	delete(options, "hello-timer")
 }

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -307,4 +307,28 @@ routes:
 			Expect(returnedState).To(MatchYAML(filteredState))
 		})
 	})
+	Context("when there is a linux bridge without 'bridge' options because is down", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: br1
+  type: linux-bridge
+  state: down
+`)
+
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: br1
+  type: linux-bridge
+  state: down
+`)
+			interfacesFilterGlob = glob.MustCompile("")
+		})
+		It("should keep the bridge as it is", func() {
+			returnedState, err := filterOut(state, interfacesFilterGlob)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
We have found that at some envs the "bridge" section from linux-bridge
is not present in case the bridge is down, this change ignore the
filtering in this is the case to preveng a segmentation fault.


> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
