### PR TITLE
manifests, Update requests sections

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -38,6 +38,10 @@ spec:
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
           - manager
+          resources:
+            requests:
+              cpu: "30m"
+              memory: "20Mi"
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -118,6 +122,10 @@ spec:
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
           - manager
+          resources:
+            requests:
+              cpu: "30m"
+              memory: "30Mi"
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -204,6 +212,10 @@ spec:
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
             - manager
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "100Mi"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
For each of the 3 nmstate pods,
supply the minimum cpu / memory requests.
Values are set according empiric tests.

See https://bugzilla.redhat.com/show_bug.cgi?id=1935218

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
