### PR TITLE
Refactor nncp controller

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -288,17 +288,6 @@ func (r *NodeNetworkConfigurationPolicyReconciler) waitEnactmentCreated(enactmen
 	return pollErr
 }
 
-func (r *NodeNetworkConfigurationPolicyReconciler) enactmentsCountByPolicy(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) (enactmentconditions.ConditionCount, error) {
-	enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
-	policyLabelFilter := client.MatchingLabels{nmstateapi.EnactmentPolicyLabel: policy.GetName()}
-	err := r.Client.List(context.TODO(), &enactments, policyLabelFilter)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting enactment list failed")
-	}
-	enactmentCount := enactmentconditions.Count(enactments, policy.Generation)
-	return enactmentCount, nil
-}
-
 func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) error {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
 	err := r.Client.Get(context.TODO(), policyKey, policy)


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
The first thing that reader is presumably interested in when opening
nodenetworkconfigurationpolicy_controller.go file is the Reconcile loop.
In this PR, I'm moving the Reconcile loop to the top of the file,
and reordering the helper functions so that the reader can see the
details in the same order in which these helper functions are called in Reconcile.

Additionally, an unused method `enactmentsCountByPolicy` is removed.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
