### PR TITLE
e2e: test linux-bridge policy succeeds when updated

### DIFF
--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -184,6 +184,9 @@ var _ = Describe("NodeNetworkState", func() {
 					hasVlans(node, secondSecondaryNic, 2, 4094).Should(Succeed())
 				}
 			})
+			It("should succeed updating the linux-bridge desiredState description", func() {
+				updateDesiredStateAndWait(linuxBrUpWithDescription(bridge1))
+			})
 		})
 		Context("with a active-backup miimon 100 bond interface up", func() {
 			BeforeEach(func() {

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -118,6 +118,19 @@ func linuxBrUpWithDisabledVlan(bridgeName string) nmstate.State {
 `, bridgeName, firstSecondaryNic))
 }
 
+func linuxBrUpWithDescription(bridgeName string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
+    description: linux bridge up with two ports
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+        - name: %s
+        - name: %s
+`, bridgeName, firstSecondaryNic, secondSecondaryNic))
+}
+
 func ovsBrAbsent(bridgeName string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
   - name: %s


### PR DESCRIPTION
Reported bug [0] revealed that nmstate verifies whether
currentState and last applied desiredState has changed
(and if it has, raises an error).

This causes errors on NNCP updates with kubernetes-nmstate
v0.52.0 and earlier.

The issue is caused by kubernetes-nmstate itself due to
vlan filtering configuration applied to linux-bridge ports
using a script, instead of nmstatectl.

This commit adds e2e test verifying that policy
adding linux-bridge succeeds when updated.

https://bugzilla.redhat.com/show_bug.cgi?id=2000052

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
