### PR TITLE
Pin NMState and NetworkManager to copr version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -b -y dnf-plugins-core && \
     dnf copr enable -y networkmanager/$NM_COPR_REPO && \
     dnf copr enable -y nmstate/$NMSTATE_COPR_REPO && \
     dnf copr enable -y nmstate/nispor && \
-    dnf install -b -y nmstate iproute iputils && \
+    dnf install -b -y $NM_COPR_REPO* $NMSTATE_COPR_REPO* iproute iputils && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
A copr is configured on the handler container to install the NN and
NMState version for the knmstate-release, but the container has now
newere versions os it's installing those instead. This change pins those
to major.minor by using the COPR name with a wildcard.

**Special notes for your reviewer**:

**Release note**:

```release-note
Pin nmstate to 0.3.z and NM to 1.26.z
```
