### PR TITLE
Consolidate error messages

### DIFF
--- a/api/shared/condition_types.go
+++ b/api/shared/condition_types.go
@@ -14,6 +14,7 @@ type Condition struct {
 	Status             corev1.ConditionStatus `json:"status"`
 	Reason             ConditionReason        `json:"reason,omitempty"`
 	Message            string                 `json:"message,omitempty"`
+	MessageEncoded     string                 `json:"messageEncoded,omitempty"`
 	LastHeartbeatTime  metav1.Time            `json:"lastHearbeatTime,omitempty"`
 	LastTransitionTime metav1.Time            `json:"lastTransitionTime,omitempty"`
 }

--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -189,11 +189,8 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	enactmentConditions.NotifyProgressing()
 	nmstateOutput, err := nmstate.ApplyDesiredState(r.APIClient, instance.Spec.DesiredState)
 	if err != nil {
-		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s, %v", nmstateOutput, err)
-		encodedMessage, _ := encodeMessage(err.Error())
-		strippedErrmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s,\n %s \n %s", nmstateOutput, formatErrorString(err), encodedMessage)
-
-		enactmentConditions.NotifyFailedToConfigure(strippedErrmsg)
+		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s,\n %v", nmstateOutput, err)
+		enactmentConditions.NotifyFailedToConfigure(errmsg)
 		log.Error(errmsg, fmt.Sprintf("Rolling back network configuration, manual intervention needed: %s", nmstateOutput))
 		return ctrl.Result{}, nil
 	}

--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -190,8 +190,10 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	nmstateOutput, err := nmstate.ApplyDesiredState(r.APIClient, instance.Spec.DesiredState)
 	if err != nil {
 		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s, %v", nmstateOutput, err)
+		encodedMessage, _ := encodeMessage(err.Error())
+		strippedErrmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s,\n %s \n %s", nmstateOutput, formatErrorString(err), encodedMessage)
 
-		enactmentConditions.NotifyFailedToConfigure(errmsg)
+		enactmentConditions.NotifyFailedToConfigure(strippedErrmsg)
 		log.Error(errmsg, fmt.Sprintf("Rolling back network configuration, manual intervention needed: %s", nmstateOutput))
 		return ctrl.Result{}, nil
 	}

--- a/deploy/crds/nmstate.io_nmstates.yaml
+++ b/deploy/crds/nmstate.io_nmstates.yaml
@@ -61,6 +61,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
@@ -56,6 +56,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -120,6 +122,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -79,6 +79,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -160,6 +162,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/deploy/crds/nmstate.io_nodenetworkstates.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkstates.yaml
@@ -50,6 +50,8 @@ spec:
                       type: string
                     message:
                       type: string
+                    messageEncoded:
+                      type: string
                     reason:
                       type: string
                     status:
@@ -107,6 +109,8 @@ spec:
                       format: date-time
                       type: string
                     message:
+                      type: string
+                    messageEncoded:
                       type: string
                     reason:
                       type: string

