### PR TITLE
Continue if Pending takes too long

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -1,6 +1,9 @@
 package shared
 
-import "k8s.io/apimachinery/pkg/util/intstr"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
 
 // NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicySpec struct {
@@ -28,6 +31,9 @@ type NodeNetworkConfigurationPolicyStatus struct {
 	// processing a NodeNetworkConfigurationPolicy
 	// +optional
 	UnavailableNodeCount int `json:"unavailableNodeCount,omitempty" optional:"true"`
+	// LastUnavailableNodeCountUpdate is time of the last UnavailableNodeCount update
+	// +optional
+	LastUnavailableNodeCountUpdate *metav1.Time `json:"lastUnavailableNodeCountUpdate,omitempty" optional:"true"`
 }
 
 const (

--- a/controllers/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -70,10 +69,11 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 	)
 
 	type incrementUnavailableNodeCountCase struct {
-		currentUnavailableNodeCount  int
-		expectedUnavailableNodeCount int
-		expectedReconcileResult      ctrl.Result
-		previousEnactmentConditions  func(*shared.ConditionList, string)
+		currentUnavailableNodeCount      int
+		expectedUnavailableNodeCount     int
+		expectedReconcileResult          ctrl.Result
+		previousEnactmentConditions      func(*shared.ConditionList, string)
+		shouldUpdateUnavailableNodeCount bool
 	}
 	DescribeTable("when claimNodeRunningUpdate is called and",
 		func(c incrementUnavailableNodeCountCase) {
@@ -130,48 +130,57 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 			obtainedNNCP := nmstatev1beta1.NodeNetworkConfigurationPolicy{}
 			cl.Get(context.TODO(), types.NamespacedName{Name: nncp.Name}, &obtainedNNCP)
 			Expect(obtainedNNCP.Status.UnavailableNodeCount).To(Equal(c.expectedUnavailableNodeCount))
+			if c.shouldUpdateUnavailableNodeCount {
+				Expect(obtainedNNCP.Status.LastUnavailableNodeCountUpdate).ToNot(BeNil())
+			}
 		},
 		Entry("No node applying policy with empty enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  0,
-				expectedUnavailableNodeCount: 0,
-				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
-				expectedReconcileResult:      ctrl.Result{},
+				currentUnavailableNodeCount:      0,
+				expectedUnavailableNodeCount:     0,
+				previousEnactmentConditions:      func(*shared.ConditionList, string) {},
+				expectedReconcileResult:          ctrl.Result{},
+				shouldUpdateUnavailableNodeCount: true,
 			}),
 		Entry("No node applying policy with progressing enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  0,
-				expectedUnavailableNodeCount: 0,
-				previousEnactmentConditions:  conditions.SetProgressing,
-				expectedReconcileResult:      ctrl.Result{},
+				currentUnavailableNodeCount:      0,
+				expectedUnavailableNodeCount:     0,
+				previousEnactmentConditions:      conditions.SetProgressing,
+				expectedReconcileResult:          ctrl.Result{},
+				shouldUpdateUnavailableNodeCount: false,
 			}),
 		Entry("No node applying policy with Pending enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  0,
-				expectedUnavailableNodeCount: 0,
-				previousEnactmentConditions:  conditions.SetPending,
-				expectedReconcileResult:      ctrl.Result{},
+				currentUnavailableNodeCount:      0,
+				expectedUnavailableNodeCount:     0,
+				previousEnactmentConditions:      conditions.SetPending,
+				expectedReconcileResult:          ctrl.Result{},
+				shouldUpdateUnavailableNodeCount: true,
 			}),
 		Entry("One node applying policy with empty enactment, should conflict incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  1,
-				expectedUnavailableNodeCount: 1,
-				previousEnactmentConditions:  func(*shared.ConditionList, string) {},
-				expectedReconcileResult:      ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
+				currentUnavailableNodeCount:      1,
+				expectedUnavailableNodeCount:     1,
+				previousEnactmentConditions:      func(*shared.ConditionList, string) {},
+				expectedReconcileResult:          ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
+				shouldUpdateUnavailableNodeCount: false,
 			}),
 		Entry("One node applying policy with Progressing enactment, should succeed incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  1,
-				expectedUnavailableNodeCount: 0,
-				previousEnactmentConditions:  conditions.SetProgressing,
-				expectedReconcileResult:      ctrl.Result{},
+				currentUnavailableNodeCount:      1,
+				expectedUnavailableNodeCount:     0,
+				previousEnactmentConditions:      conditions.SetProgressing,
+				expectedReconcileResult:          ctrl.Result{},
+				shouldUpdateUnavailableNodeCount: false,
 			}),
 		Entry("One node applying policy with Pending enactment, should conflict incrementing UnavailableNodeCount",
 			incrementUnavailableNodeCountCase{
-				currentUnavailableNodeCount:  1,
-				expectedUnavailableNodeCount: 1,
-				previousEnactmentConditions:  conditions.SetPending,
-				expectedReconcileResult:      ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
+				currentUnavailableNodeCount:      1,
+				expectedUnavailableNodeCount:     1,
+				previousEnactmentConditions:      conditions.SetPending,
+				expectedReconcileResult:          ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime},
+				shouldUpdateUnavailableNodeCount: false,
 			}),
 	)
 })

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -92,6 +92,11 @@ spec:
                   - type
                   type: object
                 type: array
+              lastUnavailableNodeCountUpdate:
+                description: LastUnavailableNodeCountUpdate is time of the last UnavailableNodeCount
+                  update
+                format: date-time
+                type: string
               unavailableNodeCount:
                 description: UnavailableNodeCount represents the total number of potentially
                   unavailable nodes that are processing a NodeNetworkConfigurationPolicy
@@ -176,6 +181,11 @@ spec:
                   - type
                   type: object
                 type: array
+              lastUnavailableNodeCountUpdate:
+                description: LastUnavailableNodeCountUpdate is time of the last UnavailableNodeCount
+                  update
+                format: date-time
+                type: string
               unavailableNodeCount:
                 description: UnavailableNodeCount represents the total number of potentially
                   unavailable nodes that are processing a NodeNetworkConfigurationPolicy

--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -40,6 +40,7 @@ const (
 	defaultDnsProbeTimeout    = 120 * time.Second
 	apiServerProbeTimeout     = 120 * time.Second
 	nodeReadinessProbeTimeout = 120 * time.Second
+	ProbesTotalTimeout        = defaultGwRetrieveTimeout + defaultDnsProbeTimeout + defaultDnsProbeTimeout + apiServerProbeTimeout + nodeReadinessProbeTimeout
 )
 
 func currentStateAsGJson() (gjson.Result, error) {


### PR DESCRIPTION
Add LastUnavailableNodeCount timestamp to avoid
getting stuck at Pending forever.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
There are situations in which nmstate-handler may fail decrementing
`policy.Status.UnavailableNodeCount`.

One example is nmstate failing to Rollback, which _should_ never happen, but
existance of https://bugzilla.redhat.com/show_bug.cgi?id=2011879 proves it may.

There are other scenarios that may prevent nmstate-handler from decrementing the lock:
removing the node while policy is progressing or temporary connectivity issue.

There should be a safe mechanism that prevents policy progress from getting stuck.
This PR adds simple check that bypasses waiting for lock if none of the nmstate-handlers
have updated the _UnavailableNodeCount_ in time calculated by (timeoutOfDesiredStateConfiguration + timeoutOfProbes).

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with NNCE being stuck at Pending
```
