### PR TITLE
Bug 1906198: Accept any name for the nmstate resource

### DIFF
--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -52,12 +52,12 @@ var _ = Describe("NMState operator", func() {
 			Expect(err).ToNot(HaveOccurred(), "List daemon sets in namespace nmstate succeeds")
 			Expect(ds.Items).To(HaveLen(1), "and has only one item")
 		})
-		Context("and the CR is created with a wrong name", func() {
+		Context("and another CR is created with a different name", func() {
 			var nmstate = defaultNMState
-			nmstate.Name = "wrong-name"
+			nmstate.Name = "different-name"
 			BeforeEach(func() {
 				err := testenv.Client.Create(context.TODO(), &nmstate)
-				Expect(err).ToNot(HaveOccurred(), "NMState CR with incorrect name is created without error")
+				Expect(err).ToNot(HaveOccurred(), "NMState CR with different name is ignored")
 			})
 			AfterEach(func() {
 				err := testenv.Client.Delete(context.TODO(), &nmstate, &client.DeleteOptions{})


### PR DESCRIPTION
Currently, the operator will only reconcile an nmstate resource that
has a name 'nmstate'. This patch makes it possible to add the resource
as any name, but subsequent resources added will be ignored.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The NMStates.nmstate.io resource can now be any name, not just 'nmstate'. The operator will only allow one resource. All others will be ignored.
```