--- a/pkg/enactmentstatus/conditions/conditions.go
+++ b/pkg/enactmentstatus/conditions/conditions.go
@@ -2,7 +2,6 @@ package conditions
 
 import (
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/go-logr/logr"
@@ -100,7 +99,14 @@ func (ec *EnactmentConditions) updateEnactmentConditions(
 }
 
 func SetFailedToConfigure(conditions *nmstate.ConditionList, message string) {
-	SetFailed(conditions, nmstate.NodeNetworkConfigurationEnactmentConditionFailedToConfigure, message)
+	strippedMessage := enactmentstatus.FormatErrorString(message)
+	SetFailed(conditions, nmstate.NodeNetworkConfigurationEnactmentConditionFailedToConfigure, strippedMessage)
+	setFailedToConfigureEncodedMessage(conditions, message)
+}
+
+func setFailedToConfigureEncodedMessage(conditions *nmstate.ConditionList, message string) {
+	condition := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing)
+	condition.MessageEncoded = enactmentstatus.CompressAndEncodeMessage(message)
 }
 
 func SetFailed(conditions *nmstate.ConditionList, reason nmstate.ConditionReason, message string) {

--- a/pkg/enactmentstatus/enactmentstatus_suite_test.go
+++ b/pkg/enactmentstatus/enactmentstatus_suite_test.go
@@ -1,0 +1,16 @@
+package enactmentstatus
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.enactmentstatus-enactmentstatus_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Enactment Status Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/enactmentstatus/message.go
+++ b/pkg/enactmentstatus/message.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enactmentstatus
+
+import (
+	"regexp"
+	"strings"
+)
+
+// The function strips disarranged parts of the error messages, so it is easier to read for the user
+func FormatErrorString(errorMessage string) string {
+	var sb strings.Builder
+	errorLines := strings.Split(errorMessage, "\n")
+	index := 0
+	if strings.Contains(errorLines[0], "error reconciling NodeNetworkConfigurationPolicy") {
+		sb.WriteString(errorLines[0] + "\n")
+		index++
+	}
+
+	re := regexp.MustCompile(`\s*(failed to execute.*'exit status \d+') '{2}\s'`)
+	matches := re.FindStringSubmatch(errorLines[index])
+	if len(matches) == 2 {
+		sb.WriteString(strings.TrimRight(matches[1], " ") + "\n")
+		index++
+	}
+	index = skipLines(errorLines, index)
+
+	formatLines(index, errorLines, &sb)
+
+	return sb.String()
+}
+
+//Loops over all lines in error message and selects lines that should be kept
+func formatLines(index int, errorLines []string, sb *strings.Builder) {
+	for index < len(errorLines) {
+		formatLine(&errorLines[index], sb)
+		index++
+		index = skipLines(errorLines, index)
+	}
+}
+
+//Simplifies a line that should be kept in the error message
+func formatLine(errorLine *string, sb *strings.Builder) {
+	lineSplitByColon := strings.Split(strings.TrimRight(*errorLine, " "), ": ")
+	indent := ""
+	for _, lineSection := range lineSplitByColon {
+		sb.WriteString(indent + lineSection + "\n")
+		indent = indent + "  "
+	}
+}
+
+func skipLines(lines []string, index int) int {
+	if index >= len(lines) {
+		return index
+	}
+
+	regexMatchFileTrace := `\A\s*File "\S*",\sline\s\d*,\sin`
+	regexTraceback := `\A\s*Traceback\s\(most\srecent\scall\slast\):`
+	regexWithDateTime := `\A\s*\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}`
+	regexCurrentState := `.*->\scurrentState:\s---`
+	regexUnhandledMessage := `\AUnhandled\s.*\sfor\s`
+	regexKeywords := `DEBUG|WARNING|UserWarning:|warnings\.warn\(`
+
+	trimmedLine := strings.Trim(lines[index], ": ")
+
+	if lineEmpty(trimmedLine) {
+		index++
+		return skipLines(lines, index)
+	}
+	if matched, _ := regexp.MatchString(regexTraceback, lines[index]); matched == true {
+		index++
+		isTraceback, _ := regexp.MatchString(regexMatchFileTrace, lines[index])
+		for isTraceback {
+			index += 2
+			isTraceback, _ = regexp.MatchString(regexMatchFileTrace, lines[index])
+		}
+		return skipLines(lines, index)
+	}
+	if matched, _ := regexp.MatchString(regexWithDateTime, lines[index]); matched == true {
+		index++
+		return skipLines(lines, index)
+	}
+	if matched, _ := regexp.MatchString(regexUnhandledMessage, lines[index]); matched == true {
+		index++
+		return skipLines(lines, index)
+	}
+	if matched, _ := regexp.MatchString(regexKeywords, lines[index]); matched == true {
+		index++
+		return skipLines(lines, index)
+	}
+	if matched, _ := regexp.MatchString(regexCurrentState, lines[index]); matched == true {
+		index = len(lines) - 1
+		return skipLines(lines, index)
+	}
+
+	return index
+}
+
+func lineEmpty(trimmedLine string) bool {
+	return trimmedLine == "" || trimmedLine == "'"
+}

--- a/pkg/enactmentstatus/message_test.go
+++ b/pkg/enactmentstatus/message_test.go
@@ -1,0 +1,75 @@
+package enactmentstatus
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Error messages formatting", func() {
+	var (
+		debugInvalidInput      = "      2021-04-15 08:17:35,057 root         DEBUG    Async action: Create checkpoint started\n      2021-04-15 08:17:35,060 root         DEBUG    Checkpoint None created for all devices\n"
+		debugValidInput        = "A message containing debug that should not be removed.\n"
+		tracebackInvalidInput  = "      Traceback (most recent call last):\n        File \"/usr/bin/nmstatectl\", line 11, in <module>\n          load_entry_point('nmstate==0.3.6', 'console_scripts', 'nmstatectl')()\n      File \"/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py\", line 69, in main\n     f\"Interface {iface.name} has unknown slave: \"\n      libnmstate.error.NmstateValueError: Interface bond1 has unknown slave: eth10\n      "
+		tracebackInvalidOutput = "      libnmstate.error.NmstateValueError\n  Interface bond1 has unknown slave\n    eth10\n"
+		tracebackValidInput    = "A message containing File \"/usr/bin/nmstatectl\" that should not be removed.\n"
+		failedToExecuteInput   = " failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' '' '2021-02-22 11:10:08,962 root         WARNING  libnm version 1.26.7 mismatches NetworkManager version 1.29.9\n"
+		failedToExecuteOutput  = "failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1'\n"
+		pingInvalidInput       = "rolling back desired state configuration: failed runnig probes after network changes: failed runnig probe 'ping' with after network reconfiguration -> currentState: ---\n      dns-resolver:\n      config:\n          search: []\n          server: []\n        running: {}\n      route-rules:\n        config: []\n      : failed to retrieve default gw at runProbes: timed out waiting for the condition"
+		pingInvalidOutput      = "      \n  failed to retrieve default gw at runProbes\n    timed out waiting for the condition\n"
+		pingValidInput         = "rolling back desired state configuration: failed runnig probes after network changes: failed runnig probe 'ping' with after network reconfiguration.\nThe rest of the message should be kept.\n"
+		pingValidOutput        = "rolling back desired state configuration\n  failed runnig probes after network changes\n    failed runnig probe 'ping' with after network reconfiguration.\nThe rest of the message should be kept.\n"
+	)
+
+	Context("With DEBUG text", func() {
+		It("Should remove DEBUG message", func() {
+			Expect(FormatErrorString(debugInvalidInput)).To(Equal(""))
+		})
+		It("Should keep message with debug keyword", func() {
+			Expect(FormatErrorString(debugValidInput)).To(Equal(debugValidInput))
+		})
+	})
+
+	Context("With Traceback text", func() {
+		It("Should remove python traceback", func() {
+			Expect(FormatErrorString(tracebackInvalidInput)).To(Equal(tracebackInvalidOutput))
+		})
+		It("Should keep message with File keyword", func() {
+			Expect(FormatErrorString(tracebackValidInput)).To(Equal(tracebackValidInput))
+		})
+	})
+
+	Context("With failed to execute text", func() {
+		It("Should remove warning form the line", func() {
+			Expect(FormatErrorString(failedToExecuteInput)).To(Equal(failedToExecuteOutput))
+		})
+	})
+
+	Context("With network reconfiguration text", func() {
+		It("Should remove yaml", func() {
+			Expect(FormatErrorString(pingInvalidInput)).To(Equal(pingInvalidOutput))
+		})
+		It("Should keep message", func() {
+			Expect(FormatErrorString(pingValidInput)).To(Equal(pingValidOutput))
+		})
+	})
+
+	Describe("Error messages compression and decompression", func() {
+		var (
+			messages = []string{
+				"A message containing debug that should not be removed.\n",
+				"      libnmstate.error.NmstateValueError\n  Interface bond1 has unknown slave\n    eth10\n",
+				"A message containing File \"/usr/bin/nmstatectl\" that should not be removed.\n",
+				"failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1'\n",
+				"      \n  failed to retrieve default gw at runProbes\n    timed out waiting for the condition\n",
+			}
+		)
+		Context("With a sample message", func() {
+			It("Should decompress the message correctly", func() {
+				for _, message := range messages {
+					encodedMessage := CompressAndEncodeMessage(message)
+					Expect(message).To(Equal(DecodeAndDecompressMessage(encodedMessage)))
+				}
+			})
+		})
+	})
+})

