### PR TITLE
Don't create unmatched enactments

### DIFF
--- a/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/api/shared/nodenetworkconfigurationenactment_types.go
@@ -24,7 +24,6 @@ const (
 	NodeNetworkConfigurationEnactmentConditionAvailable   ConditionType = "Available"
 	NodeNetworkConfigurationEnactmentConditionFailing     ConditionType = "Failing"
 	NodeNetworkConfigurationEnactmentConditionProgressing ConditionType = "Progressing"
-	NodeNetworkConfigurationEnactmentConditionMatching    ConditionType = "Matching"
 	NodeNetworkConfigurationEnactmentConditionAborted     ConditionType = "Aborted"
 )
 
@@ -32,17 +31,14 @@ var NodeNetworkConfigurationEnactmentConditionTypes = [...]ConditionType{
 	NodeNetworkConfigurationEnactmentConditionAvailable,
 	NodeNetworkConfigurationEnactmentConditionFailing,
 	NodeNetworkConfigurationEnactmentConditionProgressing,
-	NodeNetworkConfigurationEnactmentConditionMatching,
 	NodeNetworkConfigurationEnactmentConditionAborted,
 }
 
 const (
-	NodeNetworkConfigurationEnactmentConditionFailedToConfigure                ConditionReason = "FailedToConfigure"
-	NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured           ConditionReason = "SuccessfullyConfigured"
-	NodeNetworkConfigurationEnactmentConditionConfigurationProgressing         ConditionReason = "ConfigurationProgressing"
-	NodeNetworkConfigurationEnactmentConditionNodeSelectorNotMatching          ConditionReason = "NodeSelectorNotMatching"
-	NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching ConditionReason = "AllSelectorsMatching"
-	NodeNetworkConfigurationEnactmentConditionConfigurationAborted             ConditionReason = "ConfigurationAborted"
+	NodeNetworkConfigurationEnactmentConditionFailedToConfigure        ConditionReason = "FailedToConfigure"
+	NodeNetworkConfigurationEnactmentConditionSuccessfullyConfigured   ConditionReason = "SuccessfullyConfigured"
+	NodeNetworkConfigurationEnactmentConditionConfigurationProgressing ConditionReason = "ConfigurationProgressing"
+	NodeNetworkConfigurationEnactmentConditionConfigurationAborted     ConditionReason = "ConfigurationAborted"
 )
 
 func EnactmentKey(node string, policy string) types.NamespacedName {

--- a/pkg/enactment/enactment.go
+++ b/pkg/enactment/enactment.go
@@ -10,13 +10,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CountByPolicy(cli client.Client, policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) (enactmentconditions.ConditionCount, error) {
+func CountByPolicy(cli client.Client, policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) (int, enactmentconditions.ConditionCount, error) {
 	enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
 	policyLabelFilter := client.MatchingLabels{nmstateapi.EnactmentPolicyLabel: policy.GetName()}
 	err := cli.List(context.TODO(), &enactments, policyLabelFilter)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting enactment list failed")
+		return 0, nil, errors.Wrap(err, "getting enactment list failed")
 	}
 	enactmentCount := enactmentconditions.Count(enactments, policy.Generation)
-	return enactmentCount, nil
+	return len(enactments.Items), enactmentCount, nil
 }

--- a/pkg/enactmentstatus/conditions/conditions.go
+++ b/pkg/enactmentstatus/conditions/conditions.go
@@ -33,26 +33,9 @@ func New(client client.Client, enactmentKey types.NamespacedName) EnactmentCondi
 func (ec *EnactmentConditions) NotifyNodeSelectorFailure(err error) {
 	ec.logger.Info("NotifyNodeSelectorFailure")
 	message := fmt.Sprintf("failure checking node selectors : %v", err)
-	err = ec.updateEnactmentConditions(SetNodeSelectorNotMatching, message)
+	err = ec.updateEnactmentConditions(SetFailedToConfigure, message)
 	if err != nil {
 		ec.logger.Error(err, "Error notifying state NodeSelectorNotMatching with failure")
-	}
-}
-
-func (ec *EnactmentConditions) NotifyNodeSelectorNotMatching(unmatchingLabels map[string]string) {
-	ec.logger.Info("NotifyNodeSelectorNotMatching")
-	message := fmt.Sprintf("Unmatching labels: %v", unmatchingLabels)
-	err := ec.updateEnactmentConditions(SetNodeSelectorNotMatching, message)
-	if err != nil {
-		ec.logger.Error(err, "Error notifying state NodeSelectorNotMatching")
-	}
-}
-
-func (ec *EnactmentConditions) NotifyMatching() {
-	ec.logger.Info("NotifyMatching")
-	err := ec.updateEnactmentConditions(SetMatching, "All policy selectors are matching the node")
-	if err != nil {
-		ec.logger.Error(err, "Error notifying state Matching")
 	}
 }
 
@@ -220,76 +203,6 @@ func SetProgressing(conditions *nmstate.ConditionList, message string) {
 		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
 		corev1.ConditionFalse,
 		nmstate.NodeNetworkConfigurationEnactmentConditionConfigurationProgressing,
-		"",
-	)
-}
-
-func SetNodeSelectorNotMatching(conditions *nmstate.ConditionList, message string) {
-	SetNotMatching(conditions, nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorNotMatching, message)
-}
-
-func SetNotMatching(conditions *nmstate.ConditionList, reason nmstate.ConditionReason, message string) {
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionFailing,
-		corev1.ConditionFalse,
-		reason,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionAvailable,
-		corev1.ConditionFalse,
-		reason,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionProgressing,
-		corev1.ConditionFalse,
-		reason,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
-		corev1.ConditionFalse,
-		reason,
-		message,
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
-		corev1.ConditionFalse,
-		reason,
-		"",
-	)
-}
-
-func SetMatching(conditions *nmstate.ConditionList, message string) {
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionFailing,
-		corev1.ConditionUnknown,
-		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionAvailable,
-		corev1.ConditionUnknown,
-		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionProgressing,
-		corev1.ConditionUnknown,
-		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
-		"",
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
-		corev1.ConditionTrue,
-		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
-		message,
-	)
-	conditions.Set(
-		nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
-		corev1.ConditionUnknown,
-		nmstate.NodeNetworkConfigurationEnactmentConditionNodeSelectorAllSelectorsMatching,
 		"",
 	)
 }

