### PR TITLE
Mount ovs socket

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -13,6 +13,8 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 
+ENV ENABLE_OVS=""
+
 ENTRYPOINT ["manager"]
 
 LABEL io.k8s.display-name="kubernetes-nmstate-operator" \

--- a/controllers/nmstate_controller.go
+++ b/controllers/nmstate_controller.go
@@ -212,6 +212,8 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	data.Data["HandlerNodeSelector"] = amd64AndCRNodeSelector
 	data.Data["HandlerTolerations"] = handlerTolerations
 	data.Data["HandlerAffinity"] = corev1.Affinity{}
+	_, enableOVS := os.LookupEnv("ENABLE_OVS")
+	data.Data["EnableOVS"] = enableOVS
 	// TODO: This is just a place holder to make template renderer happy
 	//       proper variable has to be read from env or CR
 	data.Data["CARotateInterval"] = ""

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -260,6 +260,10 @@ spec:
               mountPath: /run/dbus/system_bus_socket
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
+{{if .EnableOVS}}
+            - name: ovs-socket
+              mountPath: /run/openvswitch/db.sock
+{{end}}
           securityContext:
             privileged: true
           readinessProbe:
@@ -278,6 +282,12 @@ spec:
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate
+{{if .EnableOVS}}
+        - name: ovs-socket
+          hostPath:
+            path: /run/openvswitch/db.sock
+            type: Socket
+{{end}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The nmstate OVS functionality depends on the OVS socket to be mounted at
the handler container but this is only possible if OVS is installed at
nodes, this change add optional mount to the handler manifests
controlled by the environment variable ENABLE_OVS on the operator, it
also sets the env variable at the openshift operator dockerfile to have
proper OVS functionality there.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
mount OVS socket if needed with ENABLE_OVS env var.
```