--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func createInterfaceWithMismatchedName() nmstate.State {
+	return nmstate.NewState(`interfaces:
+  - name: eth666
+    type: ethernet
+    state: up`)
+}
+
+func createInterfaceWithInvalidField() nmstate.State {
+	return nmstate.NewState(`interfaces:
+  - name: eth0
+    type: ethernet
+    invalid_state: up`)
+}
+
+func createInterfaceWithIncorrectIP() nmstate.State {
+	return nmstate.NewState(`interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.45.33"
+        prefix-length: 24
+      dhcp: false
+      enabled: true`)
+}
+
+func createPolicyAndWaitForEnactmentCondition(policy string, desiredState func() nmstate.State, nodeHostname string) {
+	By("Creating the policy")
+	err := setDesiredStateWithPolicyAndNodeSelector(policy, desiredState(), map[string]string{"kubernetes.io/hostname": nodeHostname})
+	if err != nil {
+		return
+	}
+
+	By("Waiting until the node becomes ready again")
+	waitForNodesReady()
+
+	By("Waiting for enactment to be failing")
+	enactmentConditionsStatusEventually(nodes[0]).Should(matchConditionsFrom(enactmentconditions.SetFailedToConfigure))
+}
+
+var _ = Describe("NodeNetworkState", func() {
+	var (
+		defaultPolicy = "test-policy"
+
+		messagesToRemove = []string{
+			"DEBUG    Async action: Create checkpoint started",
+			"DEBUG    Checkpoint None created for all devices",
+			"Traceback (most recent call last):",
+			"DEBUG    Nispor: current network state",
+			"WARNING  libnm version",
+			"rolling back desired state configuration: failed running probes after network changes: ",
+			"failed running probe 'ping' with after network reconfiguration -> currentState:",
+			"warnings.warn",
+		}
+	)
+
+	Context("with invalid field", func() {
+		var (
+			messagesToKeep = []string{
+				"libnmstate.error.NmstateVerificationError",
+				"desired",
+				"current",
+				"difference",
+			}
+		)
+
+		BeforeEach(func() {
+			createPolicyAndWaitForEnactmentCondition(defaultPolicy, createInterfaceWithInvalidField, nodes[0])
+		})
+
+		It("should discard disarranged parts of the message", func() {
+			for _, unwantedMessage := range messagesToRemove {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).NotTo(ContainSubstring(unwantedMessage))
+			}
+		})
+
+		It("should keep desired parts of the message", func() {
+			for _, desiredMessage := range messagesToKeep {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).To(ContainSubstring(desiredMessage))
+			}
+		})
+	})
+
+	Context("with mismatched interface name", func() {
+		var (
+			messagesToKeep = []string{
+				"libnmstate.error.NmstateLibnmError",
+				"No suitable device found for this connection",
+				"mismatching interface name",
+			}
+		)
+
+		BeforeEach(func() {
+			createPolicyAndWaitForEnactmentCondition(defaultPolicy, createInterfaceWithMismatchedName, nodes[0])
+		})
+
+		It("should discard disarranged parts of the message", func() {
+			for _, unwantedMessage := range messagesToRemove {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).NotTo(ContainSubstring(unwantedMessage))
+			}
+		})
+
+		It("should keep desired parts of the message", func() {
+			for _, desiredMessage := range messagesToKeep {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).To(ContainSubstring(desiredMessage))
+			}
+		})
+	})
+
+	Context("with ping fail", func() {
+		var (
+			messagesToKeep = []string{
+				"failed to retrieve default gw at runProbes",
+			}
+		)
+
+		BeforeEach(func() {
+			createPolicyAndWaitForEnactmentCondition(defaultPolicy, createInterfaceWithIncorrectIP, nodes[0])
+		})
+
+		AfterEach(func() {
+			resetDesiredStateForNodes()
+			By("Remove the policy")
+			deletePolicy("test-policy")
+		})
+
+		It("should discard disarranged parts of the message", func() {
+
+			for _, unwantedMessage := range messagesToRemove {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).NotTo(ContainSubstring(unwantedMessage))
+			}
+		})
+
+		It("should keep desired parts of the message", func() {
+			for _, desiredMessage := range messagesToKeep {
+				Expect(enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message).To(ContainSubstring(desiredMessage))
+			}
+		})
+	})
+})