--- a/pkg/enactmentstatus/conditions/counter.go
+++ b/pkg/enactmentstatus/conditions/counter.go
@@ -43,9 +43,6 @@ func (c ConditionCount) progressing() CountByConditionStatus {
 func (c ConditionCount) available() CountByConditionStatus {
 	return c[nmstate.NodeNetworkConfigurationEnactmentConditionAvailable]
 }
-func (c ConditionCount) matching() CountByConditionStatus {
-	return c[nmstate.NodeNetworkConfigurationEnactmentConditionMatching]
-}
 func (c ConditionCount) aborted() CountByConditionStatus {
 	return c[nmstate.NodeNetworkConfigurationEnactmentConditionAborted]
 }
@@ -80,12 +77,6 @@ func (c ConditionCount) Available() int {
 func (c ConditionCount) NotAvailable() int {
 	return c.available().false()
 }
-func (c ConditionCount) Matching() int {
-	return c.matching().true()
-}
-func (c ConditionCount) NotMatching() int {
-	return c.matching().false()
-}
 func (c ConditionCount) Aborted() int {
 	return c.aborted().true()
 }
@@ -94,7 +85,7 @@ func (c ConditionCount) NotAborted() int {
 }
 
 func (c ConditionCount) String() string {
-	return fmt.Sprintf("{failed: %s, progressing: %s, available: %s, matching: %s, aborted: %s}", c.failed(), c.progressing(), c.available(), c.matching(), c.aborted())
+	return fmt.Sprintf("{failed: %s, progressing: %s, available: %s, aborted: %s}", c.failed(), c.progressing(), c.available(), c.aborted())
 }
 
 func (c CountByConditionStatus) String() string {

--- a/pkg/enactmentstatus/conditions/counter_test.go
+++ b/pkg/enactmentstatus/conditions/counter_test.go
@@ -15,7 +15,6 @@ const (
 	failing     = nmstate.NodeNetworkConfigurationEnactmentConditionFailing
 	available   = nmstate.NodeNetworkConfigurationEnactmentConditionAvailable
 	progressing = nmstate.NodeNetworkConfigurationEnactmentConditionProgressing
-	matching    = nmstate.NodeNetworkConfigurationEnactmentConditionMatching
 	aborted     = nmstate.NodeNetworkConfigurationEnactmentConditionAborted
 	t           = corev1.ConditionTrue
 	f           = corev1.ConditionFalse
@@ -63,203 +62,136 @@ var _ = Describe("Enactment condition counter", func() {
 				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
 				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
 				progressing: CountByConditionStatus{t: 0, f: 0, u: 2},
-				matching:    CountByConditionStatus{t: 0, f: 0, u: 2},
 				aborted:     CountByConditionStatus{t: 0, f: 0, u: 2},
 			},
 		}),
-		Entry("e(NotMatching), e(NotMatching)", EnactmentCounterCase{
+		Entry("e(Failed), e(Progressing)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetNodeSelectorNotMatching),
-				enactment(1, SetNodeSelectorNotMatching),
-			),
-			expectedCount: ConditionCount{
-				available:   CountByConditionStatus{t: 0, f: 2, u: 0},
-				failing:     CountByConditionStatus{t: 0, f: 2, u: 0},
-				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
-				matching:    CountByConditionStatus{t: 0, f: 2, u: 0},
-				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
-			},
-		}),
-		Entry("e(NotMatching), e(Matching, Progressing)", EnactmentCounterCase{
-			policyGeneration: 1,
-			enactmentsToCount: enactments(
-				enactment(1, SetNodeSelectorNotMatching),
-				enactment(1, SetMatching, SetProgressing),
-			),
-			expectedCount: ConditionCount{
-				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
-				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
-				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
-				matching:    CountByConditionStatus{t: 1, f: 1, u: 0},
-				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
-			},
-		}),
-		Entry("e(Matching, Failed), e(Matching, Progressing)", EnactmentCounterCase{
-			policyGeneration: 1,
-			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetFailedToConfigure),
-				enactment(1, SetMatching, SetProgressing),
+				enactment(1, SetFailedToConfigure),
+				enactment(1, SetProgressing),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
 				failing:     CountByConditionStatus{t: 1, f: 0, u: 1},
 				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
 			},
 		}),
-		Entry("e(Matching, Success), e(Matching, Progressing)", EnactmentCounterCase{
+		Entry("e(Success), e(Progressing)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetSuccess),
-				enactment(1, SetMatching, SetProgressing),
+				enactment(1, SetSuccess),
+				enactment(1, SetProgressing),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 1, f: 0, u: 1},
 				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
 				progressing: CountByConditionStatus{t: 1, f: 1, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
 			},
 		}),
-		Entry("e(Matching, Progressing), e(Matching, Progressing)", EnactmentCounterCase{
+		Entry("e(Progressing), e(Progressing)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetProgressing),
-				enactment(1, SetMatching, SetProgressing),
+				enactment(1, SetProgressing),
+				enactment(1, SetProgressing),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
 				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
 				progressing: CountByConditionStatus{t: 2, f: 0, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
 			},
 		}),
-		Entry("e(Matching, Success), e(Matching, Success)", EnactmentCounterCase{
+		Entry("e(Success), e(Success)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetSuccess),
-				enactment(1, SetMatching, SetSuccess),
+				enactment(1, SetSuccess),
+				enactment(1, SetSuccess),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 2, f: 0, u: 0},
 				failing:     CountByConditionStatus{t: 0, f: 2, u: 0},
 				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
 			},
 		}),
-		Entry("e(Matching, Failed), e(Matching, Failed)", EnactmentCounterCase{
+		Entry("e(Failed), e(Failed)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetFailedToConfigure),
-				enactment(1, SetMatching, SetFailedToConfigure),
+				enactment(1, SetFailedToConfigure),
+				enactment(1, SetFailedToConfigure),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 2, u: 0},
 				failing:     CountByConditionStatus{t: 2, f: 0, u: 0},
 				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 0, f: 2, u: 0},
 			},
 		}),
