### PR TITLE
Remove nmstate-config ConfigMap

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -199,10 +199,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: INTERFACES_FILTER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{template "handlerPrefix" .}}nmstate-config
-                  key: interfaces_filter
+              value: "{veth*,cali*}"
             - name: ENABLE_PROFILER
               value: "False"
             - name: PROFILER_PORT
@@ -232,14 +229,6 @@ spec:
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{template "handlerPrefix" .}}nmstate-config
-  namespace: {{ .HandlerNamespace }}
-data:
-  interfaces_filter: "{veth*,cali*}"
 ---
 apiVersion: v1
 kind: Service

--- a/docs/user-guide/101-reporting.md
+++ b/docs/user-guide/101-reporting.md
@@ -168,7 +168,7 @@ The reported state is updated every 5 seconds.
 
 By default, all `veth*` interfaces are omitted from the report in order not to
 clutter the output with all Pod connections. This filtering can be adjusted via
-`interfaces_filter` variable in kubernetes-nmstate configmap.
+environment variable `INTERFACES_FILTER`at nmstate-handler daemonset.
 
 | Filter            | Effect                                                             |
 | ---               | ---                                                                |
@@ -177,12 +177,11 @@ clutter the output with all Pod connections. This filtering can be adjusted via
 | `"{veth*,vnet*}"` | Omit all interfaces starting with either `veth` or `vnet`          |
 
 
-To override the default configuration, use `patch` command. Additionally, in
-order for the config to take effect, all handlers need to be restarted:
+To override the default configuration, use `set env` command. Additionally, in
+order for the config to take effect, all handlers will be restarted:
 
 ```json
-kubectl -n nmstate patch configmap nmstate-config --patch '{"data": {"interfaces_filter": ""}}'
-kubectl -n nmstate delete pods --all
+kubectl set env -n nmstate daemonset/nmstate-handler INTERFACES_FILTER=""
 ```
 
 The `NodeNetworkState` will now list all interfaces seen on the host.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The current way to filter interfaces from NNS is using a variable at
nmstate-config we are not propagating this to NMState CR or CNAO and
since nmstate-handler is deployed at every node it does not scale well.
This change remove the ConfigMap and keep the pod environment variable.

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove nmstate-config ConfigMap
```
