### PR TITLE
[release-0.52] ovs: Mount OVS socket if needed

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -13,6 +13,8 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 
+ENV ENABLE_OVS=""
+
 ENTRYPOINT ["manager"]
 
 LABEL io.k8s.display-name="kubernetes-nmstate-operator" \

--- a/controllers/nmstate_controller.go
+++ b/controllers/nmstate_controller.go
@@ -183,6 +183,8 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	data.Data["HandlerNodeSelector"] = amd64AndCRNodeSelector
 	data.Data["HandlerTolerations"] = handlerTolerations
 	data.Data["HandlerAffinity"] = corev1.Affinity{}
+	_, enableOVS := os.LookupEnv("ENABLE_OVS")
+	data.Data["EnableOVS"] = enableOVS
 	// TODO: This is just a place holder to make template renderer happy
 	//       proper variable has to be read from env or CR
 	data.Data["CARotateInterval"] = ""

--- a/controllers/nmstate_controller_test.go
+++ b/controllers/nmstate_controller_test.go
@@ -207,7 +207,65 @@ var _ = Describe("NMState controller reconcile", func() {
 			Expect(anyTolerationsPresent(handlerTolerations, deployment.Spec.Template.Spec.Tolerations)).To(BeFalse())
 		})
 	})
+	Context("when OVS is NOT enabled", func() {
+		var (
+			request ctrl.Request
+		)
+		BeforeEach(func() {
+			s := scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NMState{},
+			)
+			objs := []runtime.Object{&nmstate}
+			// Create a fake client to mock API calls.
+			cl = fake.NewFakeClientWithScheme(s, objs...)
+			reconciler.Client = cl
+			request.Name = existingNMStateName
+			result, err := reconciler.Reconcile(context.Background(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+		It("should not mount host OVS socket at handler", func() {
+			handlerDs := &appsv1.DaemonSet{}
+			handlerKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
+			err := cl.Get(context.TODO(), handlerKey, handlerDs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasOVSSocketMounted(*handlerDs)).To(BeFalse())
+		})
+	})
+	Context("when OVS is enabled", func() {
+		var (
+			request ctrl.Request
+		)
+		BeforeEach(func() {
+			os.Setenv("ENABLE_OVS", "")
+		})
+		BeforeEach(func() {
+			s := scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NMState{},
+			)
+			objs := []runtime.Object{&nmstate}
+			// Create a fake client to mock API calls.
+			cl = fake.NewFakeClientWithScheme(s, objs...)
+			reconciler.Client = cl
+			request.Name = existingNMStateName
+			result, err := reconciler.Reconcile(context.Background(), request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+		AfterEach(func() {
+			os.Unsetenv("ENABLE_OVS")
+		})
 
+		It("should not mount host OVS socket at handler", func() {
+			handlerDs := &appsv1.DaemonSet{}
+			handlerKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
+			err := cl.Get(context.TODO(), handlerKey, handlerDs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasOVSSocketMounted(*handlerDs)).To(BeTrue())
+		})
+	})
 })
 
 func copyManifest(src, dst string) error {
@@ -314,6 +372,31 @@ func isSuperset(ss, t corev1.Toleration) bool {
 	default:
 		return false
 	}
+}
+
+func hasOVSSocketHostPath(ds appsv1.DaemonSet) bool {
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		if v.Name == "ovs-socket" &&
+			v.HostPath != nil &&
+			v.HostPath.Path == "/run/openvswitch/db.sock" &&
+			v.HostPath.Type != nil &&
+			*v.HostPath.Type == corev1.HostPathSocket {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOVSSocketMounted(ds appsv1.DaemonSet) bool {
+	if !hasOVSSocketHostPath(ds) {
+		return false
+	}
+	for _, v := range ds.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if v.Name == "ovs-socket" && v.MountPath == "/run/openvswitch/db.sock" {
+			return true
+		}
+	}
+	return false
 }
 
 //allTolerationsPresent check if all tolerations from toBeCheckedTolerations are superseded by actualTolerations.

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -262,6 +262,10 @@ spec:
               mountPath: /run/dbus/system_bus_socket
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
+{{if .EnableOVS}}
+            - name: ovs-socket
+              mountPath: /run/openvswitch/db.sock
+{{end}}
           securityContext:
             privileged: true
           readinessProbe:
@@ -280,6 +284,12 @@ spec:
         - name: nmstate-lock
           hostPath:
             path: /var/k8s_nmstate
+{{if .EnableOVS}}
+        - name: ovs-socket
+          hostPath:
+            path: /run/openvswitch/db.sock
+            type: Socket
+{{end}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The nmstate OVS functionality depends on the OVS socket to be mounted at
the handler container but this is only possible if OVS is installed at
nodes, this change add optional mount to the handler manifests
controlled by the environment variable ENABLE_OVS on the operator, it
also sets the env variable at the openshift operator dockerfile to have
proper OVS functionality there.

cherry-pick #829

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:


**Special notes for your reviewer**:
cherry-pick #829

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
[release-0.52] Mount OVS socket if needed
```
