### PR TITLE
Return nil when reached maxUnavailable count

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -185,7 +185,8 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				enactmentConditions.NotifyPending()
-				return ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime}, err
+				log.Info(err.Error())
+				return ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime}, nil
 			}
 			return ctrl.Result{}, err
 		}

--- a/controllers/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller_test.go
@@ -72,10 +72,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 	type incrementUnavailableNodeCountCase struct {
 		currentUnavailableNodeCount  int
 		expectedUnavailableNodeCount int
-		expectedReconcileError       string
 		expectedReconcileResult      ctrl.Result
 		previousEnactmentConditions  func(*shared.ConditionList, string)
-		shouldConflict               bool
 	}
 	DescribeTable("when claimNodeRunningUpdate is called and",
 		func(c incrementUnavailableNodeCountCase) {
@@ -126,9 +124,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				NamespacedName: types.NamespacedName{Name: nncp.Name},
 			})
 
-			if c.shouldConflict {
-				Expect(err.Error()).To(Equal(c.expectedReconcileError))
-			}
+			Expect(err).To(BeNil())
 			Expect(res).To(Equal(c.expectedReconcileResult))
 
 			obtainedNNCP := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
@@ -141,7 +137,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 0,
 				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
 				expectedReconcileResult:      ctrl.Result{},
-				shouldConflict:               false,
 			}),
 		Entry("No node applying policy with progressing enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
@@ -149,7 +144,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 0,
 				previousEnactmentConditions:  conditions.SetProgressing,
 				expectedReconcileResult:      ctrl.Result{},
-				shouldConflict:               false,
 			}),
 		Entry("No node applying policy with Pending enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
@@ -157,7 +151,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 0,
 				previousEnactmentConditions:  conditions.SetPending,
 				expectedReconcileResult:      ctrl.Result{},
-				shouldConflict:               false,
 			}),
 		Entry("One node applying policy with empty enactment, should conflict incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
@@ -165,8 +158,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 1,
 				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
 				expectedReconcileResult:      ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
-				expectedReconcileError:       "Operation cannot be fulfilled on nodenetworkconfigurationpolicies \"test\": maximal number of 1 nodes are already processing policy configuration",
-				shouldConflict:               true,
 			}),
 		Entry("One node applying policy with Progressing enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
@@ -174,7 +165,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 0,
 				previousEnactmentConditions:  conditions.SetProgressing,
 				expectedReconcileResult:      ctrl.Result{},
-				shouldConflict:               false,
 			}),
 		Entry("One node applying policy with Pending enactment, should conflict incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
@@ -182,8 +172,6 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedUnavailableNodeCount: 1,
 				previousEnactmentConditions:  conditions.SetPending,
 				expectedReconcileResult:      ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
-				expectedReconcileError:       "Operation cannot be fulfilled on nodenetworkconfigurationpolicies \"test\": maximal number of 1 nodes are already processing policy configuration",
-				shouldConflict:               true,
 			}),
 	)
 })


### PR DESCRIPTION
kubernetes requeues request with rate limiting when an error
is returned, regardless of what is in the returned Result.
See [k8s controller](https://github.com/kubernetes-sigs/controller-runtime/blob/16bf3ad036b908d897543c415fcc0bafc5cec711/pkg/internal/controller/controller.go#L297)

As a consequence, in big clusters, nodes that wait for policy
need to wait for increasingly long time between each reconcile
loop.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with handlers waiting in Pending state for longer than neccessary
```