-		Entry("e(Matching, Failed), e(Matching, Aborted)", EnactmentCounterCase{
+		Entry("e(Failed), e(Aborted)", EnactmentCounterCase{
 			policyGeneration: 1,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetFailedToConfigure),
-				enactment(1, SetMatching, SetConfigurationAborted),
+				enactment(1, SetFailedToConfigure),
+				enactment(1, SetConfigurationAborted),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 2, u: 0},
 				failing:     CountByConditionStatus{t: 1, f: 1, u: 0},
 				progressing: CountByConditionStatus{t: 0, f: 2, u: 0},
-				matching:    CountByConditionStatus{t: 2, f: 0, u: 0},
 				aborted:     CountByConditionStatus{t: 1, f: 1, u: 0},
 			},
 		}),
-		Entry("p(2), e(1,NotMatching), e(2,NotMatching)", EnactmentCounterCase{
+		Entry("p(2), e(1,Progressing), e(2,Progressing)", EnactmentCounterCase{
 			policyGeneration: 2,
 			enactmentsToCount: enactments(
-				enactment(1, SetNodeSelectorNotMatching),
-				enactment(2, SetNodeSelectorNotMatching),
-			),
-			expectedCount: ConditionCount{
-				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
-				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
-				progressing: CountByConditionStatus{t: 0, f: 1, u: 1},
-				matching:    CountByConditionStatus{t: 0, f: 1, u: 1},
-				aborted:     CountByConditionStatus{t: 0, f: 1, u: 1},
-			},
-		}),
-		Entry("p(2), e(1,Matching), e(2,Matching)", EnactmentCounterCase{
-			policyGeneration: 2,
-			enactmentsToCount: enactments(
-				enactment(1, SetMatching),
-				enactment(2, SetMatching),
-			),
-			expectedCount: ConditionCount{
-				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
-				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
-				progressing: CountByConditionStatus{t: 0, f: 0, u: 2},
-				matching:    CountByConditionStatus{t: 1, f: 0, u: 1},
-				aborted:     CountByConditionStatus{t: 0, f: 0, u: 2},
-			},
-		}),
-		Entry("p(2), e(1,Matching,Progressing), e(2,Matching,Progressing)", EnactmentCounterCase{
-			policyGeneration: 2,
-			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetProgressing),
-				enactment(2, SetMatching, SetProgressing),
+				enactment(1, SetProgressing),
+				enactment(2, SetProgressing),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 0, u: 2},
 				failing:     CountByConditionStatus{t: 0, f: 0, u: 2},
 				progressing: CountByConditionStatus{t: 1, f: 0, u: 1},
-				matching:    CountByConditionStatus{t: 1, f: 0, u: 1},
 				aborted:     CountByConditionStatus{t: 0, f: 1, u: 1},
 			},
 		}),
