### PR TITLE
Fix MISSING values in handler logs

### DIFF
--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -56,7 +56,7 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 		})
 		It("should update it with according to network state refresh duration", func() {
 			for node, originalNNS := range originalNNSs {
-				Byf("Checking timestamp against original one %s", originalNNS.Status.LastSuccessfulUpdateTime.String())
+				Byf("Checking timestamp against original one %s", originalNNS.Status.LastSuccessfulUpdateTime)
 				Eventually(func() time.Time {
 					currentNNS := nodeNetworkState(types.NamespacedName{Name: node})
 					return currentNNS.Status.LastSuccessfulUpdateTime.Time

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -40,8 +40,8 @@ var (
 	maxUnavailable = environment.GetVarWithDefault("NMSTATE_MAX_UNAVAILABLE", nmstatenode.DEFAULT_MAXUNAVAILABLE)
 )
 
-func Byf(message string, arguments ...string) {
-	By(fmt.Sprintf(message, arguments))
+func Byf(message string, arguments ...interface{}) {
+	By(fmt.Sprintf(message, arguments...))
 }
 
 func interfacesName(interfaces []interface{}) []string {
@@ -258,7 +258,7 @@ func deleteConnection(nodesToModify []string, name string) []error {
 }
 
 func deleteDevice(nodesToModify []string, name string) []error {
-	Byf("Delete device %s  at nodes %v", name, fmt.Sprint(nodesToModify))
+	Byf("Delete device %s  at nodes %v", name, nodesToModify)
 	_, errs := runner.RunAtNodes(nodesToModify, "sudo", "nmcli", "device", "delete", name)
 	return errs
 }
@@ -361,7 +361,7 @@ func bridgeVlansAtNode(node string) (string, error) {
 }
 
 func getVLANFlagsEventually(node string, connection string, vlan int) AsyncAssertion {
-	Byf("Getting vlan filtering flags for node %s connection %s and vlan %d", node, connection, fmt.Sprint(vlan))
+	Byf("Getting vlan filtering flags for node %s connection %s and vlan %d", node, connection, vlan)
 	return Eventually(func() []string {
 		bridgeVlans, err := bridgeVlansAtNode(node)
 		if err != nil {
@@ -403,7 +403,7 @@ func hasVlans(node string, connection string, minVlan int, maxVlan int) AsyncAss
 	ExpectWithOffset(1, maxVlan).To(BeNumerically(">", 0))
 	ExpectWithOffset(1, maxVlan).To(BeNumerically(">=", minVlan))
 
-	Byf("Check %s has %s with vlan filtering vids %d-%d", node, connection, fmt.Sprint(minVlan), fmt.Sprint(maxVlan))
+	Byf("Check %s has %s with vlan filtering vids %d-%d", node, connection, minVlan, maxVlan)
 	return Eventually(func() error {
 		bridgeVlans, err := bridgeVlansAtNode(node)
 		if err != nil {


### PR DESCRIPTION
The commit fixes bug in func Byf, where all arguments were passed as the first argument of the message, while all other arguments were left empty.

Example:

Now, all arguments are passed to the first argument only, causing other arguments to display `%!{}(MISSING)` values.
`STEP: Check [node02 eth0 2 4094] has %!s(MISSING) with vlan filtering vids %!d(MISSING)-%!d(MISSING)`

This is fixed in this PR, so arguments are correctly placed to its positions.
`STEP: Check node02 has eth0 with vlan filtering vids 2-4094`


Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