### PR DESCRIPTION
Makes the error output prettier by removing
unnecessary parts, e.g. traceback, full yaml and
fixes special character escaping issue in errors.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

Makes the error output of NNCE error message
prettier by removing unnecessary parts, e.g. traceback,
 full yaml, and ixes special character escaping issue in errors.

**Output samples:**

_Example 1_

**Original**
```
message: |-
      error reconciling NodeNetworkConfigurationPolicy at desired state apply: ,
       failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' '' '2021-04-15 08:17:35,030 root         WARNING  libnm version 1.26.7 mismatches NetworkManager version 1.29.9
      2021-04-15 08:17:35,057 root         DEBUG    Async action: Create checkpoint started
      2021-04-15 08:17:35,060 root         DEBUG    Checkpoint None created for all devices
      2021-04-15 08:17:35,060 root         DEBUG    Async action: Create checkpoint finished
      2021-04-15 08:17:35,061 root         DEBUG    Async action: Add profile: eth666 started
      2021-04-15 08:17:35,065 root         DEBUG    Async action: Add profile: eth666 finished
      2021-04-15 08:17:35,065 root         DEBUG    Async action: Activate profile: eth666 started
      2021-04-15 08:17:35,066 root         DEBUG    Action Activate profile: eth666 failed, trying again.
      2021-04-15 08:17:35,067 root         DEBUG    Async action: Rollback to checkpoint /org/freedesktop/NetworkManager/Checkpoint/2 started
      2021-04-15 08:17:35,069 root         DEBUG    Checkpoint /org/freedesktop/NetworkManager/Checkpoint/2 rollback executed
      2021-04-15 08:17:35,069 root         DEBUG    Interface lo rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface calic82870b62e9 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface eth0 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface cali661fbd931aa rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface cali7d7f8e3e762 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface eth2 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface cali770b5dc9800 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface docker0 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface cali3a2807641ac rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface tunl0 rollback succeeded
      2021-04-15 08:17:35,069 root         DEBUG    Interface cali8ffbc7dfd36 rollback succeeded
      2021-04-15 08:17:35,070 root         DEBUG    Interface eth1 rollback succeeded
      2021-04-15 08:17:35,070 root         DEBUG    Interface cali9e8a4e2983a rollback succeeded
      2021-04-15 08:17:35,070 root         DEBUG    Interface cali074cadeaf8a rollback succeeded
      2021-04-15 08:17:35,070 root         DEBUG    Async action: Rollback to checkpoint /org/freedesktop/NetworkManager/Checkpoint/2 finished
      Traceback (most recent call last):
        File "/usr/bin/nmstatectl", line 11, in <module>
          load_entry_point('nmstate==0.3.7', 'console_scripts', 'nmstatectl')()
        File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 69, in main
          return args.func(args)
        File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 279, in apply
          args.save_to_disk,
        File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 308, in apply_state
          save_to_disk=save_to_disk,
        File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 73, in apply
          _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk)
        File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 106, in _apply_ifaces_state
          plugin.apply_changes(net_state, save_to_disk)
        File "/usr/lib/python3.6/site-packages/libnmstate/nm/plugin.py", line 174, in apply_changes
          nm_applier.apply_changes(self.context, net_state, save_to_disk)
        File "/usr/lib/python3.6/site-packages/libnmstate/nm/applier.py", line 183, in apply_changes
          _set_ifaces_admin_state(context, ifaces_desired_state, con_profiles)
        File "/usr/lib/python3.6/site-packages/libnmstate/nm/applier.py", line 354, in _set_ifaces_admin_state
          context.wait_all_finish()
        File "/usr/lib/python3.6/site-packages/libnmstate/nm/context.py", line 215, in wait_all_finish
          raise tmp_error
      libnmstate.error.NmstateLibnmError: Activate profile: eth666 failed: error=nm-manager-error-quark: No suitable device found for this connection (device eth0 not available because profile is not compatible with device (mismatching interface name)). (3)
      '
```

