### PR TITLE
Add tolerations support for handler daemonset.

### DIFF
--- a/api/v1beta1/nmstate_types.go
+++ b/api/v1beta1/nmstate_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,6 +30,10 @@ type NMStateSpec struct {
 	// as labels applied to the node.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Tolerations is an optional list of tolerations to be added to handler DaemonSet manifest
+	// If Tolerations is specified, the handler daemonset will be also scheduled on nodes with corresponding taints
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // NMStateStatus defines the observed state of NMState

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta1
 
 import (
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -92,6 +93,13 @@ func (in *NMStateSpec) DeepCopyInto(out *NMStateSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/controllers/nmstate_controller.go
+++ b/controllers/nmstate_controller.go
@@ -168,6 +168,11 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	}
 	amd64AndCRNodeSelector["beta.kubernetes.io/arch"] = "amd64"
 
+	handlerTolerations := instance.Spec.Tolerations
+	if handlerTolerations == nil {
+		handlerTolerations = []corev1.Toleration{operatorExistsToleration}
+	}
+
 	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
 	data.Data["HandlerImage"] = os.Getenv("RELATED_IMAGE_HANDLER_IMAGE")
 	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
@@ -176,7 +181,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	data.Data["WebhookTolerations"] = []corev1.Toleration{masterExistsNoScheduleToleration}
 	data.Data["WebhookAffinity"] = corev1.Affinity{}
 	data.Data["HandlerNodeSelector"] = amd64AndCRNodeSelector
-	data.Data["HandlerTolerations"] = []corev1.Toleration{operatorExistsToleration}
+	data.Data["HandlerTolerations"] = handlerTolerations
 	data.Data["HandlerAffinity"] = corev1.Affinity{}
 	// TODO: This is just a place holder to make template renderer happy
 	//       proper variable has to be read from env or CR

--- a/deploy/crds/nmstate.io_nmstates.yaml
+++ b/deploy/crds/nmstate.io_nmstates.yaml
@@ -46,6 +46,49 @@ spec:
                   that have each of the indicated key-value pairs as labels applied
                   to the node.
                 type: object
+              tolerations:
+                description: Tolerations is an optional list of tolerations to be
+                  added to handler DaemonSet manifest If Tolerations is specified,
+                  the handler daemonset will be also scheduled on nodes with corresponding
+                  taints
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
           status:
             description: NMStateStatus defines the observed state of NMState


### PR DESCRIPTION
Add tolerations support for handler daemonset.

fixes #789 
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:

This PR allows specifying custom tolerations for nmstate handler daemonset.
Comparing with the change introduced in #755 (which was an extension of the toleration list to allow any taints) this change allows an opt-out behavior and complement nodeSelector support introduced in #514)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
By default, nmstate will be deployed on all nodes. This behavior can be changed through nodeSelector/toleration attributes on the NMState CR.
```
