### PR TITLE
Show DNS Resolver in NNS

### DIFF
--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -341,4 +341,32 @@ routes:
 		})
 	})
 
+	Context("With DNS Resolver populated", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`interfaces:
+  - name: eth1
+    state: up
+    type: ethernet
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 8.8.8.8
+  running:
+    search:
+    - example.running.com
+    - example.running.org
+    server:
+    - 8.8.4.4`)
+		})
+
+		It("Should keep the DNS Resolver intact", func() {
+			returnedState, err := filterOut(state, ifaceStates)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(state))
+		})
+	})
 })

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -3,12 +3,14 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+
 	"sigs.k8s.io/yaml"
 )
 
 type rootState struct {
-	Interfaces []interfaceState `json:"interfaces" yaml:"interfaces"`
-	Routes     *routesState     `json:"routes,omitempty" yaml:"routes,omitempty"`
+	Interfaces  []interfaceState `json:"interfaces" yaml:"interfaces"`
+	Routes      *routesState     `json:"routes,omitempty" yaml:"routes,omitempty"`
+	DnsResolver *dnsResolver     `json:"dns-resolver,omitempty" yaml:"dns-resolver,omitempty"`
 }
 
 type routesState struct {
@@ -19,6 +21,16 @@ type routesState struct {
 type interfaceState struct {
 	interfaceFields `yaml:",inline"`
 	Data            map[string]interface{}
+}
+
+type dnsResolver struct {
+	Config  *DnsResolverData `json:"config,omitempty" yaml:"config,omitempty"`
+	Running *DnsResolverData `json:"running,omitempty" yaml:"running,omitempty"`
+}
+
+type DnsResolverData struct {
+	Search []interface{} `json:"search" yaml:"search"`
+	Server []interface{} `json:"server" yaml:"server"`
 }
 
 // interfaceFields allows unmarshaling directly into the defined fields


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

DNS Resolver is not included in NodeNetworkState, adding types to marshal/unmarshal
DNS data and include it in the NNS as well.

**Special notes for your reviewer**:

**Release note**:


```release-note
Show dns-resolver in NodeNetworkState
```
