### PR TITLE
Fix bond name creation in e2e tests

### DIFF
--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -37,7 +37,7 @@ const TestPolicy = "test-policy"
 
 var (
 	bridgeCounter  = 0
-	bondConunter   = 0
+	bondCounter    = 0
 	maxUnavailable = environment.GetVarWithDefault("NMSTATE_MAX_UNAVAILABLE", nmstatenode.DEFAULT_MAXUNAVAILABLE)
 )
 
@@ -469,8 +469,8 @@ func nextBridge() string {
 }
 
 func nextBond() string {
-	bridgeCounter++
-	return fmt.Sprintf("bond%d", bondConunter)
+	bondCounter++
+	return fmt.Sprintf("bond%d", bondCounter)
 }
 
 func currentStateJSON(node string) []byte {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Fixes the bond name creation in the e2e tests.

**Release note**:
```release-note
NONE
```