-		Entry("p(2), e(1,Matching,Success), e(2,Matching,Success)", EnactmentCounterCase{
+		Entry("p(2), e(1,Success), e(2,Success)", EnactmentCounterCase{
 			policyGeneration: 2,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetSuccess),
-				enactment(2, SetMatching, SetSuccess),
+				enactment(1, SetSuccess),
+				enactment(2, SetSuccess),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 1, f: 0, u: 1},
 				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
 				progressing: CountByConditionStatus{t: 0, f: 1, u: 1},
-				matching:    CountByConditionStatus{t: 1, f: 0, u: 1},
 				aborted:     CountByConditionStatus{t: 0, f: 1, u: 1},
 			},
 		}),
-		Entry("p(2), e(1,Matching,Failed), e(2,Matching,Failed)", EnactmentCounterCase{
+		Entry("p(2), e(1,Failed), e(2,Failed)", EnactmentCounterCase{
 			policyGeneration: 2,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetFailedToConfigure),
-				enactment(2, SetMatching, SetFailedToConfigure),
+				enactment(1, SetFailedToConfigure),
+				enactment(2, SetFailedToConfigure),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
 				failing:     CountByConditionStatus{t: 1, f: 0, u: 1},
 				progressing: CountByConditionStatus{t: 0, f: 1, u: 1},
-				matching:    CountByConditionStatus{t: 1, f: 0, u: 1},
 				aborted:     CountByConditionStatus{t: 0, f: 1, u: 1},
 			},
 		}),
