### PR TITLE
Set max unavailable to 10%

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -182,6 +182,10 @@ spec:
   selector:
     matchLabels:
       name: {{template "handlerPrefix" .}}nmstate-handler
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind enhancement

**What this PR does / why we need it**:

The default value of maxUnavailable is 1. That serializes upgrades and
may drag for very long time. This change turns it into 10% to speed up
the upgrade process while keeping services reasonably available.

https://bugzilla.redhat.com/show_bug.cgi?id=1990065

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set maximum unavailable replicas of handler to 10%
```
