### PR TITLE
[release-0.47] Avoid incrementing NRU when NNCE

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller_test.go
@@ -1,14 +1,23 @@
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
 )
 
 var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() {
@@ -60,6 +69,106 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				GenerationNew:   2,
 				ReconcileCreate: true,
 				ReconcileUpdate: true,
+			}),
+	)
+
+	type incrementUnavailableNodeCountCase struct {
+		currentUnavailableNodeCount  int
+		expectedUnavailableNodeCount int
+		expectedReconcileError       string
+		expectedReconcileResult      ctrl.Result
+		previousEnactmentConditions  func(*shared.ConditionList, string)
+		shouldConflict               bool
+	}
+	DescribeTable("when claimNodeRunningUpdate is called and",
+		func(c incrementUnavailableNodeCountCase) {
+			reconciler := NodeNetworkConfigurationPolicyReconciler{}
+			s := scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NodeNetworkConfigurationPolicy{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactment{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactmentList{},
+			)
+
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			nncp := nmstatev1beta1.NodeNetworkConfigurationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Status: shared.NodeNetworkConfigurationPolicyStatus{
+					UnavailableNodeCount: c.currentUnavailableNodeCount,
+				},
+			}
+			nnce := nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: shared.EnactmentKey(nodeName, nncp.Name).Name,
+				},
+				Status: shared.NodeNetworkConfigurationEnactmentStatus{},
+			}
+
+			// simulate NNCE existnce/non-existence by setting conditions
+			c.previousEnactmentConditions(&nnce.Status.Conditions, "")
+
+			objs := []runtime.Object{&nncp, &nnce, &node}
+
+			// Create a fake client to mock API calls.
+			clb := fake.ClientBuilder{}
+			clb.WithScheme(s)
+			clb.WithRuntimeObjects(objs...)
+			cl := clb.Build()
+
+			reconciler.Client = cl
+			reconciler.Log = ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationPolicy")
+
+			res, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: nncp.Name},
+			})
+
+			if c.shouldConflict {
+				Expect(err.Error()).To(Equal(c.expectedReconcileError))
+			}
+			Expect(res).To(Equal(c.expectedReconcileResult))
+
+			obtainedNNCP := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
+			cl.Get(context.TODO(), types.NamespacedName{Name: nncp.Name}, &obtainedNNCP)
+			Expect(obtainedNNCP.Status.UnavailableNodeCount).To(Equal(c.expectedUnavailableNodeCount))
+		},
+		Entry("No node applying policy with empty enactment, should succeed incrementing UnavailableNodeCount",
+			incrementUnavailableNodeCountCase{
+				currentUnavailableNodeCount:  0,
+				expectedUnavailableNodeCount: 0,
+				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
+				expectedReconcileResult:      ctrl.Result{},
+				shouldConflict:               false,
+			}),
+		Entry("No node applying policy with progressing enactment, should succeed incrementing UnavailableNodeCount",
+			incrementUnavailableNodeCountCase{
+				currentUnavailableNodeCount:  0,
+				expectedUnavailableNodeCount: 0,
+				previousEnactmentConditions:  conditions.SetProgressing,
+				expectedReconcileResult:      ctrl.Result{},
+				shouldConflict:               false,
+			}),
+		Entry("One node applying policy with empty enactment, should conflict incrementing UnavailableNodeCount",
+			incrementUnavailableNodeCountCase{
+				currentUnavailableNodeCount:  1,
+				expectedUnavailableNodeCount: 1,
+				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
+				expectedReconcileResult:      ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
+				expectedReconcileError:       "Operation cannot be fulfilled on nodenetworkconfigurationpolicies \"test\": maximal number of 1 nodes are already processing policy configuration",
+				shouldConflict:               true,
+			}),
+		Entry("One node applying policy with Progressing enactment, should succeed incrementing UnavailableNodeCount",
+			incrementUnavailableNodeCountCase{
+				currentUnavailableNodeCount:  1,
+				expectedUnavailableNodeCount: 0,
+				previousEnactmentConditions:  conditions.SetProgressing,
+				expectedReconcileResult:      ctrl.Result{},
+				shouldConflict:               false,
 			}),
 	)
 })

--- a/pkg/enactmentstatus/status.go
+++ b/pkg/enactmentstatus/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -53,4 +54,12 @@ func Update(client client.Client, key types.NamespacedName, statusSetter func(*n
 			return isEqual, nil
 		})
 	})
+}
+
+func IsProgressing(conditions *nmstate.ConditionList) bool {
+	progressingCondition := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing)
+	if progressingCondition != nil && progressingCondition.Status == corev1.ConditionTrue {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
At the beginning, check if NNCE exists for a policy and is in
progressing state.

If it is, then it means that handler was killed while applying the
desired state - do not increment unavailableNodeCount in such case.

There is still a window where killing handler would cause
inconsistency - between status is set to Failed or Success and the
unavailableNodeCount is decremented.

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:
Depends on https://github.com/kubevirt/project-infra/pull/1324

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