-		Entry("p(2), e(1,Matching,Failed), e(2,Matching,Aborted)", EnactmentCounterCase{
+		Entry("p(2), e(1,Failed), e(2,Aborted)", EnactmentCounterCase{
 			policyGeneration: 2,
 			enactmentsToCount: enactments(
-				enactment(1, SetMatching, SetFailedToConfigure),
-				enactment(2, SetMatching, SetConfigurationAborted),
+				enactment(1, SetFailedToConfigure),
+				enactment(2, SetConfigurationAborted),
 			),
 			expectedCount: ConditionCount{
 				available:   CountByConditionStatus{t: 0, f: 1, u: 1},
 				failing:     CountByConditionStatus{t: 0, f: 1, u: 1},
 				progressing: CountByConditionStatus{t: 0, f: 1, u: 1},
-				matching:    CountByConditionStatus{t: 1, f: 0, u: 1},
 				aborted:     CountByConditionStatus{t: 1, f: 0, u: 1},
 			},
 		}),

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -106,35 +106,36 @@ func Update(cli client.Client, policyKey types.NamespacedName) error {
 			return errors.Wrap(err, "getting enactments failed")
 		}
 
-		// Count only nodes that runs nmstate handler, could be that
-		// users don't want to run knmstate at master for example so
-		// they don't want to change net config there.
-		nmstateNodes, err := node.NodesRunningNmstate(cli)
+		// Count only nodes that runs nmstate handler and match the policy
+		// nodeSelector, could be that users don't want to run knmstate at master for example
+		// so they don't want to change net config there.
+		nmstateMatchingNodes, err := node.NodesRunningNmstate(cli, policy.Spec.NodeSelector)
 		if err != nil {
 			return errors.Wrap(err, "getting nodes running kubernets-nmstate pods failed")
 		}
-		numberOfNmstateNodes := len(nmstateNodes)
+		numberOfNmstateMatchingNodes := len(nmstateMatchingNodes)
 
 		// Let's get conditions with true status count filtered by policy generation
-		enactmentsCount := enactmentconditions.Count(enactments, policy.Generation)
+		enactmentsCountByCondition := enactmentconditions.Count(enactments, policy.Generation)
 
-		numberOfFinishedEnactments := enactmentsCount.Available() + enactmentsCount.Failed() + enactmentsCount.NotMatching() + enactmentsCount.Aborted()
+		numberOfFinishedEnactments := enactmentsCountByCondition.Available() + enactmentsCountByCondition.Failed() + enactmentsCountByCondition.Aborted()
 
-		logger.Info(fmt.Sprintf("enactments count: %s", enactmentsCount))
-		if numberOfFinishedEnactments < numberOfNmstateNodes {
-			SetPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateNodes))
+		logger.Info(fmt.Sprintf("numberOfNmstateMatchingNodes: %d, enactments count: %s", numberOfNmstateMatchingNodes, enactmentsCountByCondition))
+
+		if numberOfNmstateMatchingNodes == 0 {
+			message := "Policy does not match any node"
+			SetPolicyNotMatching(&policy.Status.Conditions, message)
+		} else if numberOfFinishedEnactments < numberOfNmstateMatchingNodes {
+			SetPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateMatchingNodes))
 		} else {
-			if enactmentsCount.Matching() == 0 {
-				message := "Policy does not match any node"
-				SetPolicyNotMatching(&policy.Status.Conditions, message)
-			} else if enactmentsCount.Failed() > 0 || enactmentsCount.Aborted() > 0 {
-				message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCount.Failed(), enactmentsCount.Matching())
-				if enactmentsCount.Aborted() > 0 {
-					message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCount.Aborted())
+			if enactmentsCountByCondition.Failed() > 0 || enactmentsCountByCondition.Aborted() > 0 {
+				message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCountByCondition.Failed(), numberOfNmstateMatchingNodes)
+				if enactmentsCountByCondition.Aborted() > 0 {
+					message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCountByCondition.Aborted())
 				}
 				SetPolicyFailedToConfigure(&policy.Status.Conditions, message)
 			} else {
-				message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCount.Available(), enactmentsCount.Available())
+				message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCountByCondition.Available(), enactmentsCountByCondition.Available())
 				SetPolicySuccess(&policy.Status.Conditions, message)
 			}
 		}

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -52,6 +52,11 @@ func p(conditionsSetter func(*nmstate.ConditionList, string), message string) nm
 	}
 }
 
+func s(nodeSelector map[string]string, policy nmstatev1beta1.NodeNetworkConfigurationPolicy) nmstatev1beta1.NodeNetworkConfigurationPolicy {
+	policy.Spec.NodeSelector = nodeSelector
+	return policy
+}
+
 func nodeName(idx int) string {
 	return fmt.Sprintf("node%d", idx)
 }
