### PR TITLE
Set the KUBEVIRT_PROVIDER at the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ WHAT ?= ./pkg ./controllers ./api
 
 unit_test_args ?=  -r -keepGoing --randomizeAllSpecs --randomizeSuites --race --trace $(UNIT_TEST_ARGS)
 
+export KUBEVIRT_PROVIDER ?= k8s-1.20
 export KUBEVIRT_NUM_NODES ?= 2 # 1 master, 1 worker needed for e2e tests
 export KUBEVIRT_NUM_SECONDARY_NICS ?= 2
 

--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -16,7 +16,6 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.20'
     export KUBEVIRT_NUM_NODES=3 # 1 master, 2 workers
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/automation/check-patch.e2e-operator-k8s.sh
+++ b/automation/check-patch.e2e-operator-k8s.sh
@@ -14,7 +14,6 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.20'
     export KUBEVIRT_NUM_NODES=3 # 1 master, 2 workers
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
If the KUBEVIRT_PROVIDER is not set at the Makefile the secondary nics
names are not known and test start to fail. This change add the default
KUBEVIRT_PROVIDER at the Makefile and remove it from the automation so
the Makefile is the one ruling about it.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
