### PR TITLE
Relationship labels, Label self deployed resources

### DIFF
--- a/api/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/api/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/pkg/names"
 )
 
 // +kubebuilder:object:root=true
@@ -38,9 +39,7 @@ func NewEnactment(nodeName string, policy NodeNetworkConfigurationPolicy) NodeNe
 				{Name: policy.Name, Kind: policy.TypeMeta.Kind, APIVersion: policy.TypeMeta.APIVersion, UID: policy.UID},
 			},
 			// Associate policy with the enactment using labels
-			Labels: map[string]string{
-				shared.EnactmentPolicyLabel: policy.Name,
-			},
+			Labels: names.IncludeRelationshipLabels(map[string]string{shared.EnactmentPolicyLabel: policy.Name}),
 		},
 		Status: shared.NodeNetworkConfigurationEnactmentStatus{
 			DesiredState: shared.NewState(""),

--- a/api/v1beta1/nodenetworkconfigurationenactment_types.go
+++ b/api/v1beta1/nodenetworkconfigurationenactment_types.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/pkg/names"
 )
 
 // +kubebuilder:object:root=true
@@ -40,9 +41,7 @@ func NewEnactment(nodeName string, policy NodeNetworkConfigurationPolicy) NodeNe
 				{Name: policy.Name, Kind: policy.TypeMeta.Kind, APIVersion: policy.TypeMeta.APIVersion, UID: policy.UID},
 			},
 			// Associate policy with the enactment using labels
-			Labels: map[string]string{
-				shared.EnactmentPolicyLabel: policy.Name,
-			},
+			Labels: names.IncludeRelationshipLabels(map[string]string{shared.EnactmentPolicyLabel: policy.Name}),
 		},
 		Status: shared.NodeNetworkConfigurationEnactmentStatus{
 			DesiredState: shared.NewState(""),

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -192,6 +192,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: COMPONENT
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: PART_OF
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/part-of']
+            - name: VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
+            - name: MANAGED_BY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/managed-by']
             - name: OPERATOR_NAME
               value: "{{template "handlerPrefix" .}}nmstate"
             - name: NODE_NAME

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/pkg/names"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 	"github.com/nmstate/kubernetes-nmstate/pkg/probe"
 )
@@ -61,6 +62,7 @@ func InitializeNodeNetworkState(client client.Client, node *corev1.Node) (*nmsta
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            node.ObjectMeta.Name,
 			OwnerReferences: ownerRefList,
+			Labels:          names.IncludeRelationshipLabels(nil),
 		},
 	}
 

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -1,7 +1,39 @@
 package names
 
+import (
+	"os"
+)
+
 // ManifestDir is the directory where manifests are located.
 var ManifestDir = "./bindata"
 
 // NMStateResourceName is the name of the CR that the operator will reconcile
 const NMStateResourceName = "nmstate"
+
+// Relationship labels
+const COMPONENT_LABEL_KEY = "app.kubernetes.io/component"
+const PART_OF_LABEL_KEY = "app.kubernetes.io/part-of"
+const VERSION_LABEL_KEY = "app.kubernetes.io/version"
+const MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by"
+
+func IncludeRelationshipLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	mapLabelKeys := map[string]string{
+		"COMPONENT":  COMPONENT_LABEL_KEY,
+		"PART_OF":    PART_OF_LABEL_KEY,
+		"VERSION":    VERSION_LABEL_KEY,
+		"MANAGED_BY": MANAGED_BY_LABEL_KEY,
+	}
+
+	for key, label := range mapLabelKeys {
+		envVar := os.Getenv(key)
+		if envVar != "" {
+			labels[label] = envVar
+		}
+	}
+
+	return labels
+}

--- a/pkg/names/names_suite_test.go
+++ b/pkg/names/names_suite_test.go
@@ -1,0 +1,16 @@
+package names
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-names-names_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Names Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -1,0 +1,90 @@
+package names
+
+import (
+	"os"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IncludeRelationshipLabels", func() {
+	Context("When env vars don't exist", func() {
+		BeforeEach(func() {
+			os.Unsetenv("COMPONENT")
+			os.Unsetenv("PART_OF")
+			os.Unsetenv("VERSION")
+			os.Unsetenv("MANAGED_BY")
+		})
+
+		It("Should return empty map when input was nil map", func() {
+			labels := IncludeRelationshipLabels(nil)
+			Expect(labels).To(HaveLen(0))
+		})
+
+		It("Should return the same map when input was not nil", func() {
+			labelsBase := map[string]string{"foo": "bar"}
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+			Expect(reflect.DeepEqual(labelsBase, labels)).To(Equal(true))
+		})
+	})
+
+	Context("When all the env vars are not empty", func() {
+		const expectedComponentLabel = "component_unit_tests"
+		const expectedPartOfLabel = "part_of_unit_tests"
+		const expectedVersionLabel = "version_of_unit_tests"
+		const expectedManagedByLabel = "managed_by_unit_tests"
+
+		BeforeEach(func() {
+			os.Setenv("COMPONENT", expectedComponentLabel)
+			os.Setenv("PART_OF", expectedPartOfLabel)
+			os.Setenv("VERSION", expectedVersionLabel)
+			os.Setenv("MANAGED_BY", expectedManagedByLabel)
+		})
+
+		It("Should return labels with all the values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+			Expect(labels[VERSION_LABEL_KEY]).To(Equal(expectedVersionLabel))
+			Expect(labels[MANAGED_BY_LABEL_KEY]).To(Equal(expectedManagedByLabel))
+		})
+
+		It("Should update labels with the right values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar", VERSION_LABEL_KEY: "old_version"})
+
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+			Expect(labels[VERSION_LABEL_KEY]).To(Equal(expectedVersionLabel))
+			Expect(labels[MANAGED_BY_LABEL_KEY]).To(Equal(expectedManagedByLabel))
+		})
+	})
+
+	Context("When some of the env vars are not empty", func() {
+		const expectedComponentLabel = "component_unit_tests"
+		const expectedPartOfLabel = "part_of_unit_tests"
+
+		BeforeEach(func() {
+			os.Setenv("COMPONENT", expectedComponentLabel)
+			os.Setenv("PART_OF", expectedPartOfLabel)
+			os.Setenv("VERSION", "")
+			os.Unsetenv("MANAGED_BY")
+		})
+
+		It("Should return labels with the right values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+
+			_, found := labels[VERSION_LABEL_KEY]
+			Expect(found).To(Equal(false))
+
+			_, found = labels[MANAGED_BY_LABEL_KEY]
+			Expect(found).To(Equal(false))
+		})
+	})
+})


### PR DESCRIPTION
In order to have relationship (app.kubernetes.io/*)
on all deployed resources,
this commit handles the resources that are deployed by itself
such as:
1. Node Network Configuration Enactments
2. Node Network State

The labels are inherited from the pod, if exists.
The pod will have those labels if deployed by OLM / HCO,
otherwise it won't and the labels won't be added to the above
resources.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
