### PR TITLE
Use custom Backoff retries setting for status update

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -336,7 +336,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 func (r *NodeNetworkConfigurationPolicyReconciler) decrementUnavailableNodeCount(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
 	instance := &nmstatev1beta1.NodeNetworkConfigurationPolicy{}
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(policyconditions.StatusUpdateRetry, func() error {
 		err := r.Client.Get(context.TODO(), policyKey, instance)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Applying a policy that breaks node connectivity causes client
to return cached NNCP resource with outdated resourceVersion
until watchers reconnect again, which takes something around
half a minute.

Using outdated policy leads to conflicts at the end of Reconcile,
where the Policy status is recalculated.

This commit adds custom StatusUpdateRetry Backoff that increases
number of attempts and factor to allow watchers to reconnect.

This custom StatusUpdateRetry is used in functions, that are called
after the policy desiredState was applied (and potentionally broke the
node) - decrementUnavailableNodeCount and policyconditions.Update
functions.

**Special notes for your reviewer**:
Fixes #785

**Release note**:

```release-note
NONE
```
