### PR TITLE
Fix typos in User Guide

### DIFF
--- a/docs/user-guide/102-configuration.md
+++ b/docs/user-guide/102-configuration.md
@@ -175,7 +175,7 @@ status:
 
 The output contains the `desiredState` applied by the Policy for the given Node.
 It also contains a list of conditions. This list is more detailed than the one
-in Policy. It shows whether the limit of unavailable nods was reached so the
+in Policy. It shows whether the limit of unavailable nodes was reached so the
 node has to wait for other nodes to finish applying network configuration
 (`Pending`), if the `desiredState` is currently being applied on the node
 (`Progressing`), if the configuration failed (`Failing`) or succeeded
@@ -402,7 +402,7 @@ status:
 ## Selecting nodes
 
 All the Policies we used so far were applied on all nodes across the cluster. It
-is however possible to select only a subset of nodes using via a node selector.
+is however possible to select only a subset of nodes using a node selector.
 
 In the following example, we configure a VLAN interface with tag 100 over a NIC
 `eth1`. This configuration will be done only on node which has labels matching

--- a/docs/user-guide/103-troubleshooting.md
+++ b/docs/user-guide/103-troubleshooting.md
@@ -13,11 +13,11 @@ the operator protect the user from breaking the cluster networking.
 If any of the following cases render the configuration faulty, the setup will be
 automatically rolled back and Enactment will report the failure.
 
-* Configuration fails to be applied on the host (due missing interfaces, inability to obtain IP, invalid attributes, ...)
+* Configuration fails to be applied on the host (due to missing interfaces, inability to obtain IP, invalid attributes, ...)
 * Connectivity to the default gateway is broken
 * Connectivity to the API server is broken
 
-In the following example, we will create a Policy configuring and unavailable
+In the following example, we will create a Policy configuring an unavailable
 interface and observe the results:
 
 <!-- When updating following example, don't forget to update respective attached file -->


### PR DESCRIPTION
There were minor typos in NMState User Guide, which are now fixed.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
