### PR TITLE
[Release 0.47] Fix issue with missing vlans after upgrade

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -33,7 +33,7 @@ main() {
 
     export E2E_TEST_SUITE_ARGS="--junit-output=$ARTIFACTS/junit.functest.xml"
 
-    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="-noColor" test-e2e-handler
+    make E2E_TEST_TIMEOUT=80m E2E_TEST_ARGS="-noColor" test-e2e-handler
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/pkg/helper/bridges.go
+++ b/pkg/helper/bridges.go
@@ -1,14 +1,19 @@
 package helper
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	yaml "sigs.k8s.io/yaml"
 
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 )
 
 var defaultVlanFiltering = map[string]interface{}{
@@ -50,6 +55,85 @@ func ApplyDefaultVlanFiltering(desiredState nmstate.State) (nmstate.State, error
 		return desiredState, err
 	}
 	return nmstate.State{Raw: resultYaml}, nil
+}
+
+func EnableVlanFiltering() (string, error) {
+	currentState, err := nmstatectl.Show()
+	if err != nil {
+		return "failed to get currentState", err
+	}
+	upBridgesWithPorts, err := GetUpLinuxBridgesWithPorts(shared.NewState(currentState))
+	if err != nil {
+		return "failed to list bridges with ports", err
+	}
+	out, err := enableVlanFiltering(upBridgesWithPorts)
+	if err != nil {
+		return fmt.Sprintf("failed to enable vlan-filtering via nmcli: %s", out), err
+	}
+	return "", nil
+}
+
+func GetUpLinuxBridgesWithPorts(desiredState nmstate.State) (map[string][]string, error) {
+	bridgesWithPorts := map[string][]string{}
+
+	result, err := yaml.YAMLToJSON(desiredState.Raw)
+	if err != nil {
+		return bridgesWithPorts, fmt.Errorf("error converting desiredState to JSON: %v", err)
+	}
+
+	ifaces := gjson.ParseBytes(result).Get("interfaces").Array()
+	for _, iface := range ifaces {
+		if !isLinuxBridgeUp(iface) {
+			continue
+		}
+		for _, port := range iface.Get("bridge.port").Array() {
+			if hasVlanConfiguration(port) {
+				continue
+			}
+			bridgeName := iface.Get("name").String()
+			bridgesWithPorts[bridgeName] = append(bridgesWithPorts[bridgeName], port.Get("name").String())
+		}
+	}
+	return bridgesWithPorts, nil
+}
+
+func enableVlanFiltering(upBridgesWithPorts map[string][]string) (string, error) {
+	for bridge, ports := range upBridgesWithPorts {
+		out, err := enableBridgeVlanFiltering(bridge)
+		if err != nil {
+			return out, err
+		}
+		for _, port := range ports {
+			out, err = enableBridgPortVlans(port)
+			if err != nil {
+				return out, err
+			}
+		}
+	}
+	return "", nil
+}
+
+func enableBridgeVlanFiltering(bridgeName string) (string, error) {
+	command := "nmcli"
+	args := []string{"con", "mod", bridgeName, "bridge.vlan-filtering", "yes"}
+	return runCommand(command, args)
+}
+
+func enableBridgPortVlans(port string) (string, error) {
+	command := "nmcli"
+	args := []string{"con", "mod", port, "bridge-port.vlans", "2-4094"}
+	return runCommand(command, args)
+}
+
+func runCommand(command string, args []string) (string, error) {
+	cmd := exec.Command(command, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to execute %s %s: '%v', '%s', '%s'", command, strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), nil
 }
 
 func isLinuxBridgeUp(iface gjson.Result) bool {

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -103,6 +103,11 @@ func ApplyDesiredState(client client.Client, desiredState shared.State) (string,
 		return "Ignoring empty desired state", nil
 	}
 
+	out, err := EnableVlanFiltering()
+	if err != nil {
+		return out, fmt.Errorf("failed to enable vlan filtering via nmcli: %s", err.Error())
+	}
+
 	// Before apply we get the probes that are working fine, they should be
 	// working fine after apply
 	probes := probe.Select(client)


### PR DESCRIPTION
Backport of https://github.com/nmstate/kubernetes-nmstate/pull/891

When upgrading from an older knmstate version that uses
vlan-filtering script to a version relying on nmstate
API, nmstate fails on verification when reconciling
bridge with ports configured by the older knmstate
version.

This change applies the vlans using nmcli, so that
there is no discrepancy between kernel and NM configuration.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix issue with missing vlans on linux-bridge ports after upgrade from older versions
```
