### PR TITLE
Validate NodeSelector with the same rules as label

### DIFF
--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/pkg/policyconditions"
 )
 
-func p(conditionsSetter func(*shared.ConditionList, string), message string) nmstatev1beta1.NodeNetworkConfigurationPolicy {
+func p(nodeSelector map[string]string, conditionsSetter func(*shared.ConditionList, string), message string) nmstatev1beta1.NodeNetworkConfigurationPolicy {
 	conditions := shared.ConditionList{}
 	conditionsSetter(&conditions, message)
 	return nmstatev1beta1.NodeNetworkConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testPolicy",
+		},
+		Spec: shared.NodeNetworkConfigurationPolicySpec{
+			NodeSelector: nodeSelector,
 		},
 		Status: shared.NodeNetworkConfigurationPolicyStatus{
 			Conditions: conditions,
@@ -26,6 +29,7 @@ func p(conditionsSetter func(*shared.ConditionList, string), message string) nms
 }
 
 var _ = Describe("NNCP Conditions Validation Admission Webhook", func() {
+	var allNodes = map[string]string{}
 	var testPolicy = nmstatev1beta1.NodeNetworkConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testPolicy",
@@ -45,7 +49,7 @@ var _ = Describe("NNCP Conditions Validation Admission Webhook", func() {
 	},
 		Entry("current policy in progress", ValidationWebhookCase{
 			policy:        testPolicy,
-			currentPolicy: p(policyconditions.SetPolicyProgressing, ""),
+			currentPolicy: p(allNodes, policyconditions.SetPolicyProgressing, ""),
 			validationFn:  validatePolicyNotInProgressHook,
 			validationResult: []metav1.StatusCause{
 				{
@@ -55,20 +59,52 @@ var _ = Describe("NNCP Conditions Validation Admission Webhook", func() {
 		}),
 		Entry("current policy successfully configured", ValidationWebhookCase{
 			policy:           testPolicy,
-			currentPolicy:    p(policyconditions.SetPolicySuccess, ""),
+			currentPolicy:    p(allNodes, policyconditions.SetPolicySuccess, ""),
 			validationFn:     validatePolicyNotInProgressHook,
 			validationResult: []metav1.StatusCause{},
 		}),
 		Entry("current policy not matching", ValidationWebhookCase{
 			policy:           testPolicy,
-			currentPolicy:    p(policyconditions.SetPolicyNotMatching, ""),
+			currentPolicy:    p(allNodes, policyconditions.SetPolicyNotMatching, ""),
 			validationFn:     validatePolicyNotInProgressHook,
 			validationResult: []metav1.StatusCause{},
 		}),
 		Entry("current policy failed to configure", ValidationWebhookCase{
 			policy:           testPolicy,
-			currentPolicy:    p(policyconditions.SetPolicyFailedToConfigure, ""),
+			currentPolicy:    p(allNodes, policyconditions.SetPolicyFailedToConfigure, ""),
 			validationFn:     validatePolicyNotInProgressHook,
+			validationResult: []metav1.StatusCause{},
+		}),
+		Entry("policy has invalid node selector key", ValidationWebhookCase{
+			policy:       p(map[string]string{"bad key": "bar"}, policyconditions.SetPolicySuccess, ""),
+			validationFn: validatePolicyNodeSelector,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "invalid label key: \"bad key\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')",
+				Field:   "spec.nodeSelector",
+			}},
+		}),
+		Entry("policy has node selector value with length beyond the limit", ValidationWebhookCase{
+			policy:       p(map[string]string{"kubernetes.io/hostname": "this-is-longer-than-sixty-three-characters-hostname-bar-bar-bar.foo.com"}, policyconditions.SetPolicySuccess, ""),
+			validationFn: validatePolicyNodeSelector,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "invalid label value: \"this-is-longer-than-sixty-three-characters-hostname-bar-bar-bar.foo.com\": at key: \"kubernetes.io/hostname\": must be no more than 63 characters",
+				Field:   "spec.nodeSelector",
+			}},
+		}),
+		Entry("policy has node selector value with invalid format", ValidationWebhookCase{
+			policy:       p(map[string]string{"kubernetes.io/hostname": "foo+bar"}, policyconditions.SetPolicySuccess, ""),
+			validationFn: validatePolicyNodeSelector,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "invalid label value: \"foo+bar\": at key: \"kubernetes.io/hostname\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')",
+				Field:   "spec.nodeSelector",
+			}},
+		}),
+		Entry("policy has valid node selector", ValidationWebhookCase{
+			policy:           p(map[string]string{"kubernetes.io/hostname": "node01"}, policyconditions.SetPolicySuccess, ""),
+			validationFn:     validatePolicyNodeSelector,
 			validationResult: []metav1.StatusCause{},
 		}),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement



**What this PR does / why we need it**:
When a List operation is done passing label selector the labels are
validated before execute the query, at kubernetes-nmstate the
NodeSelector field is passed as a label selector to check for the nodes
that matches, if the NodeSelector is not valid the enactments will not
be created user will not know the state of the NNCP. This change
validate the NodeSelector at the webhook to fail fast on its errors.

**Special notes for your reviewer**:

Closes https://github.com/nmstate/kubernetes-nmstate/issues/753

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Validate NodeSelector at the validation webhook.
```
