### PR TITLE
Add readiness probe to handler

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -216,6 +216,14 @@ spec:
               mountPath: /var/k8s_nmstate
           securityContext:
             privileged: true
+          readinessProbe:
+            exec:
+              command:
+              - nmstatectl
+              - show
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
       volumes:
         - name: dbus-socket
           hostPath:


### PR DESCRIPTION


Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
If kubernetes-nmstate is deployed at a cluster with not compatible nodes
(like NetworkManager not started, bad version or not installed) the
kubernetes-nmstate-handler start without issue. This change add a
readiness probe that runs "nmstatectl show" to check if nmstatectl is
functional at a basic level.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Added readiness probe running nmstatectl show to handler
```
