### PR TITLE
state, filter: Treat numeric-only iface names

### DIFF
--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -331,4 +331,51 @@ interfaces:
 		})
 	})
 
+	Context("when the interfaces have (only) numeric characters", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: eth1
+- name: 1
+- name: 1101011
+`)
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: eth1
+- name: 1
+- name: 1101011
+`)
+			interfacesFilterGlob = glob.MustCompile("1*")
+		})
+
+		It("they are not filtered out", func() {
+			returnedState, err := filterOut(state, interfacesFilterGlob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+
+	Context("when the interfaces have (only) special numeric characters", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: eth1
+- name: 1.0
+- name: 0xff
+`)
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: eth1
+- name: 1
+- name: 255
+`)
+			interfacesFilterGlob = glob.MustCompile("has-no-effect")
+		})
+
+		It("they are not interpreted correctly", func() {
+			returnedState, err := filterOut(state, interfacesFilterGlob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
 })


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
When processing the filtering of the interfaces status, the interfaces
with names that include only numeric characters are interpreted as
float64.

In order to (partially) support such interfaces, make sure to detect them
and avoid their filtering. I.E. these interfaces cannot be filtered-out.

Note: This solution is partial due to the improper interpretation of
special numeric (only) names such as (123.0 and 0xff). These will
wrongly get interpreted as 123 and 255.

**Special notes for your reviewer**:

**Release note**:
```release-note
Support interface names with numeric-only characters.
Names with special characters, like `1.0` or `0xff` are not supported.
```
