### PR TITLE
Add execute permission to test_logs directory

### DIFF
--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -141,7 +141,7 @@ func (r *KubernetesNMStateReporter) logPods(testName string, sinceTime time.Time
 }
 
 func (r *KubernetesNMStateReporter) OpenTestLogFile(logType string, testName string, cb func(f io.Writer), extraWriters ...io.Writer) {
-	err := os.MkdirAll(r.artifactsDir, 0644)
+	err := os.MkdirAll(r.artifactsDir, 0755)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
test_logs directory is created without x permissions
so it's not possible to cd into it.

This also causes second run of e2e handler tests to fail
on permissions if any testcase failed in the first run.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Fixed test_log directory permissions

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
