### PR TITLE
PodDisruptionBudget, Update apiVersion

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -364,7 +364,7 @@ webhooks:
         apiVersions: ["v1alpha1","v1beta1"]
         resources: ["nodenetworkconfigurationpolicies"]
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   namespace: {{ .HandlerNamespace }}


### PR DESCRIPTION
Since the previous apiVersion of PodDisruptionBudget is deprecated,
use policy/v1 instead.

`policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget`

https://bugzilla.redhat.com/show_bug.cgi?id=2000480

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
