### PR TITLE
Fix NodeNetworkState e2e tests to use primary NIC name from environment variable

### DIFF
--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"fmt"
+
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
 	. "github.com/onsi/ginkgo"
@@ -15,15 +17,15 @@ func createInterfaceWithMismatchedName() nmstate.State {
 }
 
 func createInterfaceWithInvalidField() nmstate.State {
-	return nmstate.NewState(`interfaces:
-  - name: eth0
+	return nmstate.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
     type: ethernet
-    invalid_state: up`)
+    invalid_state: up`, primaryNic))
 }
 
 func createInterfaceWithIncorrectIP() nmstate.State {
-	return nmstate.NewState(`interfaces:
-  - name: eth0
+	return nmstate.NewState(fmt.Sprintf(`interfaces:
+  - name: %s
     type: ethernet
     state: up
     ipv4:
@@ -31,7 +33,7 @@ func createInterfaceWithIncorrectIP() nmstate.State {
       - ip: "192.168.45.33"
         prefix-length: 24
       dhcp: false
-      enabled: true`)
+      enabled: true`, primaryNic))
 }
 
 func createPolicyAndWaitForEnactmentCondition(policy string, desiredState func() nmstate.State, nodeHostname string) {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind enhancement

**What this PR does / why we need it**:
Fixes the e2e tests of NodeNetworkState to use the primary NIC configured via env vars instead of hard coded interface name. Hard coding the interface name can cause issues, if the primary NIC isn't named `eth0` (as done in http://github.com/openshift/kubernetes-nmstate):

```
• Failure [5.086 seconds]
NodeNetworkState
kubernetes-nmstate/test/e2e/handler/error_messages_formatting_test.go:51
  with invalid field
  kubernetes-nmstate/test/e2e/handler/error_messages_formatting_test.go:67
    should keep desired parts of the message [It]
    kubernetes-nmstate/test/e2e/handler/error_messages_formatting_test.go:87

    Expected
        <string>: error reconciling NodeNetworkConfigurationPolicy at desired state apply: ,
        failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1'
        libnmstate.error.NmstateLibnmError
          Activate profile uuid:99eefc3b-362f-4209-b9a6-ee141ba01e5e iface:eth0 type
            ethernet failed
              error=nm-manager-error-quark
                No suitable device found for this connection (device enp1s0 not available because profile is not compatible with device (mismatching interface name)). (3)
        
    to contain substring
        <string>: libnmstate.error.NmstateVerificationError

```

**Release note**:
```release-note
NONE
```
