### PR TITLE
Explicitly unmanage veth interfaces

### DIFF
--- a/build/bin/unmanaged-veth
+++ b/build/bin/unmanaged-veth
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+
+echo '[keyfile]
+unmanaged-devices=interface-name:veth*
+' > /host/etc/NetworkManager/conf.d/001-cnv-unmanaged-veth.conf
+dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call  /org/freedesktop/systemd1 --print-reply org.freedesktop.systemd1.Manager.ReloadUnit string:NetworkManager.service string:replace

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -153,6 +153,8 @@ spec:
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket
+            - name: networkmanager-config
+              mountPath: /host/etc/NetworkManager/conf.d
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
           securityContext:
@@ -162,6 +164,10 @@ spec:
           hostPath:
             path: /run/dbus/system_bus_socket
             type: Socket
+        - name: networkmanager-config
+          hostPath:
+            path: /etc/NetworkManager/conf.d
+            type: Directory
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

nmstate 0.3 introduces a bug where all veths attached to nmstatectl
configured bridge turn into "managed" by NetworkManager. This was not
the case in 0.2.

Due to this regression, NetworkManager deliberatelly detaches veth
ifaces from the bridge and by doing that it disconnectecs Pods/VMs from
the network.

With this change, we explicitly set veth interfaces as unmanaged.

Important: With this change, it is no longer possible to change
configuration of bridges that have veths attached.

This should be reverted once https://bugzilla.redhat.com/show_bug.cgi?id=1932247 becomes available.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Explicitly set host veths as unmanaged
```
