### PR TITLE
Fix issue with missing vlans after upgrade

### DIFF
--- a/pkg/helper/bridges.go
+++ b/pkg/helper/bridges.go
@@ -1,14 +1,19 @@
 package helper
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	yaml "sigs.k8s.io/yaml"
 
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 )
 
 var defaultVlanFiltering = map[string]interface{}{
@@ -50,6 +55,85 @@ func ApplyDefaultVlanFiltering(desiredState nmstate.State) (nmstate.State, error
 		return desiredState, err
 	}
 	return nmstate.State{Raw: resultYaml}, nil
+}
+
+func EnableVlanFiltering() (string, error) {
+	currentState, err := nmstatectl.Show()
+	if err != nil {
+		return "failed to get currentState", err
+	}
+	upBridgesWithPorts, err := GetUpLinuxBridgesWithPorts(shared.NewState(currentState))
+	if err != nil {
+		return "failed to list bridges with ports", err
+	}
+	out, err := enableVlanFiltering(upBridgesWithPorts)
+	if err != nil {
+		return fmt.Sprintf("failed to enable vlan-filtering via nmcli: %s", out), err
+	}
+	return "", nil
+}
+
+func GetUpLinuxBridgesWithPorts(desiredState nmstate.State) (map[string][]string, error) {
+	bridgesWithPorts := map[string][]string{}
+
+	result, err := yaml.YAMLToJSON(desiredState.Raw)
+	if err != nil {
+		return bridgesWithPorts, fmt.Errorf("error converting desiredState to JSON: %v", err)
+	}
+
+	ifaces := gjson.ParseBytes(result).Get("interfaces").Array()
+	for _, iface := range ifaces {
+		if !isLinuxBridgeUp(iface) {
+			continue
+		}
+		for _, port := range iface.Get("bridge.port").Array() {
+			if hasVlanConfiguration(port) {
+				continue
+			}
+			bridgeName := iface.Get("name").String()
+			bridgesWithPorts[bridgeName] = append(bridgesWithPorts[bridgeName], port.Get("name").String())
+		}
+	}
+	return bridgesWithPorts, nil
+}
+
+func enableVlanFiltering(upBridgesWithPorts map[string][]string) (string, error) {
+	for bridge, ports := range upBridgesWithPorts {
+		out, err := enableBridgeVlanFiltering(bridge)
+		if err != nil {
+			return out, err
+		}
+		for _, port := range ports {
+			out, err = enableBridgPortVlans(port)
+			if err != nil {
+				return out, err
+			}
+		}
+	}
+	return "", nil
+}
+
+func enableBridgeVlanFiltering(bridgeName string) (string, error) {
+	command := "nmcli"
+	args := []string{"con", "mod", bridgeName, "bridge.vlan-filtering", "yes"}
+	return runCommand(command, args)
+}
+
+func enableBridgPortVlans(port string) (string, error) {
+	command := "nmcli"
+	args := []string{"con", "mod", port, "bridge-port.vlans", "2-4094"}
+	return runCommand(command, args)
+}
+
+func runCommand(command string, args []string) (string, error) {
+	cmd := exec.Command(command, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to execute %s %s: '%v', '%s', '%s'", command, strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), nil
 }
 
 func isLinuxBridgeUp(iface gjson.Result) bool {

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -129,6 +129,11 @@ func ApplyDesiredState(client client.Client, desiredState shared.State) (string,
 		return "Ignoring empty desired state", nil
 	}
 
+	out, err := EnableVlanFiltering()
+	if err != nil {
+		return out, fmt.Errorf("failed to enable vlan filtering via nmcli: %s", err.Error())
+	}
+
 	// Before apply we get the probes that are working fine, they should be
 	// working fine after apply
 	probes := probe.Select(client)


### PR DESCRIPTION
When upgrading from an older knmstate version that uses
vlan-filtering script to a version relying on nmstate
API, nmstate fails on verification when reconciling
bridge with ports configured by the older knmstate
version.

This change applies the vlans using nmcli, so that
there is no discrepancy between kernel and NM configuration.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix issue with missing vlans on linux-bridge ports after upgrade from older versions
```
