### PR TITLE
cluster-sync, Fix Eventually and consistently logic

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -8,11 +8,11 @@ function eventually {
     cmd=$@
     echo "Checking eventually $cmd"
     while ! $cmd; do
-        sleep $interval
-        timeout=$(( $timeout - $interval ))
         if [ $timeout -le 0 ]; then
             return 1
         fi
+        sleep $interval
+        timeout=$(( $timeout - $interval ))
     done
 }
 

--- a/cluster/sync-common.sh
+++ b/cluster/sync-common.sh
@@ -4,11 +4,11 @@ function eventually {
     cmd=$@
     echo "Checking eventually $cmd"
     while ! $cmd; do
-        sleep $interval
-        timeout=$(( $timeout - $interval ))
         if [ $timeout -le 0 ]; then
             return 1
         fi
+        sleep $interval
+        timeout=$(( $timeout - $interval ))
     done
 }
 
@@ -18,11 +18,11 @@ function consistently {
     cmd=$@
     echo "Checking consistently $cmd"
     while $cmd; do
-        sleep $interval
-        timeout=$(( $timeout - $interval ))
         if [ $timeout -le 0 ]; then
             return 0
         fi
+        sleep $interval
+        timeout=$(( $timeout - $interval ))
     done
     return 1
 }


### PR DESCRIPTION
Current logic of Eventually and consistently
would not trigger the last needed iteration,
since it compare the count to zero after sleeping.
Fix the logic, by doing the comparison in the beginning
of the loop, this way it won't sleep on the last unneeded
iteration, and will also perform that last iteration.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