**Current (python traceback, debug and warning removed)**
```
    message: |
      error reconciling NodeNetworkConfigurationPolicy at desired state apply: ,
       failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1'
      libnmstate.error.NmstateLibnmError
        Activate profile: eth666 failed
          error=nm-manager-error-quark
            No suitable device found for this connection (device eth0 not available because profile is not compatible with device (mismatching interface name)). (3)
```



_Example 2_

**Original**
```
error reconciling NodeNetworkConfigurationPolicy at desired state apply:
      ,\n failed to execute nmstatectl set --no-commit --timeout 480: 'exit status
      1' '' '2021-04-15 08:14:08,025 root         WARNING  libnm version 1.26.7 mismatches
      NetworkManager version 1.29.9\n2021-04-15 08:14:08,052 root         DEBUG    Async
      action: Create checkpoint started\n2021-04-15 08:14:08,059 root         DEBUG
      \   Checkpoint None created for all devices\n2021-04-15 08:14:08,059 root         DEBUG
      \   Async action: Create checkpoint finished\n2021-04-15 08:14:08,060 root         DEBUG
      \   Async action: Add profile: eth1 started\n2021-04-15 08:14:08,064 root         DEBUG
      \   Async action: Add profile: eth1 finished\n2021-04-15 08:14:08,065 root         DEBUG
      \   Async action: Activate profile: eth1 started\n2021-04-15 08:14:08,067 root
      \        DEBUG    Connection activation initiated: dev=eth1, con-state=<enum
      NM_ACTIVE_CONNECTION_STATE_ACTIVATING of type NM.ActiveConnectionState>\n2021-04-15
      08:14:08,082 root         DEBUG    Connection activation succeeded: dev=eth1,
      con-state=<enum NM_ACTIVE_CONNECTION_STATE_ACTIVATED of type NM.ActiveConnectionState>,
      dev-state=<enum NM_DEVICE_STATE_ACTIVATED of type NM.DeviceState>, state-flags=<flags
      NM_ACTIVATION_STATE_FLAG_LAYER2_READY | NM_ACTIVATION_STATE_FLAG_IP4_READY |
      NM_ACTIVATION_STATE_FLAG_IP6_READY of type NM.ActivationStateFlags>\n2021-04-15
      08:14:08,082 root         DEBUG    Async action: Activate profile: eth1 finished\n2021-04-15
      08:14:28,774 root         DEBUG    Async action: Rollback to checkpoint /org/freedesktop/NetworkManager/Checkpoint/1
      started\n2021-04-15 08:14:28,779 root         DEBUG    Checkpoint /org/freedesktop/NetworkManager/Checkpoint/1
      rollback executed\n2021-04-15 08:14:28,780 root         DEBUG    Interface cali661fbd931aa
      rollback succeeded\n2021-04-15 08:14:28,780 root         DEBUG    Interface
      cali7d7f8e3e762 rollback succeeded\n2021-04-15 08:14:28,780 root         DEBUG
      \   Interface cali3a2807641ac rollback succeeded\n2021-04-15 08:14:28,780 root
      \        DEBUG    Interface cali074cadeaf8a rollback succeeded\n2021-04-15 08:14:28,780
      root         DEBUG    Interface cali9e8a4e2983a rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface docker0 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface eth2 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface cali8ffbc7dfd36 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface cali770b5dc9800 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface tunl0 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface eth1 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface eth0 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface lo rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Interface calic82870b62e9 rollback succeeded\n2021-04-15
      08:14:28,780 root         DEBUG    Async action: Rollback to checkpoint /org/freedesktop/NetworkManager/Checkpoint/1
      finished\nTraceback (most recent call last):\n  File \"/usr/bin/nmstatectl\",
      line 11, in <module>\n    load_entry_point('nmstate==0.3.7', 'console_scripts',
      'nmstatectl')()\n  File \"/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py\",
      line 69, in main\n    return args.func(args)\n  File \"/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py\",
      line 279, in apply\n    args.save_to_disk,\n  File \"/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py\",
      line 308, in apply_state\n    save_to_disk=save_to_disk,\n  File \"/usr/lib/python3.6/site-packages/libnmstate/netapplier.py\",
      line 73, in apply\n    _apply_ifaces_state(plugins, net_state, verify_change,
      save_to_disk)\n  File \"/usr/lib/python3.6/site-packages/libnmstate/netapplier.py\",
      line 123, in _apply_ifaces_state\n    _verify_change(plugins, net_state)\n  File
      \"/usr/lib/python3.6/site-packages/libnmstate/netapplier.py\", line 136, in
      _verify_change\n    net_state.verify(current_state)\n  File \"/usr/lib/python3.6/site-packages/libnmstate/net_state.py\",
      line 63, in verify\n    self._ifaces.verify(current_state.get(Interface.KEY))\n
      \ File \"/usr/lib/python3.6/site-packages/libnmstate/ifaces/ifaces.py\", line
      446, in verify\n    cur_iface.state_for_verify(),\nlibnmstate.error.NmstateVerificationError:
      \ndesired\n=======\n---\nname: eth1\ntype: ethernet\nstate: up\nstasdte: up\n\ncurrent\n=======\n---\nname:
      eth1\ntype: ethernet\nstate: up\nethernet:\n  auto-negotiation: false\nipv4:\n
      \ enabled: false\nipv6:\n  enabled: false\nlldp:\n  enabled: false\nmac-address:
      52:55:00:D1:56:00\nmtu: 1500\n\ndifference\n==========\n--- desired\n+++ current\n@@
      -2,4 +2,13 @@\n name: eth1\n type: ethernet\n state: up\n-stasdte: up\n+ethernet:\n+
      \ auto-negotiation: false\n+ipv4:\n+  enabled: false\n+ipv6:\n+  enabled: false\n+lldp:\n+
      \ enabled: false\n+mac-address: 52:55:00:D1:56:00\n+mtu: 1500\n\n\n
```

**Current (python traceback, DEBUG, WARNING messages removed, fixed formatting)**
```
message: |
      error reconciling NodeNetworkConfigurationPolicy at desired state apply: ,
       failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1'
      libnmstate.error.NmstateVerificationError:
      desired
      =======
      ---
      name: eth1
      type: ethernet
      state: up
      stasdte: up
      current
      =======
      ---
      name: eth1
      type: ethernet
      state: up
      ethernet:
      auto-negotiation: false
      ipv4:
      enabled: false
      ipv6:
      enabled: false
      lldp:
      enabled: false
      mac-address: 52:55:00:D1:56:00
      mtu: 1500
      difference
      ==========
      --- desired
      +++ current
      @@ -2,4 +2,13 @@
      name: eth1
      type: ethernet
      state: up
      -stasdte: up
      +ethernet:
      +  auto-negotiation: false
      +ipv4:
      +  enabled: false
      +ipv6:
      +  enabled: false
      +lldp:
      +  enabled: false
      +mac-address: 52:55:00:D1:56:00
      +mtu: 1500
```



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
