### PR TITLE
[release-0.47] Return nil when reached maxUnavailable count

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -182,7 +182,8 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 		err = r.incrementUnavailableNodeCount(instance)
 		if err != nil {
 			if apierrors.IsConflict(err) {
-				return ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime}, err
+				log.Info(err.Error())
+				return ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime}, nil
 			}
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
This is a cherry-pick of #838

kubernetes requeues request with rate limiting when an error
is returned, regardless of what is in the returned Result.

As a consequence, in big clusters, nodes that wait for policy
need to wait for increasingly long time between each reconcile
loop.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with handlers waiting in Pending state for longer than neccessary
```
