### PR TITLE
[release-0.43] Don't confict with nodeRunningUpdate same node (#773)

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -20,9 +20,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -171,7 +172,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) claimNodeRunningUpdate(policy
 	if err != nil {
 		return err
 	}
-	if policy.Status.NodeRunningUpdate != "" {
+	if policy.Status.NodeRunningUpdate != "" && policy.Status.NodeRunningUpdate != nodeName {
 		return apierrors.NewConflict(schema.GroupResource{Resource: "nodenetworkconfigurationpolicies"}, policy.Name, fmt.Errorf("Another node is working on configuration"))
 	}
 	policy.Status.NodeRunningUpdate = nodeName

--- a/controllers/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller_test.go
@@ -1,17 +1,26 @@
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 )
 
-var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() {
+var _ = Describe("NodeNetworkConfigurationPolicy controller", func() {
 	type predicateCase struct {
 		GenerationOld   int64
 		GenerationNew   int64
@@ -60,6 +69,64 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				GenerationNew:   2,
 				ReconcileCreate: true,
 				ReconcileUpdate: true,
+			}),
+	)
+	type claimNodeRunningUpdateCase struct {
+		currentNodeRunningUpdate  string
+		expectedNodeRunningUpdate string
+		shouldConflict            bool
+	}
+	DescribeTable("when claimNodeRunningUpdate is called and",
+		func(c claimNodeRunningUpdateCase) {
+			reconciler := NodeNetworkConfigurationPolicyReconciler{}
+			s := scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NodeNetworkConfigurationPolicy{},
+			)
+
+			nncp := nmstatev1beta1.NodeNetworkConfigurationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: shared.NodeNetworkConfigurationPolicyStatus{
+					NodeRunningUpdate: c.currentNodeRunningUpdate,
+				},
+			}
+
+			objs := []runtime.Object{&nncp}
+
+			// Create a fake client to mock API calls.
+			cl := fake.NewFakeClientWithScheme(s, objs...)
+
+			reconciler.Client = cl
+			reconciler.Log = ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationPolicy")
+
+			err := reconciler.claimNodeRunningUpdate(&nncp)
+			if c.shouldConflict {
+				Expect(err).Should(WithTransform(apierrors.IsConflict, BeTrue()), "should conflict")
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+			obtainedNNCP := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
+			cl.Get(context.TODO(), types.NamespacedName{Name: nncp.Name}, &obtainedNNCP)
+			Expect(obtainedNNCP.Status.NodeRunningUpdate).To(Equal(c.expectedNodeRunningUpdate))
+		},
+		Entry("there is no node configuring network, should update nodeRunnigUpdate field",
+			claimNodeRunningUpdateCase{
+				expectedNodeRunningUpdate: nodeName,
+				shouldConflict:            false,
+			}),
+		Entry("there is different node configuring network, should fail with conflict",
+			claimNodeRunningUpdateCase{
+				currentNodeRunningUpdate:  nodeName + "foo",
+				expectedNodeRunningUpdate: nodeName + "foo",
+				shouldConflict:            true,
+			}),
+		Entry("the node running the handler is configuring the network, should not conflict",
+			claimNodeRunningUpdateCase{
+				currentNodeRunningUpdate:  nodeName,
+				expectedNodeRunningUpdate: nodeName,
+				shouldConflict:            false,
 			}),
 	)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
When "parallel" option is false if the NNCP status field
nodeRunningUpdate is not empty it means that a node is progressing so
Reconcile return a conflict, in the case of handler restarting before
"unclaiming" the NNCP will be reconcile again and a conflict will be
return. This change fix that by not returning conflict if the handler
restarting is the one that has claim the NNCP.

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:
/hold
Depends on https://github.com/kubevirt/project-infra/pull/1322

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
