### PR TITLE
Fix order of logging calls in handler startup code

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,8 +192,8 @@ func main() {
 		// Check that nmstatectl is working
 		_, err := nmstatectl.Show()
 		if err != nil {
-			os.Exit(1)
 			setupLog.Error(err, "failed checking nmstatectl health")
+			os.Exit(1)
 		}
 
 		// Handler runs with host networking so opening ports is problematic
@@ -204,8 +204,8 @@ func main() {
 		setupLog.Info("Marking handler as healthy touching healthy file", "healthyFile", healthyFile)
 		err = file.Touch(healthyFile)
 		if err != nil {
-			os.Exit(1)
 			setupLog.Error(err, "failed marking handler as healthy")
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
The previous order of these calls resulted in the container exiting
before the log message was output, which made it impossible to debug
what went wrong. This just changes the order so the message is logged
and then the process exits.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix logging so the handler process won't exit silently in some error situations.
```
