### PR TITLE
Remove usage of offensive language from user-guide

### DIFF
--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -246,7 +246,7 @@ status:
 ```
 
 As seen in the output, the configuration is indeed applied and there is a bond
-available with two NICs used as its slaves.
+available with two NICs used as its ports.
 
 ## Removing interfaces
 
@@ -294,10 +294,10 @@ kubectl delete nncp bond0-eth1-eth2
 
 Another maybe surprising behavior is, that by removing an interface, original
 configuration of the node interfaces is not restored. In case of the bonding it
-means that after it is deleted, its slave NICs won't come back up, even if they
-had previously configured IP address. The operator is not owning the interfaces
-and does not want to do anything that is not explicitly specified, that's up to
-the user.
+means that after it is deleted, its ports won't come back up as standalone
+ports, even if they had previously configured IP address. The operator is not
+owning the interfaces and does not want to do anything that is not explicitly
+specified, that's up to the user.
 
 `NodeNetworkState` shows that both of the NICs are now down and without any IP
 configuration.
@@ -330,7 +330,7 @@ status:
       type: ethernet
 ```
 
-In order to configure IP on previously enslaved NICs, apply a new Policy:
+In order to configure IP on previously attached NICs, apply a new Policy:
 
 <!-- When updating following example, don't forget to update respective attached file -->
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/bug

**What this PR does / why we need it**:

Some offensive language was left in user-guide even after https://github.com/nmstate/kubernetes-nmstate/pull/661 got merged.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
