### PR TITLE
Move cert-manager execution to a new pod

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -56,6 +56,75 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+          ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+          volumeMounts:
+          - name: tls-key-pair
+            readOnly: true
+            mountPath: /tmp/k8s-webhook-server/serving-certs/
+      volumes:
+        - name: tls-key-pair
+          secret:
+            secretName: {{template "handlerPrefix" .}}nmstate-webhook
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-cert-manager
+  namespace: {{ .HandlerNamespace }}
+  labels:
+    app: kubernetes-nmstate
+    component: kubernetes-nmstate-cert-manager
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: {{template "handlerPrefix" .}}nmstate-cert-manager
+  template:
+    metadata:
+      labels:
+        app: kubernetes-nmstate
+        component: kubernetes-nmstate-cert-manager
+        name: {{template "handlerPrefix" .}}nmstate-cert-manager
+      annotations:
+        description: kubernetes-nmstate-webhook rotate webhook certs
+    spec:
+      serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
+      nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
+      tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
+      affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
+      containers:
+        - name: nmstate-cert-manager
+          args:
+          - --v=production
+          # Replace this with the built image name
+          image: {{ .HandlerImage }}
+          imagePullPolicy: {{ .HandlerPullPolicy }}
+          command:
+          - manager
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RUN_CERT_MANAGER
+              value: ""
+            - name: OPERATOR_NAME
+              value: "{{template "handlerPrefix" .}}nmstate"
+            - name: ENABLE_PROFILER
+              value: "False"
+            - name: PROFILER_PORT
+              value: "6060"
             - name: CA_ROTATE_INTERVAL
               value: {{ .CARotateInterval | default "8760h0m0s" }}
             - name: CA_OVERLAP_INTERVAL
@@ -64,28 +133,6 @@ spec:
               value: {{ .CertRotateInterval | default "4380h0m0s" }}
             - name: CERT_OVERLAP_INTERVAL
               value: {{ .CertOverlapInterval | default "24h0m0s" }}
-          ports:
-          - containerPort: 8443
-            name: webhook-server
-            protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: webhook-server
-              scheme: HTTPS
-              httpHeaders:
-              - name: Content-Type
-                value: application/json
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          volumeMounts:
-          - name: tls-key-pair
-            readOnly: true
-            mountPath: /etc/webhook/certs
-      volumes:
-        - name: tls-key-pair
-          secret:
-            secretName: {{template "handlerPrefix" .}}nmstate-webhook
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -187,7 +234,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - port: 443
-      targetPort: 8443
+      targetPort: 9443
   selector:
     name: {{template "handlerPrefix" .}}nmstate-webhook
 ---
@@ -261,13 +308,3 @@ spec:
   selector:
     matchLabels:
       name: {{template "handlerPrefix" .}}nmstate-webhook
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{template "handlerPrefix" .}}nmstate-webhook
-  namespace: {{ .HandlerNamespace }}
-type: kubernetes.io/tls
-data:
-  tls.crt: YmFkIGNlcnRpZmljYXRlCg==
-  tls.key: YmFkIGtleQo=

