### PR TITLE
e2e tests: Populate nodes list by handler pods

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -55,13 +55,13 @@ var _ = BeforeSuite(func() {
 	portFieldName = "port"
 	miimonFormat = "%d"
 
-	By("Getting nmstate-enabled worker node list from cluster")
-	nodeList := corev1.NodeList{}
-	filterWorkers := client.MatchingLabels{"node-role.kubernetes.io/worker": ""}
-	err := testenv.Client.List(context.TODO(), &nodeList, filterWorkers)
+	By("Getting nmstate-enabled node list from cluster")
+	podList := corev1.PodList{}
+	filterHandlers := client.MatchingLabels{"component": "kubernetes-nmstate-handler"}
+	err := testenv.Client.List(context.TODO(), &podList, filterHandlers)
 	Expect(err).ToNot(HaveOccurred())
-	for _, node := range nodeList.Items {
-		nodes = append(nodes, node.Name)
+	for _, pod := range podList.Items {
+		nodes = append(nodes, pod.Spec.NodeName)
 	}
 
 	resetDesiredStateForNodes()


### PR DESCRIPTION
With support for custom handler NodeSelector, do not
populate nodes list by worker label, but instead
select nodes with running handler pod.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
