### PR TITLE
e2e: Remove rollback test that is now obsolete

### DIFF
--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -91,28 +91,6 @@ func discoverNameServers(nic string) nmstate.State {
 }
 
 var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]rollback", func() {
-	Context("when an error happens during state configuration", func() {
-		AfterEach(func() {
-			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
-			resetDesiredStateForNodes()
-		})
-		It("should rollback failed state configuration", func() {
-			updateDesiredState(linuxBrBadYaml(bridge1))
-
-			By("Should not be available") // Fail fast
-			policyConditionsStatusConsistently().ShouldNot(containPolicyAvailable())
-
-			By("Wait for reconcile to fail")
-			waitForDegradedTestPolicy()
-			for _, node := range nodes {
-				By(fmt.Sprintf("Check that %s has being rolled back", bridge1))
-				interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
-
-				By(fmt.Sprintf("Check that %s continue with rolled back state", bridge1))
-				interfacesNameForNodeConsistently(node).ShouldNot(ContainElement(bridge1))
-			}
-		})
-	})
 	// This spec is done only at first node since policy has to be different
 	// per node (ip addresses has to be different at cluster).
 	Context("when connectivity to default gw is lost after state configuration", func() {


### PR DESCRIPTION
In previous commit that removed vlan-filtering script,
this test was changed to use bad yaml, instead of renaming
the vlan-filtering binary, to make applyDesiredState fail
on purpose.

The problem is, this change is not equivalent - previously, the
desired state was applied, and only then the function failed.
Now however, this test fails to apply the desired state, so rollback
is not really exercised.

The thing is, after removing the use of the vlan-filtering script,
the only function call that can potentially fail is nmstatectl commit,
and there doesn't seem to be practical way to make it fail.

For that reason, this test appears to be obsolete and can be removed.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
