### PR TITLE
limit nmstate-handler to linux nodes

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -190,6 +190,8 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-handler
       annotations:
         description: kubernetes-nmstate-handler configures and presents node networking, reconciling declerative NNCP and reports with NNS and NNCE
+      nodeSelector:
+        kubernetes.io/os: linux
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.


### PR DESCRIPTION
It currently does not work on any other operating system. Attempting
means sure failure to apply NNCP.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2012920
Signed-off-by: Dan Kenigsberg <danken@redhat.com>

/kind bug

**What this PR does / why we need it**:
This should let k-nmstate ignore and tolerate non-Linux workers

**Special notes for your reviewer**:

**Release note**:
```release-note
kubernetes-nmstate works only on Linux nodes, so NNCP never succeeded on a cluster with Windows nodes. Now Windows VMs are ignored and tolerated.
```
