### PR TITLE
Fix counting of nmstate enabled nodes

### DIFF
--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -24,8 +24,8 @@ func NodesRunningNmstate(cli client.Reader, nodeSelector map[string]string) ([]c
 	}
 
 	pods := corev1.PodList{}
-	byApp := client.MatchingLabels{"app": "kubernetes-nmstate"}
-	err = cli.List(context.TODO(), &pods, byApp)
+	byComponent := client.MatchingLabels{"component": "kubernetes-nmstate-handler"}
+	err = cli.List(context.TODO(), &pods, byComponent)
 	if err != nil {
 		return []corev1.Node{}, errors.Wrap(err, "getting pods failed")
 	}

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -74,13 +74,13 @@ func newNode(idx int) corev1.Node {
 	return node
 }
 
-func newPodAtNode(idx int, name string, namespace string, app string) corev1.Pod {
+func newPodAtNode(idx int, name string, namespace string, component string) corev1.Pod {
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%d", name, idx),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app": app,
+				"component": component,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -91,7 +91,7 @@ func newPodAtNode(idx int, name string, namespace string, app string) corev1.Pod
 }
 
 func newNmstatePodAtNode(idx int) corev1.Pod {
-	return newPodAtNode(idx, "nmstate-handler", "nmstate", "kubernetes-nmstate")
+	return newPodAtNode(idx, "nmstate-handler", "nmstate", "kubernetes-nmstate-handler")
 }
 
 func newNonNmstatePodAtNode(idx int) corev1.Pod {


### PR DESCRIPTION
Currently, the label app=kubernetes-nmstate is used to count number
of nmstate enabled nodes, but this label is also present on webhooks
and cert manager, which may run on control-plane.

Using label `component=kubernetes-nmstate-handler` ensures that only
nodes with handlers running on them are considered.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with NNCP Status stuck in progressing due to incorrect counting of nmstate enabled nodes
```
