### PR TITLE
handler,webhook:use variable to set min replicas

### DIFF
--- a/controllers/nmstate_controller.go
+++ b/controllers/nmstate_controller.go
@@ -173,7 +173,10 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 		handlerTolerations = []corev1.Toleration{operatorExistsToleration}
 	}
 
-	const WEBHOOK_REPLICAS = int32(2)
+	const (
+		WEBHOOK_REPLICAS     = int32(2)
+		WEBHOOK_MIN_REPLICAS = int32(1)
+	)
 
 	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
 	data.Data["HandlerImage"] = os.Getenv("RELATED_IMAGE_HANDLER_IMAGE")
@@ -183,6 +186,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	data.Data["WebhookTolerations"] = []corev1.Toleration{masterExistsNoScheduleToleration}
 	data.Data["WebhookAffinity"] = corev1.Affinity{}
 	data.Data["WebhookReplicas"] = WEBHOOK_REPLICAS
+	data.Data["WebhookMinReplicas"] = WEBHOOK_MIN_REPLICAS
 	data.Data["HandlerNodeSelector"] = amd64AndCRNodeSelector
 	data.Data["HandlerTolerations"] = handlerTolerations
 	data.Data["HandlerAffinity"] = corev1.Affinity{}

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -362,7 +362,7 @@ metadata:
   namespace: {{ .HandlerNamespace }}
   name: {{template "handlerPrefix" .}}nmstate-webhook
 spec:
-  minAvailable: 1
+  minAvailable: {{  .WebhookMinReplicas  }}
   selector:
     matchLabels:
       name: {{template "handlerPrefix" .}}nmstate-webhook


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
In order to set the number of minimum webhook replicas dynamically, the operator
yaml should accept a variable to set number of minimum replicas.

An example use-case for that would be to set the minimum number of webhook replicas to 0 when running
on a Single-Node-Openshift cluster, to no interfere with the upgrade process, where the
number of active webhook pods will be reduced from 1 to 0 to perform the upgrade.

This commit introduce this variable and sets it with a fixed value of 1. In a follow-up work
This could be enhanced to be completely dynamic.

Signed-off-by: alonsadan <asadan@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
