### PR TITLE
state, filter: Fix the interpretation of ifaces names

### DIFF
--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -73,12 +73,11 @@ func filterOutDynamicAttributes(iface map[string]interface{}) {
 	delete(options, "hello-timer")
 }
 
-func filterOutInterfaces(ifaces []interface{}, interfacesFilterGlob glob.Glob) []interface{} {
-	filteredInterfaces := []interface{}{}
-	for _, iface := range ifaces {
-		name := iface.(map[string]interface{})["name"]
-		if !interfacesFilterGlob.Match(name.(string)) {
-			filterOutDynamicAttributes(iface.(map[string]interface{}))
+func filterOutInterfaces(ifacesState []interfaceState, interfacesFilterGlob glob.Glob) []interfaceState {
+	filteredInterfaces := []interfaceState{}
+	for _, iface := range ifacesState {
+		if !interfacesFilterGlob.Match(iface.Name) {
+			filterOutDynamicAttributes(iface.Data)
 			filteredInterfaces = append(filteredInterfaces, iface)
 		}
 	}
@@ -87,8 +86,7 @@ func filterOutInterfaces(ifaces []interface{}, interfacesFilterGlob glob.Glob) [
 
 func filterOut(currentState shared.State, interfacesFilterGlob glob.Glob) (shared.State, error) {
 	var state rootState
-	err := yaml.Unmarshal(currentState.Raw, &state)
-	if err != nil {
+	if err := yaml.Unmarshal(currentState.Raw, &state); err != nil {
 		return currentState, err
 	}
 

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -331,4 +331,32 @@ interfaces:
 		})
 	})
 
+	Context("when the interfaces has numeric characters quoted", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: eth0
+- name: '0'
+- name: '1101010'
+- name: '0.0'
+- name: '1.0'
+- name: '0xfe'
+- name: '60.e+02'
+`)
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: eth0
+- name: '1101010'
+- name: '1.0'
+- name: '60.e+02'
+`)
+			interfacesFilterGlob = glob.MustCompile("0*")
+		})
+
+		It("should filter out interfaces correctly", func() {
+			returnedState, err := filterOut(state, interfacesFilterGlob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
 })

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -372,8 +372,7 @@ interfaces:
 			filteredState = nmstate.NewState(`
 interfaces:
 - name: eth0
-- name: "1000"
-- name: "6000"
+- name: "60e+02"
 `)
 			interfacesFilterGlob = glob.MustCompile("10e*")
 		})

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -359,4 +359,29 @@ interfaces:
 			Expect(returnedState).To(MatchYAML(filteredState))
 		})
 	})
+
+	// See https://github.com/yaml/pyyaml/issues/173 for why this scenario is checked.
+	Context("when the interfaces names have numbers in scientific notation without dot", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: eth0
+- name: 10e+02
+- name: 60e+02
+`)
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: eth0
+- name: "1000"
+- name: "6000"
+`)
+			interfacesFilterGlob = glob.MustCompile("10e*")
+		})
+
+		It("does not filter out interfaces correctly and does not represent them correctly", func() {
+			returnedState, err := filterOut(state, interfacesFilterGlob)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
 })

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -1,11 +1,47 @@
 package state
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
 type rootState struct {
-	Interfaces []interface{} `json:"interfaces"`
-	Routes     *routesState  `json:"routes,omitempty"`
+	Interfaces []interfaceState `json:"interfaces"`
+	Routes     *routesState     `json:"routes,omitempty"`
 }
 
 type routesState struct {
 	Config  []interface{} `json:"config"`
 	Running []interface{} `json:"running"`
+}
+
+type interfaceState struct {
+	interfaceFields
+	Data map[string]interface{}
+}
+
+// interfaceFields allows unmarshaling directly into the defined fields
+type interfaceFields struct {
+	Name string `json:"name"`
+}
+
+func (i interfaceState) MarshalJSON() (output []byte, err error) {
+	i.Data["name"] = i.Name
+	return json.Marshal(i.Data)
+}
+
+func (i *interfaceState) UnmarshalJSON(b []byte) error {
+	if err := yaml.Unmarshal(b, &i.Data); err != nil {
+		return fmt.Errorf("failed Unmarshaling b: %w", err)
+	}
+
+	var ifaceFields interfaceFields
+	if err := yaml.Unmarshal(b, &ifaceFields); err != nil {
+		return fmt.Errorf("failed Unmarshaling raw: %w", err)
+	}
+	i.Data["name"] = ifaceFields.Name
+	i.Name = ifaceFields.Name
+	return nil
 }

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -3,28 +3,27 @@ package state
 import (
 	"encoding/json"
 	"fmt"
-
 	"sigs.k8s.io/yaml"
 )
 
 type rootState struct {
-	Interfaces []interfaceState `json:"interfaces"`
-	Routes     *routesState     `json:"routes,omitempty"`
+	Interfaces []interfaceState `json:"interfaces" yaml:"interfaces"`
+	Routes     *routesState     `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 type routesState struct {
-	Config  []interface{} `json:"config"`
-	Running []interface{} `json:"running"`
+	Config  []interface{} `json:"config" yaml:"config"`
+	Running []interface{} `json:"running" yaml:"running"`
 }
 
 type interfaceState struct {
-	interfaceFields
-	Data map[string]interface{}
+	interfaceFields `yaml:",inline"`
+	Data            map[string]interface{}
 }
 
 // interfaceFields allows unmarshaling directly into the defined fields
 type interfaceFields struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 func (i interfaceState) MarshalJSON() (output []byte, err error) {
@@ -42,6 +41,6 @@ func (i *interfaceState) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("failed Unmarshaling raw: %w", err)
 	}
 	i.Data["name"] = ifaceFields.Name
-	i.Name = ifaceFields.Name
+	i.interfaceFields = ifaceFields
 	return nil
 }

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -1,0 +1,11 @@
+package state
+
+type rootState struct {
+	Interfaces []interface{} `json:"interfaces"`
+	Routes     *routesState  `json:"routes,omitempty"`
+}
+
+type routesState struct {
+	Config  []interface{} `json:"config"`
+	Running []interface{} `json:"running"`
+}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
In scenarios where an interface has only numeric characters, the
application panics with a failure to extract a string type from a Go
interface (which is actually a float64).

In order to fix the problem, the parsing of the interface name is performed
using a dedicated interface-state structure.

In addition, the representation of special numeric values that an interface name can have is also fixed, such that `0xfe` can be correctly represented back and not shown as an integer (`254`).

---

In order to support this, a type structure that represents the basic state root items has been used.
This structure includes:
- interfaces
- routes:
  - config
  - running

In order to keep the generic nature of these items content,
they use as value a generic Go interface{}.

**Special notes for your reviewer**:

**Release note**:
```release-note
Support interface names with numeric values (e.g. 123, 1.0, 0xfe).
```
