### PR TITLE
Fix inaccuracy in NMState documentation

### DIFF
--- a/api/v1/nmstate_types.go
+++ b/api/v1/nmstate_types.go
@@ -41,7 +41,7 @@ type NMStateSpec struct {
 	// +optional
 	InfraNodeSelector map[string]string `json:"infraNodeSelector,omitempty"`
 	// InfraTolerations is an optional list of tolerations to be added to webhook & certmanager Deployment manifests
-	// If InfraTolerations is specified, the handler daemonset will be able to be scheduled on nodes with corresponding taints
+	// If InfraTolerations is specified, the webhook and certmanager will be able to be scheduled on nodes with corresponding taints
 	// +optional
 	InfraTolerations []corev1.Toleration `json:"infraTolerations,omitempty"`
 }

--- a/api/v1beta1/nmstate_types.go
+++ b/api/v1beta1/nmstate_types.go
@@ -40,7 +40,7 @@ type NMStateSpec struct {
 	// +optional
 	InfraNodeSelector map[string]string `json:"infraNodeSelector,omitempty"`
 	// InfraTolerations is an optional list of tolerations to be added to webhook & certmanager Deployment manifests
-	// If InfraTolerations is specified, the handler daemonset will be able to be scheduled on nodes with corresponding taints
+	// If InfraTolerations is specified, the webhook and certmanager will be able to be scheduled on nodes with corresponding taints
 	// +optional
 	InfraTolerations []corev1.Toleration `json:"infraTolerations,omitempty"`
 }

--- a/deploy/crds/nmstate.io_nmstates.yaml
+++ b/deploy/crds/nmstate.io_nmstates.yaml
@@ -48,7 +48,7 @@ spec:
               infraTolerations:
                 description: InfraTolerations is an optional list of tolerations to
                   be added to webhook & certmanager Deployment manifests If InfraTolerations
-                  is specified, the handler daemonset will be able to be scheduled
+                  is specified, the webhook and certmanager will be able to be scheduled
                   on nodes with corresponding taints
                 items:
                   description: The pod this Toleration is attached to tolerates any
@@ -206,7 +206,7 @@ spec:
               infraTolerations:
                 description: InfraTolerations is an optional list of tolerations to
                   be added to webhook & certmanager Deployment manifests If InfraTolerations
-                  is specified, the handler daemonset will be able to be scheduled
+                  is specified, the webhook and certmanager will be able to be scheduled
                   on nodes with corresponding taints
                 items:
                   description: The pod this Toleration is attached to tolerates any


### PR DESCRIPTION
InfraTolerations and InfraNodeSelector are related to webhook and certmanager, not handler

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
