### PR TITLE
e2e tests: Return back allNodes variable

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	t                    *testing.T
+	allNodes             []string
 	nodes                []string
 	startTime            time.Time
 	bond1                string
@@ -61,7 +62,17 @@ var _ = BeforeSuite(func() {
 	err := testenv.Client.List(context.TODO(), &podList, filterHandlers)
 	Expect(err).ToNot(HaveOccurred())
 	for _, pod := range podList.Items {
-		nodes = append(nodes, pod.Spec.NodeName)
+		allNodes = append(allNodes, pod.Spec.NodeName)
+	}
+
+	By("Getting nmstate-enabled worker node list from cluster")
+	nodeList := corev1.NodeList{}
+	filterWorkers := client.MatchingLabels{"node-role.kubernetes.io/worker": ""}
+	err = testenv.Client.List(context.TODO(), &nodeList, filterWorkers)
+	for _, node := range nodeList.Items {
+		if containsNode(allNodes, node.Name) {
+			nodes = append(nodes, node.Name)
+		}
 	}
 
 	resetDesiredStateForNodes()
@@ -93,7 +104,7 @@ var _ = BeforeEach(func() {
 	startTime = time.Now()
 
 	By("Getting nodes initial state")
-	for _, node := range nodes {
+	for _, node := range allNodes {
 		nodeState := nodeInterfacesState(node, interfacesToIgnore)
 		nodesInterfacesState[node] = nodeState
 	}
@@ -101,7 +112,7 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	By("Verifying initial state")
-	for _, node := range nodes {
+	for _, node := range allNodes {
 		Eventually(func() []byte {
 			By("Verifying initial state eventually")
 			nodeState := nodeInterfacesState(node, interfacesToIgnore)
@@ -124,4 +135,13 @@ func getMaxFailsFromEnv() int {
 	}
 
 	return maxFails
+}
+
+func containsNode(nodes []string, node string) bool {
+	for _, n := range nodes {
+		if n == node {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -19,7 +19,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 	)
 	BeforeEach(func() {
 		originalNNSs = map[string]nmstatev1beta1.NodeNetworkState{}
-		for _, node := range nodes {
+		for _, node := range allNodes {
 			key := types.NamespacedName{Name: node}
 			originalNNSs[node] = nodeNetworkState(key)
 		}
@@ -49,10 +49,10 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 		expectedDummyName := "dummy0"
 
 		BeforeEach(func() {
-			createDummyConnectionAtNodes(expectedDummyName)
+			createDummyConnectionAtAllNodes(expectedDummyName)
 		})
 		AfterEach(func() {
-			deleteConnectionAndWait(nodes, expectedDummyName)
+			deleteConnectionAndWait(allNodes, expectedDummyName)
 		})
 		It("should update it with according to network state refresh duration", func() {
 			for node, originalNNS := range originalNNSs {

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -48,7 +48,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		It("[test_id:3813]should not update any nodes and have not enactments", func() {
-			for _, node := range nodes {
+			for _, node := range allNodes {
 				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
 			}
 			Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(0), "should not create any enactment")
@@ -62,10 +62,10 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			It("should update all nodes and have Matching enactment state", func() {
-				for _, node := range nodes {
+				for _, node := range allNodes {
 					interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
 				}
-				Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(len(nodes)), "should create all the enactments")
+				Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(len(allNodes)), "should create all the enactments")
 
 			})
 

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -236,6 +236,10 @@ func createDummyConnectionAtNodes(dummyName string) []error {
 	return createDummyConnection(nodes, dummyName)
 }
 
+func createDummyConnectionAtAllNodes(dummyName string) []error {
+	return createDummyConnection(allNodes, dummyName)
+}
+
 func deleteConnection(nodesToModify []string, name string) []error {
 	By(fmt.Sprintf("Delete connection %s", name))
 	_, errs := runner.RunAtNodes(nodesToModify, "sudo", "nmcli", "con", "delete", name)


### PR DESCRIPTION
Removal of allNodes variable caseed e2e tests to fail in cluster
where NMState doesn't specify nodeSelector.

To make e2e tests not depend on NMState nodeSelector,
revert removal of allNodes variable.
The allNodes and nodes variables have the following content:
- allNodes: contains all cluster nodes with nmstate-handler pod
- nodes: contains all cluster nodes with nmstate-handler pod and
"node-role.kubernetes.io/worker" label

This way, e2e tests don't need to make any assumptions about used
NMState nodeSelector (and in the future tolerations, affinities...)

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