--- a/main.go
+++ b/main.go
@@ -93,6 +93,9 @@ func main() {
 	if environment.IsWebhook() {
 		ctrlOptions.LeaderElection = true
 		ctrlOptions.LeaderElectionID = "5d2e944a.nmstate.io"
+	} else if environment.IsCertManager() {
+		ctrlOptions.LeaderElection = true
+		ctrlOptions.LeaderElectionID = "5d2e944b.nmstate.io"
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrlOptions)
@@ -101,39 +104,51 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Runs only webhook controllers if it's specified
-	if environment.IsWebhook() {
-
-		webhookOpts := certificate.Options{
+	if environment.IsCertManager() {
+		certManagerOpts := certificate.Options{
 			Namespace:   os.Getenv("POD_NAMESPACE"),
 			WebhookName: "nmstate",
 			WebhookType: certificate.MutatingWebhook,
 		}
 
-		webhookOpts.CARotateInterval, err = environment.LookupAsDuration("CA_ROTATE_INTERVAL")
+		certManagerOpts.CARotateInterval, err = environment.LookupAsDuration("CA_ROTATE_INTERVAL")
 		if err != nil {
 			setupLog.Error(err, "Failed retrieving ca rotate interval")
 			os.Exit(1)
 		}
 
-		webhookOpts.CAOverlapInterval, err = environment.LookupAsDuration("CA_OVERLAP_INTERVAL")
+		certManagerOpts.CAOverlapInterval, err = environment.LookupAsDuration("CA_OVERLAP_INTERVAL")
 		if err != nil {
 			setupLog.Error(err, "Failed retrieving ca overlap interval")
 			os.Exit(1)
 		}
 
-		webhookOpts.CertRotateInterval, err = environment.LookupAsDuration("CERT_ROTATE_INTERVAL")
+		certManagerOpts.CertRotateInterval, err = environment.LookupAsDuration("CERT_ROTATE_INTERVAL")
 		if err != nil {
 			setupLog.Error(err, "Failed retrieving cert rotate interval")
 			os.Exit(1)
 		}
-		webhookOpts.CertOverlapInterval, err = environment.LookupAsDuration("CERT_OVERLAP_INTERVAL")
+
+		certManagerOpts.CertOverlapInterval, err = environment.LookupAsDuration("CERT_OVERLAP_INTERVAL")
 		if err != nil {
 			setupLog.Error(err, "Failed retrieving cert overlap interval")
 			os.Exit(1)
 		}
 
-		if err := webhook.AddToManager(mgr, webhookOpts); err != nil {
+		certManager, err := certificate.NewManager(mgr.GetClient(), certManagerOpts)
+		if err != nil {
+			setupLog.Error(err, "unable to create cert-manager", "controller", "cert-manager")
+			os.Exit(1)
+		}
+
+		err = certManager.Add(mgr)
+		if err != nil {
+			setupLog.Error(err, "unable to add cert-manager to controller-runtime manager", "controller", "cert-manager")
+			os.Exit(1)
+		}
+		// Runs only webhook controllers if it's specified
+	} else if environment.IsWebhook() {
+		if err := webhook.AddToManager(mgr); err != nil {
 			setupLog.Error(err, "Cannot initialize webhook")
 			os.Exit(1)
 		}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -15,13 +15,19 @@ func IsOperator() bool {
 
 // IsWebhook returns true when RUN_WEBHOOK_SERVER env var is present
 func IsWebhook() bool {
-	_, runOperator := os.LookupEnv("RUN_WEBHOOK_SERVER")
-	return runOperator
+	_, runWebhook := os.LookupEnv("RUN_WEBHOOK_SERVER")
+	return runWebhook
+}
+
+// IsCertManager return true when RUN_CERT_MANAGER env var is present
+func IsCertManager() bool {
+	_, runCertManager := os.LookupEnv("RUN_CERT_MANAGER")
+	return runCertManager
 }
 
 // IsHandler returns true if it's not the operator or webhook server
 func IsHandler() bool {
-	return !IsWebhook() && !IsOperator()
+	return !IsWebhook() && !IsOperator() && !IsCertManager()
 }
 
 // Returns node name runnig the pod

--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -2,19 +2,14 @@ package nodenetworkconfigurationpolicy
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/pkg/errors"
-
-	"github.com/qinqon/kube-admission-webhook/pkg/certificate"
-	webhookserver "github.com/qinqon/kube-admission-webhook/pkg/webhook/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 const (
 	webhookName = "nmstate"
 )
 
-func Add(mgr manager.Manager, o certificate.Options) error {
-
+func Add(mgr manager.Manager) error {
 	// We need two hooks, the update of nncp and nncp/status (it's a subresource) happends
 	// at different times, also if you modify status at nncp webhook it does not modify it
 	// you need at nncp/status webhook that will catch that and do the final modifications.
@@ -22,20 +17,10 @@ func Add(mgr manager.Manager, o certificate.Options) error {
 	// 1.- User changes nncp desiredState so it triggers deleteConditionsHook()
 	// 2.- Since we have delete the condition the status-mutate webhook get called and
 	//     there we set conditions to Unknown this final result will be updated.
-	server, err := webhookserver.New(mgr.GetClient(), o,
-		webhookserver.WithHook("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook()),
-		webhookserver.WithHook("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook()),
-		webhookserver.WithHook("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook()),
-		webhookserver.WithHook("/nodenetworkconfigurationpolicies-progress-validate", validatePolicyUpdateHook(mgr.GetClient())),
-	)
-	if err != nil {
-		return errors.Wrap(err, "failed creating new webhook server")
-	}
-	return server.Add(mgr)
-}
-
-// add adds a new Webhook to mgr with r as the webhook.Server
-func add(mgr manager.Manager, s manager.Runnable) error {
-	mgr.Add(s)
-	return nil
+	server := &webhook.Server{}
+	server.Register("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook())
+	server.Register("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook())
+	server.Register("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook())
+	server.Register("/nodenetworkconfigurationpolicies-progress-validate", validatePolicyUpdateHook(mgr.GetClient()))
+	return mgr.Add(server)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,18 +1,16 @@
 package webhook
 
 import (
-	"github.com/qinqon/kube-admission-webhook/pkg/certificate"
-
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(m manager.Manager, o certificate.Options) error
+var AddToManagerFuncs []func(m manager.Manager) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, o certificate.Options) error {
+func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, o); err != nil {
+		if err := f(m); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Currectly the cert-manager from kube-admission-webhook is running
whithing the webhook server itself, this means that we need to create a
placeholder secret and also a very specific readiness probe has to be
used to ensure that secret is properly rotated at start up. This change
introduces a new pod runing the cert-manager code so we don't need to
create the placeholder secret (the webhook pod will not start until the
secret is not created) and we don't need a readiness probess since
secret will be correct form the beginning.

Also start up is faster since webhook pods start at the very moment the
secret is created by cert-manager pod.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Move cert-manager code to a cert-manager pod 
```
