### PR TITLE
Introduce Byf to functional tests

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -47,7 +47,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 	Context("when there is a default interface with dynamic address", func() {
 		addressByNode := map[string]string{}
 		BeforeEach(func() {
-			By(fmt.Sprintf("Check %s is the default route interface and has dynamic address", primaryNic))
+			Byf("Check %s is the default route interface and has dynamic address", primaryNic)
 			for _, node := range nodes {
 				defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
 				Expect(dhcpFlag(node, primaryNic)).Should(BeTrue())
@@ -60,18 +60,18 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 					address = ipv4Address(node, primaryNic)
 					return address
 				}, 15*time.Second, 1*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s has no ipv4 address", primaryNic))
-				By(fmt.Sprintf("Fetching current IP address %s", address))
+				Byf("Fetching current IP address %s", address)
 				addressByNode[node] = address
 			}
-			By(fmt.Sprintf("Reseting state of %s", firstSecondaryNic))
+			Byf("Reseting state of %s", firstSecondaryNic)
 			resetNicStateForNodes(firstSecondaryNic)
-			By(fmt.Sprintf("Creating %s on %s and %s", bond1, primaryNic, firstSecondaryNic))
+			Byf("Creating %s on %s and %s", bond1, primaryNic, firstSecondaryNic)
 			updateDesiredStateAndWait(boundUpWithPrimaryAndSecondary(bond1))
 			By("Done configuring test")
 
 		})
 		AfterEach(func() {
-			By(fmt.Sprintf("Removing bond %s and configuring %s with dhcp", bond1, primaryNic))
+			Byf("Removing bond %s and configuring %s with dhcp", bond1, primaryNic)
 			updateDesiredStateAndWait(bondAbsentWithPrimaryUp(bond1))
 
 			By("Waiting until the node becomes ready again")
@@ -82,7 +82,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 
 			resetDesiredStateForNodes()
 
-			By(fmt.Sprintf("Check %s has the default ip address", primaryNic))
+			Byf("Check %s has the default ip address", primaryNic)
 			for _, node := range nodes {
 				Eventually(func() string {
 					return ipv4Address(node, primaryNic)
@@ -102,14 +102,14 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			}
 			// Restart only first node that it's a control-plane if other node is restarted it will stuck in NotReady state
 			nodeToReboot := nodes[0]
-			By(fmt.Sprintf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot))
+			Byf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot)
 			err := restartNode(nodeToReboot)
 			Expect(err).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("Wait for nns to be refreshed at %s", nodeToReboot))
+			Byf("Wait for nns to be refreshed at %s", nodeToReboot)
 			waitForNodeNetworkStateUpdate(nodeToReboot)
 
-			By(fmt.Sprintf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1))
+			Byf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1)
 			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, addressByNode[nodeToReboot])
 		})
 	})

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -55,7 +55,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 		addressByNode := map[string]string{}
 
 		BeforeEach(func() {
-			By(fmt.Sprintf("Check %s is the default route interface and has dynamic address", primaryNic))
+			Byf("Check %s is the default route interface and has dynamic address", primaryNic)
 			for _, node := range nodes {
 				defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
 				Expect(dhcpFlag(node, primaryNic)).Should(BeTrue())
@@ -85,7 +85,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 			})
 
 			AfterEach(func() {
-				By(fmt.Sprintf("Removing bridge and configuring %s with dhcp", primaryNic))
+				Byf("Removing bridge and configuring %s with dhcp", primaryNic)
 				setDesiredStateWithPolicy(DefaultNetwork, resetDefaultInterface())
 
 				By("Waiting until the node becomes ready again")
@@ -94,14 +94,14 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				By("Wait for policy to be ready")
 				waitForAvailablePolicy(DefaultNetwork)
 
-				By(fmt.Sprintf("Check %s has the default ip address", primaryNic))
+				Byf("Check %s has the default ip address", primaryNic)
 				for _, node := range nodes {
 					Eventually(func() string {
 						return ipv4Address(node, primaryNic)
 					}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", primaryNic))
 				}
 
-				By(fmt.Sprintf("Check %s is back as the default route interface", primaryNic))
+				Byf("Check %s is back as the default route interface", primaryNic)
 				for _, node := range nodes {
 					defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
 				}
@@ -141,10 +141,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				err := restartNode(nodeToReboot)
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("Wait for nns to be refreshed at %s", nodeToReboot))
+				Byf("Wait for nns to be refreshed at %s", nodeToReboot)
 				waitForNodeNetworkStateUpdate(nodeToReboot)
 
-				By(fmt.Sprintf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot))
+				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)
 				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot})
 			})
 		})

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -97,9 +97,9 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeEach(func() {
 	bond1 = nextBond()
-	By(fmt.Sprintf("Setting bond1=%s", bond1))
+	Byf("Setting bond1=%s", bond1)
 	bridge1 = nextBridge()
-	By(fmt.Sprintf("Setting bridge1=%s", bridge1))
+	Byf("Setting bridge1=%s", bridge1)
 	startTime = time.Now()
 
 	By("Getting nodes initial state")

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -68,7 +68,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		It("[test_id:3795] should have Failing ConditionType set to true", func() {
 			for _, node := range nodes {
-				By(fmt.Sprintf("Check %s failing state is reached", node))
+				Byf("Check %s failing state is reached", node)
 				enactmentConditionsStatusEventually(node).Should(
 					SatisfyAny(
 						matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
@@ -87,7 +87,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				go func() {
 					defer wg.Done()
 					defer GinkgoRecover()
-					By(fmt.Sprintf("Check %s failing state is kept", node))
+					Byf("Check %s failing state is kept", node)
 					enactmentConditionsStatusConsistently(node).Should(
 						SatisfyAny(
 							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
@@ -132,7 +132,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				go func() {
 					defer wg.Done()
 					defer GinkgoRecover()
-					By(fmt.Sprintf("Check %s failing state is kept", node))
+					Byf("Check %s failing state is kept", node)
 					enactmentConditionsStatusConsistently(node).Should(
 						SatisfyAny(
 							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),

--- a/test/e2e/handler/nnce_desiredstate_test.go
+++ b/test/e2e/handler/nnce_desiredstate_test.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -24,7 +22,7 @@ var _ = Describe("Enactment DesiredState", func() {
 		It("should have desiredState for node", func() {
 			for _, node := range nodes {
 				enactmentKey := nmstate.EnactmentKey(node, TestPolicy)
-				By(fmt.Sprintf("Check enactment %s has expected desired state", enactmentKey.Name))
+				Byf("Check enactment %s has expected desired state", enactmentKey.Name)
 				nnce := nodeNetworkConfigurationEnactment(enactmentKey)
 				Expect(nnce.Status.DesiredState).To(MatchYAML(linuxBrUpWithDefaults(bridge1)))
 			}

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -35,7 +35,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 					currentStatus := nodeNetworkState(key).Status
 					originalStatus := originalNNS.Status
 					if currentStatus.CurrentState.String() == originalStatus.CurrentState.String() {
-						By(fmt.Sprintf("Check LastSuccessfulUpdateTime changed at %s", node))
+						Byf("Check LastSuccessfulUpdateTime changed at %s", node)
 						Expect(currentStatus.LastSuccessfulUpdateTime).To(Equal(originalStatus.LastSuccessfulUpdateTime))
 					} else {
 						return fmt.Errorf("Network configuration changed, sending and error to retry")
@@ -56,7 +56,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 		})
 		It("should update it with according to network state refresh duration", func() {
 			for node, originalNNS := range originalNNSs {
-				By(fmt.Sprintf("Checking timestamp against original one %s", originalNNS.Status.LastSuccessfulUpdateTime))
+				Byf("Checking timestamp against original one %s", originalNNS.Status.LastSuccessfulUpdateTime.String())
 				Eventually(func() time.Time {
 					currentNNS := nodeNetworkState(types.NamespacedName{Name: node})
 					return currentNNS.Status.LastSuccessfulUpdateTime.Time

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -29,13 +28,13 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	)
 	Context("when policy is set with node selector not matching any nodes", func() {
 		BeforeEach(func() {
-			By(fmt.Sprintf("Set policy %s with not matching node selector", bridge1))
+			Byf("Set policy %s with not matching node selector", bridge1)
 			setDesiredStateWithPolicyAndNodeSelectorEventually(bridge1, linuxBrUp(bridge1), testNodeSelector)
 			waitForAvailablePolicy(bridge1)
 		})
 
 		AfterEach(func() {
-			By(fmt.Sprintf("Deleteting linux bridge %s at all nodes", bridge1))
+			Byf("Deleteting linux bridge %s at all nodes", bridge1)
 			setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrAbsent(bridge1))
 			waitForAvailablePolicy(bridge1)
 			deletePolicy(bridge1)
@@ -56,7 +55,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		Context("and we remove the node selector", func() {
 			BeforeEach(func() {
-				By(fmt.Sprintf("Remove node selector at policy %s", bridge1))
+				Byf("Remove node selector at policy %s", bridge1)
 				setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrUp(bridge1))
 				waitForAvailablePolicy(bridge1)
 			})

--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -113,12 +113,12 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Wait for reconcile to fail")
 			waitForDegradedTestPolicy()
-			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
+			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return dhcpFlag(nodes[0], primaryNic)
 			}, 480*time.Second, ReadInterval).Should(BeTrue(), "DHCP flag hasn't rollback to true")
 
-			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
+			Byf("Check that %s continue with rolled back state", primaryNic)
 			Consistently(func() bool {
 				return dhcpFlag(nodes[0], primaryNic)
 			}, 5*time.Second, 1*time.Second).Should(BeTrue(), "DHCP flag has change to false")
@@ -140,12 +140,12 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Wait for reconcile to fail")
 			waitForDegradedTestPolicy()
-			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
+			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return autoDNS(nodes[0], primaryNic)
 			}, 480*time.Second, ReadInterval).Should(BeTrue(), "should eventually have auto-dns=true")
 
-			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
+			Byf("Check that %s continue with rolled back state", primaryNic)
 			Consistently(func() bool {
 				return autoDNS(nodes[0], primaryNic)
 			}, 5*time.Second, 1*time.Second).Should(BeTrue(), "should consistently have auto-dns=true")
@@ -168,12 +168,12 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Wait for reconcile to fail")
 			waitForDegradedTestPolicy()
-			By(fmt.Sprintf("Check that %s is rolled back", primaryNic))
+			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return autoDNS(nodes[0], primaryNic)
 			}, 480*time.Second, ReadInterval).Should(BeTrue(), "should eventually have auto-dns=true")
 
-			By(fmt.Sprintf("Check that %s continue with rolled back state", primaryNic))
+			Byf("Check that %s continue with rolled back state", primaryNic)
 			Consistently(func() bool {
 				return autoDNS(nodes[0], primaryNic)
 			}, 5*time.Second, 1*time.Second).Should(BeTrue(), "should consistently have auto-dns=true")

--- a/test/e2e/handler/simple_vlan_and_ip_test.go
+++ b/test/e2e/handler/simple_vlan_and_ip_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NodeNetworkState", func() {
 			updateDesiredStateAndWait(ifaceUpWithVlanUp(firstSecondaryNic, vlanId))
 			for index, node := range nodes {
 				ipAddress := fmt.Sprintf(ipAddressTemplate, index)
-				By(fmt.Sprintf("applying static IP %s on node %s", ipAddress, node))
+				Byf("applying static IP %s on node %s", ipAddress, node)
 				updateDesiredStateAtNodeAndWait(node, vlanUpWithStaticIP(fmt.Sprintf("%s.%s", firstSecondaryNic, vlanId), ipAddress))
 			}
 

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
@@ -69,7 +68,7 @@ var _ = Describe("Validation Admission Webhook", func() {
 			resetDesiredStateForNodes()
 		})
 		It("Should deny updating rolled out policy when it's in progress", func() {
-			By(fmt.Sprintf("Updating the policy %s", TestPolicy))
+			Byf("Updating the policy %s", TestPolicy)
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				return setDesiredStateWithPolicyAndNodeSelector(TestPolicy, linuxBrUpNoPorts(bridge1), map[string]string{})
 			})


### PR DESCRIPTION
In the tests, `By(fmt.Stringf(...))` is used quite often and may be annoying. 
Therefore, in this PR, shortened `Byf` is introduced to simplify that.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
resolves #212 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