@@ -164,9 +169,9 @@ var _ = Describe("Policy Conditions", func() {
 		},
 		Entry("when all enactments are progressing then policy is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
+				e("node1", "policy1", enactmentconditions.SetProgressing),
+				e("node2", "policy1", enactmentconditions.SetProgressing),
+				e("node3", "policy1", enactmentconditions.SetProgressing),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -174,9 +179,9 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when all enactments are success then policy is success", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -184,9 +189,9 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when not all enactments are created is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
@@ -194,9 +199,9 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when enactments are progressing/success then policy is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetProgressing),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -204,10 +209,10 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when enactments are failed/progressing/success then policy is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
-				e("node4", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetProgressing),
+				e("node3", "policy1", enactmentconditions.SetFailedToConfigure),
+				e("node4", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
@@ -215,9 +220,9 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when all the enactments are at failing or success policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetFailedToConfigure),
+				e("node2", "policy1", enactmentconditions.SetFailedToConfigure),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -225,29 +230,25 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when all the enactments are at failing policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetFailedToConfigure),
+				e("node1", "policy1", enactmentconditions.SetFailedToConfigure),
+				e("node2", "policy1", enactmentconditions.SetFailedToConfigure),
+				e("node3", "policy1", enactmentconditions.SetFailedToConfigure),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
 			Policy: p(SetPolicyFailedToConfigure, "3/3 nodes failed to configure"),
 		}),
 		Entry("when no node matches policy node selector, policy state is not matching", ConditionsCase{
-			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetNodeSelectorNotMatching),
-				e("node2", "policy1", enactmentconditions.SetNodeSelectorNotMatching),
-				e("node3", "policy1", enactmentconditions.SetNodeSelectorNotMatching),
-			},
-			Nodes:  newNodes(3),
-			Pods:   newNmstatePods(3),
-			Policy: p(SetPolicyNotMatching, "Policy does not match any node"),
+			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{},
+			Nodes:      newNodes(3),
+			Pods:       newNmstatePods(3),
+			Policy:     s(map[string]string{"foo": "bar"}, p(SetPolicyNotMatching, "Policy does not match any node")),
 		}),
-		Entry("when some enacments has unknown matching state policy state is progressing", ConditionsCase{
+		Entry("when some enacments has unknown state policy state is progressing", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
 				e("node1", "policy1"),
 				e("node2", "policy1"),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -255,11 +256,11 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when some enactments are from different profile it does no affect the profile status", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node1", "policy2", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
-				e("node2", "policy2", enactmentconditions.SetMatching, enactmentconditions.SetProgressing),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
+				e("node1", "policy2", enactmentconditions.SetProgressing),
+				e("node2", "policy2", enactmentconditions.SetProgressing),
 			},
 			Nodes:  newNodes(3),
 			Pods:   newNmstatePods(3),
@@ -267,9 +268,9 @@ var _ = Describe("Policy Conditions", func() {
 		}),
 		Entry("when a node does not run nmstate pod ignore it for policy conditions calculations", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
-				e("node1", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node2", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
-				e("node3", "policy1", enactmentconditions.SetMatching, enactmentconditions.SetSuccess),
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
 			},
 			Nodes: newNodes(4),
 			Pods: []corev1.Pod{

--- a/pkg/policyconditions/policyconditions_suite_test.go
+++ b/pkg/policyconditions/policyconditions_suite_test.go
@@ -7,7 +7,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/ginkgo/reporters"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})
 
 func TestUnit(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -36,10 +36,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Status: corev1.ConditionFalse,
 		},
 		shared.Condition{
-			Type:   shared.NodeNetworkConfigurationEnactmentConditionMatching,
-			Status: corev1.ConditionTrue,
-		},
-		shared.Condition{
 			Type:   shared.NodeNetworkConfigurationEnactmentConditionAborted,
 			Status: corev1.ConditionTrue,
 		},
@@ -69,10 +65,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Status: corev1.ConditionUnknown,
 				},
 				nmstate.Condition{
-					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
-					Status: corev1.ConditionTrue,
-				},
-				nmstate.Condition{
 					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
 					Status: corev1.ConditionFalse,
 				},
@@ -89,10 +81,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				nmstate.Condition{
 					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionFailing,
 					Status: corev1.ConditionFalse,
-				},
-				nmstate.Condition{
-					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionMatching,
-					Status: corev1.ConditionTrue,
 				},
 				nmstate.Condition{
 					Type:   nmstate.NodeNetworkConfigurationEnactmentConditionAborted,
@@ -140,10 +128,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			shared.Condition{
 				Type:   shared.NodeNetworkConfigurationEnactmentConditionProgressing,
 				Status: corev1.ConditionFalse,
-			},
-			shared.Condition{
-				Type:   shared.NodeNetworkConfigurationEnactmentConditionMatching,
-				Status: corev1.ConditionTrue,
 			},
 			shared.Condition{
 				Type:   shared.NodeNetworkConfigurationEnactmentConditionAborted,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
The enactments that are not matching are created with unmatching
condition, this is a problem at big clusters whey a NNCP with a very
restrictive NodeSelector is applied since it will load the system with a
lot of NNCE saying not matching and this give you no value. This change
just skip creating NNCE if they are not matching.

**Special notes for your reviewer**:
Related to https://github.com/nmstate/kubernetes-nmstate/issues/725#issuecomment-827537190

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Don't create not matching enactments.
```
