### PR TITLE
Fix maxUnavailable nodes calculation from percentages to only consider matching nodes

### DIFF
--- a/pkg/enactment/enactment.go
+++ b/pkg/enactment/enactment.go
@@ -1,0 +1,22 @@
+package enactment
+
+import (
+	"context"
+
+	nmstateapi "github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CountByPolicy(cli client.Client, policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) (enactmentconditions.ConditionCount, error) {
+	enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
+	policyLabelFilter := client.MatchingLabels{nmstateapi.EnactmentPolicyLabel: policy.GetName()}
+	err := cli.List(context.TODO(), &enactments, policyLabelFilter)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting enactment list failed")
+	}
+	enactmentCount := enactmentconditions.Count(enactments, policy.Generation)
+	return enactmentCount, nil
+}

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -2,11 +2,18 @@ package node
 
 import (
 	"context"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/pkg/enactment"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pkg/errors"
+)
+
+const (
+	DEFAULT_MAXUNAVAILABLE = "50%"
 )
 
 func NodesRunningNmstate(cli client.Client) ([]corev1.Node, error) {
@@ -33,4 +40,28 @@ func NodesRunningNmstate(cli client.Client) ([]corev1.Node, error) {
 		}
 	}
 	return filteredNodes, nil
+}
+
+func MaxUnavailableNodeCount(cli client.Client, policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) (int, error) {
+	enactmentsCount, err := enactment.CountByPolicy(cli, policy)
+	if err != nil {
+		return 0, err
+	}
+	intOrPercent := intstr.FromString(DEFAULT_MAXUNAVAILABLE)
+	if policy.Spec.MaxUnavailable != nil {
+		intOrPercent = *policy.Spec.MaxUnavailable
+	}
+	maxUnavailable, err := ScaledMaxUnavailableNodeCount(enactmentsCount.Matching(), intOrPercent)
+	return maxUnavailable, nil
+}
+
+func ScaledMaxUnavailableNodeCount(matchingNodes int, intOrPercent intstr.IntOrString) (int, error) {
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&intOrPercent, matchingNodes, true)
+	if err != nil {
+		return 0, err
+	}
+	if maxUnavailable < 1 {
+		maxUnavailable = 1
+	}
+	return maxUnavailable, nil
 }

--- a/test/e2e/handler/upgrade_test.go
+++ b/test/e2e/handler/upgrade_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("NodeNetworkConfigurationPolicy upgrade", func() {
 	Context("when v1alpha1 is populated", func() {
 		BeforeEach(func() {
-			maxUnavailableIntOrString := intstr.FromInt(maxUnavailable)
+			maxUnavailableIntOrString := intstr.FromString(maxUnavailable)
 			policy := nmstatev1alpha1.NodeNetworkConfigurationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: TestPolicy,

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -37,7 +37,7 @@ const TestPolicy = "test-policy"
 var (
 	bridgeCounter  = 0
 	bondConunter   = 0
-	maxUnavailable = environment.GetIntVarWithDefault("NMSTATE_MAX_UNAVAILABLE", 1)
+	maxUnavailable = environment.GetVarWithDefault("NMSTATE_MAX_UNAVAILABLE", nmstatenode.DEFAULT_MAXUNAVAILABLE)
 )
 
 func interfacesName(interfaces []interface{}) []string {
@@ -70,7 +70,7 @@ func setDesiredStateWithPolicyAndNodeSelector(name string, desiredState nmstate.
 	err := testenv.Client.Get(context.TODO(), key, &policy)
 	policy.Spec.DesiredState = desiredState
 	policy.Spec.NodeSelector = nodeSelector
-	maxUnavailableIntOrString := intstr.FromInt(maxUnavailable)
+	maxUnavailableIntOrString := intstr.FromString(maxUnavailable)
 	policy.Spec.MaxUnavailable = &maxUnavailableIntOrString
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"os"
-	"strconv"
 )
 
 func GetVarWithDefault(name string, defaultValue string) string {
@@ -11,13 +10,4 @@ func GetVarWithDefault(name string, defaultValue string) string {
 		value = defaultValue
 	}
 	return value
-}
-
-func GetIntVarWithDefault(name string, defaultValue int) int {
-	value := os.Getenv(name)
-	intValue, err := strconv.Atoi(value)
-	if err != nil {
-		intValue = defaultValue
-	}
-	return intValue
 }


### PR DESCRIPTION
Change how maxUnavailable node cound is computed from percentages
In the original commit that introduced maxUnavailable field, the number of nodes
that can run in parallel is computed from the entire cluster node count, when percentage
value is specified. This commit changes that to use only label matching nodes.

So if a nodeSelector is specified that selects half of cluster nodes, then specifying 50% maxUnavailable
will only allow half of the nodes that have the matching label to run in parallel.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
maxUnavailable node count is calculated from mathing nodes only when percentage is specified
```
