### PR TITLE
Run handlers on workers only in CI

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -7,8 +7,14 @@ source ./cluster/sync-operator.sh
 
 kubectl=./cluster/kubectl.sh
 
+nmstate_cr_manifest=deploy/crds/nmstate.io_v1beta1_nmstate_cr.yaml
+
 function deploy_handler() {
-    $kubectl apply -f deploy/crds/nmstate.io_v1beta1_nmstate_cr.yaml
+    $kubectl apply -f $nmstate_cr_manifest
+}
+
+function patch_handler_nodeselector() {
+    $kubectl patch -f $nmstate_cr_manifest --patch '{"spec": {"nodeSelector": { "node-role.kubernetes.io/worker": "" }}}' --type=merge
 }
 
 function wait_ready_handler() {
@@ -40,4 +46,5 @@ function wait_ready_handler() {
 deploy_operator
 wait_ready_operator
 deploy_handler
+patch_handler_nodeselector
 wait_ready_handler

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -27,7 +27,6 @@ import (
 var (
 	t                    *testing.T
 	nodes                []string
-	allNodes             []string
 	startTime            time.Time
 	bond1                string
 	bridge1              string
@@ -56,21 +55,13 @@ var _ = BeforeSuite(func() {
 	portFieldName = "port"
 	miimonFormat = "%d"
 
-	By("Getting worker node list from cluster")
+	By("Getting nmstate-enabled worker node list from cluster")
 	nodeList := corev1.NodeList{}
 	filterWorkers := client.MatchingLabels{"node-role.kubernetes.io/worker": ""}
 	err := testenv.Client.List(context.TODO(), &nodeList, filterWorkers)
 	Expect(err).ToNot(HaveOccurred())
 	for _, node := range nodeList.Items {
 		nodes = append(nodes, node.Name)
-	}
-
-	By("Getting all node list from cluster")
-	nodeList = corev1.NodeList{}
-	err = testenv.Client.List(context.TODO(), &nodeList)
-	Expect(err).ToNot(HaveOccurred())
-	for _, node := range nodeList.Items {
-		allNodes = append(allNodes, node.Name)
 	}
 
 	resetDesiredStateForNodes()
@@ -102,7 +93,7 @@ var _ = BeforeEach(func() {
 	startTime = time.Now()
 
 	By("Getting nodes initial state")
-	for _, node := range allNodes {
+	for _, node := range nodes {
 		nodeState := nodeInterfacesState(node, interfacesToIgnore)
 		nodesInterfacesState[node] = nodeState
 	}
@@ -110,7 +101,7 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	By("Verifying initial state")
-	for _, node := range allNodes {
+	for _, node := range nodes {
 		Eventually(func() []byte {
 			By("Verifying initial state eventually")
 			nodeState := nodeInterfacesState(node, interfacesToIgnore)

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -19,7 +19,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 	)
 	BeforeEach(func() {
 		originalNNSs = map[string]nmstatev1beta1.NodeNetworkState{}
-		for _, node := range allNodes {
+		for _, node := range nodes {
 			key := types.NamespacedName{Name: node}
 			originalNNSs[node] = nodeNetworkState(key)
 		}
@@ -49,10 +49,10 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 		expectedDummyName := "dummy0"
 
 		BeforeEach(func() {
-			createDummyConnectionAtAllNodes(expectedDummyName)
+			createDummyConnectionAtNodes(expectedDummyName)
 		})
 		AfterEach(func() {
-			deleteConnectionAndWait(allNodes, expectedDummyName)
+			deleteConnectionAndWait(nodes, expectedDummyName)
 		})
 		It("should update it with according to network state refresh duration", func() {
 			for node, originalNNS := range originalNNSs {

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -48,7 +48,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		It("[test_id:3813]should not update any nodes and have not enactments", func() {
-			for _, node := range allNodes {
+			for _, node := range nodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}
 			Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(0), "should not create any enactment")
@@ -62,10 +62,10 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			It("should update all nodes and have Matching enactment state", func() {
-				for _, node := range allNodes {
+				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
 				}
-				Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(len(allNodes)), "should create all the enactments")
+				Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(len(nodes)), "should create all the enactments")
 
 			})
 

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -236,21 +236,10 @@ func createDummyConnectionAtNodes(dummyName string) []error {
 	return createDummyConnection(nodes, dummyName)
 }
 
-func createDummyConnectionAtAllNodes(dummyName string) []error {
-	return createDummyConnection(nodes, dummyName)
-}
-
 func deleteConnection(nodesToModify []string, name string) []error {
 	By(fmt.Sprintf("Delete connection %s", name))
 	_, errs := runner.RunAtNodes(nodesToModify, "sudo", "nmcli", "con", "delete", name)
 	return errs
-}
-
-func deleteConnectionAtNodes(name string) []error {
-	return deleteConnection(nodes, name)
-}
-func deleteConnectionAtAllNodes(name string) []error {
-	return deleteConnection(nodes, name)
 }
 
 func deleteDevice(nodesToModify []string, name string) []error {

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -237,7 +237,7 @@ func createDummyConnectionAtNodes(dummyName string) []error {
 }
 
 func createDummyConnectionAtAllNodes(dummyName string) []error {
-	return createDummyConnection(allNodes, dummyName)
+	return createDummyConnection(nodes, dummyName)
 }
 
 func deleteConnection(nodesToModify []string, name string) []error {
@@ -250,7 +250,7 @@ func deleteConnectionAtNodes(name string) []error {
 	return deleteConnection(nodes, name)
 }
 func deleteConnectionAtAllNodes(name string) []error {
-	return deleteConnection(allNodes, name)
+	return deleteConnection(nodes, name)
 }
 
 func deleteDevice(nodesToModify []string, name string) []error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds nodeSelector to NMState CR, which makes nmstate-handler pods schedule 
only on worker nodes. This aims to mimick clusters that split workloads and control plane.

With master nodes not having nmstate-handler, there is also no NNS, meaning that `allNodes`
variable used in e2e tests looses it's point - removing in favor of keeping only one list of nodes,
which are the worker nodes.

This made some helper functions obsolete, so finally, last commit deletes unused code.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement


**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
