### PR TITLE
e2e: wait for policy transition in iface bonding tests

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -106,8 +106,9 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			err := restartNode(nodeToReboot)
 			Expect(err).ToNot(HaveOccurred())
 
-			Byf("Wait for nns to be refreshed at %s", nodeToReboot)
-			waitForNodeNetworkStateUpdate(nodeToReboot)
+			By("Wait for policy re-reconciled after node reboot")
+			waitForPolicyTransitionUpdate(TestPolicy)
+			waitForAvailablePolicy(TestPolicy)
 
 			Byf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1)
 			verifyBondIsUpWithPrimaryNicIp(nodeToReboot, expectedBond, addressByNode[nodeToReboot])


### PR DESCRIPTION
Don't wait for NNS to update after node reboot and instead
wait for policy transition time.

followup to https://github.com/nmstate/kubernetes-nmstate/pull/844 which missed to fix this occurence
of waiting for NSS refresh.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
