### PR TITLE
Revert "Explicitly unmanage veth interfaces (#701)"

### DIFF
--- a/build/bin/unmanaged-veth
+++ b/build/bin/unmanaged-veth
@@ -1,6 +1,0 @@
-#!/bin/bash -xe
-
-echo '[keyfile]
-unmanaged-devices=interface-name:veth*
-' > /host/etc/NetworkManager/conf.d/001-cnv-unmanaged-veth.conf
-dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call  /org/freedesktop/systemd1 --print-reply org.freedesktop.systemd1.Manager.ReloadUnit string:NetworkManager.service string:replace

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -153,8 +153,6 @@ spec:
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket
-            - name: networkmanager-config
-              mountPath: /host/etc/NetworkManager/conf.d
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
           securityContext:
@@ -164,10 +162,6 @@ spec:
           hostPath:
             path: /run/dbus/system_bus_socket
             type: Socket
-        - name: networkmanager-config
-          hostPath:
-            path: /etc/NetworkManager/conf.d
-            type: Directory
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate

--- a/main.go
+++ b/main.go
@@ -17,13 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"os/exec"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,8 +44,6 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/pkg/environment"
 	"github.com/nmstate/kubernetes-nmstate/pkg/webhook"
 )
-
-const unmanagedVethCommand = "unmanaged-veth"
 
 type ProfilerConfig struct {
 	EnableProfiler bool   `envconfig:"ENABLE_PROFILER"`
@@ -85,8 +81,6 @@ func main() {
 		}
 		defer handlerLock.Unlock()
 		setupLog.Info("Successfully took nmstate exclusive lock")
-
-		setVethInterfacesAsUnmanaged()
 	}
 
 	ctrlOptions := ctrl.Options{
@@ -219,14 +213,4 @@ func lockHandler() (lockfile.Lockfile, error) {
 		return true, nil
 	})
 	return handlerLock, err
-}
-
-func setVethInterfacesAsUnmanaged() {
-	cmd := exec.Command(unmanagedVethCommand)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		setupLog.Info(fmt.Sprintf("failed to execute %s: '%v', '%s', '%s'", unmanagedVethCommand, err, stdout.String(), stderr.String()))
-	}
 }


### PR DESCRIPTION
This reverts commit f717775686d23a68ccbb533830a5dd036383095f.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

The workaround fixed the issue of managing veths but caused other regressions on OpenShift where it caused removal of VXLAN handling overlay networking. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
