### PR TITLE
Fix handler e2e test interface cleanups

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -68,6 +68,7 @@ var _ = BeforeSuite(func() {
 	nodeList := corev1.NodeList{}
 	filterWorkers := client.MatchingLabels{"node-role.kubernetes.io/worker": ""}
 	err = testenv.Client.List(context.TODO(), &nodeList, filterWorkers)
+	Expect(err).ToNot(HaveOccurred())
 	for _, node := range nodeList.Items {
 		if containsNode(allNodes, node.Name) {
 			nodes = append(nodes, node.Name)

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -67,14 +67,12 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 	})
 	Context("when network configuration is changed by a NNCP", func() {
 		BeforeEach(func() {
-			// We want to test all the NNS so we apply policies to control-plane and workers
-			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrUp(bridge1))
+			// We want to test all the NNS so we apply policies to control-plane and workers (use linuxBrUpNoPorts to not affect the nodes secondary interfaces state)
+			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrUpNoPorts(bridge1))
 			waitForAvailableTestPolicy()
 		})
 		AfterEach(func() {
 			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
-			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, resetPrimaryAndSecondaryNICs())
 			waitForAvailableTestPolicy()
 			deletePolicy(TestPolicy)
 		})

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -29,7 +29,8 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	Context("when policy is set with node selector not matching any nodes", func() {
 		BeforeEach(func() {
 			Byf("Set policy %s with not matching node selector", bridge1)
-			setDesiredStateWithPolicyAndNodeSelectorEventually(bridge1, linuxBrUp(bridge1), testNodeSelector)
+			// use linuxBrUpNoPorts to not affect the nodes secondary interfaces state
+			setDesiredStateWithPolicyAndNodeSelectorEventually(bridge1, linuxBrUpNoPorts(bridge1), testNodeSelector)
 			waitForAvailablePolicy(bridge1)
 		})
 
@@ -38,12 +39,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrAbsent(bridge1))
 			waitForAvailablePolicy(bridge1)
 			deletePolicy(bridge1)
-			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, resetPrimaryAndSecondaryNICs())
-			waitForAvailableTestPolicy()
-			deletePolicy(TestPolicy)
-
-			By("Remove test label from node")
-			removeLabelsFromNode(nodes[0], testNodeSelector)
 		})
 
 		It("[test_id:3813]should not update any nodes and have not enactments", func() {
@@ -56,7 +51,8 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		Context("and we remove the node selector", func() {
 			BeforeEach(func() {
 				Byf("Remove node selector at policy %s", bridge1)
-				setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrUp(bridge1))
+				// use linuxBrUpNoPorts to not affect the nodes secondary interfaces state
+				setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrUpNoPorts(bridge1))
 				waitForAvailablePolicy(bridge1)
 			})
 
@@ -76,6 +72,10 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				//TODO: Remove this when webhook retest policy status when node labels are changed
 				time.Sleep(3 * time.Second)
 				waitForAvailablePolicy(bridge1)
+			})
+			AfterEach(func() {
+				By("Remove test label from node")
+				removeLabelsFromNode(nodes[0], testNodeSelector)
 			})
 			It("should apply the policy", func() {
 				By("Check that NNCE is created")


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind enhancement

**What this PR does / why we need it**:

_tl;dr_: Updates some e2e tests to cleanup only the NICs which got changed during the test.

For the E2E tests of the handler, the primary and both secondary interfaces are only reset on **worker** nodes before the suite starts: https://github.com/nmstate/kubernetes-nmstate/blob/621d3fc9b3ec50a6765b00af379272a9e5c7d495/test/e2e/handler/main_test.go#L77 and https://github.com/nmstate/kubernetes-nmstate/blob/621d3fc9b3ec50a6765b00af379272a9e5c7d495/test/e2e/handler/utils.go#L107-L110
 
The `AfterEach()` function for the whole suite, checks that the interfaces matches the state before the tests are run (compares with the state collected in the `BeforeEach()`): 
https://github.com/nmstate/kubernetes-nmstate/blob/621d3fc9b3ec50a6765b00af379272a9e5c7d495/test/e2e/handler/main_test.go#L113-L121

Some e2e tests call the `resetPrimaryAndSecondaryNICs()` on all nodes (including control-plane nodes). For example see line 41 in:
https://github.com/nmstate/kubernetes-nmstate/blob/621d3fc9b3ec50a6765b00af379272a9e5c7d495/test/e2e/handler/node_selector_test.go#L36-L47

This can cause issues, if the secondary interfaces on the control-plane nodes have been in state `UP` before the suite started, which will cause the suite to fail. Check the following scenario:

1. control-plane node has firstSecondaryNic state set to up
2. E2E test suite starts
3. Before each test, in the BeforeEach(), the current state of control-planes NICs are saved for later comparison
4. The test "cleans up" all interfaces by calling `setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, resetPrimaryAndSecondaryNICs())`, which sets control-plane node has firstSecondaryNic state set to down (as done for all nodes)
5. The AfterEach defined for the suite compares the state before the test (collected in 3.) with the current state and fails, as the firstSecondaryNic state is now set to down (done in 4.)

This is only an issue, in case the environment against which the E2E tests run, has the firstSecondaryNic and secondSecondaryNic state set to up initially (which e.g. is the case for OCP). Anyhow the tests should clean it up / reset the environment correctly.

This PR addresses this and fixes the tests to clean up properly.

**Special Notes for Reviewers:**
1. In cases where tests should run on each node (including control-plane), e.g. https://github.com/nmstate/kubernetes-nmstate/blob/621d3fc9b3ec50a6765b00af379272a9e5c7d495/test/e2e/handler/nns_update_timestamp_test.go#L68-L91
    I adjusted the test to use a policy which does not affect the nodes secondary NICs (in this case this was possible, by using `linuxBrUpNoPorts()` instead of `linuxBrUp()`).
2. Alternatively to updating the tests, a `resetDesiredStateForControlPlaneNodes()` could have been implemented and called in the `BeforeSuite()` so even the secondaryNics of the control-plane nodes would be "reset", but imo each test should clean up correctly.

**Release note**:
```release-note
NONE
```