### PR TITLE
Improve documentation of maxUnavailable field

### DIFF
--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -464,15 +464,14 @@ status:
 
 ## Configuring multiple nodes concurrently
 
-By default, Policy configuration is applied sequentially, one node at a time.
-This configuration strategy is safe and prevents the entire cluster from being
+By default, Policy configuration is applied in parallel on 50% of nmstate enabled nodes.
+This configuration strategy is considered safe enough and prevents the entire cluster from being
 temporarily unavailable, if the applied configuration breaks network connectivity.
 
-For big clusters however, it may take too much time for a configuration to finish.
-In such a case, `maxUnavailable` can be used to define portion size of a cluster
-that can apply a policy configuration concurrently.
+User may change this behaviour per policy by setting `maxUnavailable` field to define
+portion size of a cluster that can apply a policy configuration in parallel.
 MaxUnavailable specifies percentage or a constant number of nodes that
-can be progressing a policy at a time. The default is "50%" of cluster nodes.
+can be applying a policy at a time.
 
 The following policy specifies that up to 3 nodes may be progressing concurrently:
 


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
The doc section about maxUnavailable gives out dated information
about default rollout behaviour.

This PR updates and improves that section.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
