### PR TITLE
cluster-sync, Extend eventually timeout

### DIFF
--- a/cluster/sync-common.sh
+++ b/cluster/sync-common.sh
@@ -1,5 +1,5 @@
 function eventually {
-    timeout=$(( $KUBEVIRT_NUM_NODES * 10 ))
+    timeout=$(( $KUBEVIRT_NUM_NODES * 30 ))
     interval=5
     cmd=$@
     echo "Checking eventually $cmd"


### PR DESCRIPTION
/kind bug

The first deployment after make cluster-up
might take few more seconds.
Extend the timeout a bit, so the make cluster-sync
would be more stable.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
