### PR TITLE
Control plane, Assign Priority class to pods

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -28,6 +28,7 @@ spec:
       nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
       tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
       affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
+      priorityClassName: system-cluster-critical
       containers:
         - name: nmstate-webhook
           args:
@@ -107,6 +108,7 @@ spec:
       nodeSelector: {{ toYaml .WebhookNodeSelector | nindent 8 }}
       tolerations: {{ toYaml .WebhookTolerations | nindent 8 }}
       affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
+      priorityClassName: system-cluster-critical
       containers:
         - name: nmstate-cert-manager
           args:
@@ -192,6 +194,7 @@ spec:
       nodeSelector: {{ toYaml .HandlerNodeSelector | nindent 8 }}
       tolerations: {{ toYaml .HandlerTolerations | nindent 8 }}
       affinity: {{ toYaml .HandlerAffinity | nindent 8 }}
+      priorityClassName: system-node-critical
       containers:
         - name: nmstate-handler
           args:


### PR DESCRIPTION
Add `system-node-critical` to `nmstate-handler`,
since this pod should run on each node,

Add `system-cluster-critical` to `nmstate-webhook`
and to `nmstate-cert-manager` pods,
since those pods aren't bound to a specific node,
yet those are important control plane pods.

This will make the control plane less sensitive to preemption
than user workloads.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
