### PR TITLE
Try updating nncp with non-cached client as backup

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -362,9 +362,20 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 
 func (r *NodeNetworkConfigurationPolicyReconciler) decrementUnavailableNodeCount(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
+	err := tryDecrementingUnavailableNodeCount(r.Client, r.Client, policyKey)
+	if err != nil {
+		r.Log.Error(err, "error decrementing unavailableNodeCount with cached client, trying again with non-cached client.")
+		err = tryDecrementingUnavailableNodeCount(r.Client, r.APIClient, policyKey)
+		if err != nil {
+			r.Log.Error(err, "error decrementing unavailableNodeCount with non-cached client")
+		}
+	}
+}
+
+func tryDecrementingUnavailableNodeCount(statusWriterClient client.StatusClient, readerClient client.Reader, policyKey types.NamespacedName) error {
 	instance := &nmstatev1beta1.NodeNetworkConfigurationPolicy{}
-	err := retry.RetryOnConflict(policyconditions.StatusUpdateRetry, func() error {
-		err := r.Client.Get(context.TODO(), policyKey, instance)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := readerClient.Get(context.TODO(), policyKey, instance)
 		if err != nil {
 			return err
 		}
@@ -372,11 +383,9 @@ func (r *NodeNetworkConfigurationPolicyReconciler) decrementUnavailableNodeCount
 			return fmt.Errorf("no unavailable nodes")
 		}
 		instance.Status.UnavailableNodeCount -= 1
-		return r.Client.Status().Update(context.TODO(), instance)
+		return statusWriterClient.Status().Update(context.TODO(), instance)
 	})
-	if err != nil {
-		r.Log.Error(err, "error decrementing unavailableNodeCount")
-	}
+	return err
 }
 
 func (r *NodeNetworkConfigurationPolicyReconciler) forceNNSRefresh(name string) {

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -3,14 +3,11 @@ package policyconditions
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -22,13 +19,7 @@ import (
 )
 
 var (
-	log               = logf.Log.WithName("policyconditions")
-	StatusUpdateRetry = wait.Backoff{
-		Steps:    20,
-		Duration: 10 * time.Millisecond,
-		Factor:   2.0,
-		Jitter:   0.1,
-	}
+	log = logf.Log.WithName("policyconditions")
 )
 
 func SetPolicyProgressing(conditions *nmstate.ConditionList, message string) {
@@ -98,12 +89,25 @@ func SetPolicyFailedToConfigure(conditions *nmstate.ConditionList, message strin
 func Update(cli client.Client, apiReader client.Reader, policyKey types.NamespacedName) error {
 	logger := log.WithValues("policy", policyKey.Name)
 
+	err := update(cli, apiReader, cli, policyKey)
+	if err != nil {
+		logger.Error(err, "failed to update policy status using cached client. Retrying with non-cached.")
+		err = update(cli, apiReader, apiReader, policyKey)
+		if err != nil {
+			logger.Error(err, "failed to update policy status using non-cached client.")
+		}
+	}
+	return err
+}
+
+func update(apiWriter client.Client, apiReader client.Reader, policyReader client.Reader, policyKey types.NamespacedName) error {
+	logger := log.WithValues("policy", policyKey.Name)
 	// On conflict we need to re-retrieve enactments since the
 	// conflict can denote that the calculated policy conditions
 	// are now not accurate.
-	return retry.RetryOnConflict(StatusUpdateRetry, func() error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		policy := &nmstatev1beta1.NodeNetworkConfigurationPolicy{}
-		err := cli.Get(context.TODO(), policyKey, policy)
+		err := policyReader.Get(context.TODO(), policyKey, policy)
 		if err != nil {
 			return errors.Wrap(err, "getting policy failed")
 		}
@@ -149,7 +153,7 @@ func Update(cli client.Client, apiReader client.Reader, policyKey types.Namespac
 			}
 		}
 
-		err = cli.Status().Update(context.TODO(), policy)
+		err = apiWriter.Status().Update(context.TODO(), policy)
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				logger.Info("conflict updating policy conditions, retrying")


### PR DESCRIPTION
After applying a policy, the cached client may return
outdated resource if network configuration breaks
connectivity, which may take up to a minute to refresh again.

A previous commit addressed this by adding a custom backoff
timeout that would wait for the cached client to return
updated resource. But that solution is sub-optimal since
the wait time may take a lot of time, causing the handler to
be effectively stuck.

To improve this behaviour, this change updates NNCP in two
steps
1. Try using cached client
2. Try using non-cached client if all attempts with cached
   client fail on conflict

This way, handler isn't blocking reconcile for long period of time

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
