### PR TITLE
e2e: check LastTransitionTime instead of polling status

### DIFF
--- a/test/e2e/handler/conditions.go
+++ b/test/e2e/handler/conditions.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -137,6 +138,14 @@ func containPolicyDegraded() GomegaMatcher {
 		"Reason":  Not(BeEmpty()),
 		"Message": Not(BeEmpty()),
 	}))
+}
+
+func waitForPolicyTransitionUpdate(policy string) {
+	now := time.Now()
+	EventuallyWithOffset(1, func() time.Time {
+		availableCondition := policyConditionsStatus(policy).Find(shared.NodeNetworkConfigurationPolicyConditionAvailable)
+		return availableCondition.LastTransitionTime.Time
+	}, 4*time.Minute, 5*time.Second).Should(BeTemporally(">=", now), fmt.Sprintf("Policy %s should have updated transition time", policy))
 }
 
 func waitForAvailableTestPolicy() {

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
-	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
 
@@ -142,7 +141,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for policy re-reconciled after node reboot")
-				enactmentConditionsStatusForPolicyEventually(nodeToReboot, DefaultNetwork).Should(matchConditionsFrom(enactmentconditions.SetProgressing), "should reach progressing state at %s after node reboot", nodeToReboot)
+				waitForPolicyTransitionUpdate(DefaultNetwork)
 				waitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)


### PR DESCRIPTION
When waiting for an enactment to be progressing is tricky
because we could miss the progressing state.
Instead, wait for the LastTransitionTime to be updated.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
