### PR TITLE
kubevirtci, Simplify kubevirtci.sh script

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -1,23 +1,21 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.20'}
+export KUBEVIRTCI_TAG='2102030941-4a15921'
 
-KUBEVIRTCI_VERSION='4a15921fbd605363b4a0dc893f8d19f8ac124b55'
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
-
-export KUBEVIRTCI_TAG='2102030941-4a15921'
 
 function kubevirtci::_get_repo() {
     git --git-dir ${KUBEVIRTCI_PATH}/.git remote get-url origin
 }
 
-function kubevirtci::_get_version() {
-    git --git-dir ${KUBEVIRTCI_PATH}/.git log --format="%H" -n 1
+function kubevirtci::_get_tag() {
+    git -C ${KUBEVIRTCI_PATH} describe --tags
 }
 
 function kubevirtci::install() {
     # Remove cloned kubevirtci repository if it does not match the requested one
     if [ -d ${KUBEVIRTCI_PATH} ]; then
-        if [ $(kubevirtci::_get_repo) != ${KUBEVIRTCI_REPO} -o $(kubevirtci::_get_version) != ${KUBEVIRTCI_VERSION} ]; then
+        if [ $(kubevirtci::_get_repo) != ${KUBEVIRTCI_REPO} -o $(kubevirtci::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
             rm -rf ${KUBEVIRTCI_PATH}
         fi
     fi
@@ -26,7 +24,7 @@ function kubevirtci::install() {
         git clone ${KUBEVIRTCI_REPO} ${KUBEVIRTCI_PATH}
         (
             cd ${KUBEVIRTCI_PATH}
-            git checkout ${KUBEVIRTCI_VERSION}
+            git checkout ${KUBEVIRTCI_TAG}
         )
     fi
 }


### PR DESCRIPTION
The hash is no longer needed.
only that tag is needed in order to determine the kubevirtci
version that should be used.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
