### PR TITLE
Check nns timestamp depend on currnetState

### DIFF
--- a/test/e2e/handler/nodes_test.go
+++ b/test/e2e/handler/nodes_test.go
@@ -27,28 +27,19 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("and new interface is configured", func() {
-			var (
-				expectedDummyName = "dummy0"
-			)
+			expectedDummyName := "dummy0"
+
 			BeforeEach(func() {
-				createDummyAtNodes(expectedDummyName)
+				createDummyConnectionAtNodes(expectedDummyName)
 			})
 			AfterEach(func() {
-				deleteConnectionAtNodes(expectedDummyName)
-				By("Make sure the dummy interface gets deleted")
-				for _, node := range nodes {
-					for _, iface := range interfacesNameForNode(node) {
-						if iface == expectedDummyName {
-							deleteDeviceAtNode(node, expectedDummyName)
-						}
-					}
-				}
+				deleteConnectionAndWait(nodes, expectedDummyName)
 			})
 			It("[test_id:3794]should update node network state with it", func() {
 				for _, nodeName := range nodes {
 					Eventually(func() []string {
 						return interfacesNameForNode(nodeName)
-					}, node.NetworkStateRefresh, time.Second).Should(ContainElement(expectedDummyName))
+					}, 2*node.NetworkStateRefresh, time.Second).Should(ContainElement(expectedDummyName))
 				}
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement


Closes https://github.com/nmstate/kubernetes-nmstate/issues/670

**What this PR does / why we need it**:
The NNS timestamp e2e tests that check the update timestamp is not
changed if no NNCP is applied is failing since node network
configuration changes sometimes without manual intervention. This change
check if update timestamp is different if current state has change and
if is the same if current state has not changed.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
