### PR TITLE
Set NNCP Degraded as soon as first enactment fails

### DIFF
--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -3,6 +3,7 @@ package policyconditions
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -139,19 +140,17 @@ func update(apiWriter client.Client, apiReader client.Reader, policyReader clien
 		if numberOfNmstateMatchingNodes == 0 {
 			message := "Policy does not match any node"
 			SetPolicyNotMatching(&policy.Status.Conditions, message)
+		} else if enactmentsCountByCondition.Failed() > 0 || enactmentsCountByCondition.Aborted() > 0 {
+			message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCountByCondition.Failed(), numberOfNmstateMatchingNodes)
+			if enactmentsCountByCondition.Aborted() > 0 {
+				message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCountByCondition.Aborted())
+			}
+			SetPolicyFailedToConfigure(&policy.Status.Conditions, message)
 		} else if numberOfFinishedEnactments < numberOfNmstateMatchingNodes {
 			SetPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateMatchingNodes))
 		} else {
-			if enactmentsCountByCondition.Failed() > 0 || enactmentsCountByCondition.Aborted() > 0 {
-				message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCountByCondition.Failed(), numberOfNmstateMatchingNodes)
-				if enactmentsCountByCondition.Aborted() > 0 {
-					message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCountByCondition.Aborted())
-				}
-				SetPolicyFailedToConfigure(&policy.Status.Conditions, message)
-			} else {
-				message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCountByCondition.Available(), enactmentsCountByCondition.Available())
-				SetPolicySuccess(&policy.Status.Conditions, message)
-			}
+			message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCountByCondition.Available(), enactmentsCountByCondition.Available())
+			SetPolicySuccess(&policy.Status.Conditions, message)
 		}
 
 		err = apiWriter.Status().Update(context.TODO(), policy)

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Policy Conditions", func() {
 			Pods:   newNmstatePods(3),
 			Policy: p(SetPolicyProgressing, "Policy is progressing 2/3 nodes finished"),
 		}),
-		Entry("when enactments are failed/progressing/success then policy is progressing", ConditionsCase{
+		Entry("when enactments are failed/progressing/success then policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
 				e("node1", "policy1", enactmentconditions.SetSuccess),
 				e("node2", "policy1", enactmentconditions.SetProgressing),
@@ -219,7 +219,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
-			Policy: p(SetPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
+			Policy: p(SetPolicyFailedToConfigure, "1/4 nodes failed to configure"),
 		}),
 		Entry("when all the enactments are at failing or success policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{


### PR DESCRIPTION
Don't wait for all enactments to finish, set the Degraded
condition as soon as first Failing enactment appears.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Set NNCP Degraded condition as soon as first Failing enactment appears 
```
