### PR TITLE
[Release 0.52] Set NNCP Degraded as soon as first enactment fails

### DIFF
--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Policy Conditions", func() {
 			Pods:   newNmstatePods(3),
 			Policy: p(SetPolicyProgressing, "Policy is progressing 2/3 nodes finished"),
 		}),
-		Entry("when enactments are failed/progressing/success then policy is progressing", ConditionsCase{
+		Entry("when enactments are failed/progressing/success then policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
 				e("node1", "policy1", enactmentconditions.SetSuccess),
 				e("node2", "policy1", enactmentconditions.SetProgressing),
@@ -216,7 +216,7 @@ var _ = Describe("Policy Conditions", func() {
 			},
 			Nodes:  newNodes(4),
 			Pods:   newNmstatePods(4),
-			Policy: p(SetPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
+			Policy: p(SetPolicyFailedToConfigure, "1/4 nodes failed to configure"),
 		}),
 		Entry("when all the enactments are at failing or success policy is degraded", ConditionsCase{
 			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -118,14 +118,28 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(abortedConditions).To(Equal(len(nodes)-failingConditions), "other nodes should have aborted enactment")
 			}
 
+			By("Wait for enactments to reach failing or aborted state")
+			var wg sync.WaitGroup
+			wg.Add(len(nodes))
+			for i, _ := range nodes {
+				node := nodes[i]
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					By(fmt.Sprintf("Check %s failing state is kept", node))
+					enactmentConditionsStatusEventually(node).Should(
+						SatisfyAny(
+							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
+							matchConditionsFrom(enactmentconditions.SetConfigurationAborted),
+						), "should consistently keep failing or aborted conditions at enactments")
+				}()
+			}
+			wg.Wait()
+
 			By("Check policy is at degraded state")
 			waitForDegradedTestPolicy()
 
-			By("Check there is one failing enactment and the rest are aborted")
-			checkEnactmentCounts(TestPolicy)
-
-			By("Check that the enactment stays in failing or aborted state")
-			var wg sync.WaitGroup
+			By("Check that the enactments stay in failing or aborted state")
 			wg.Add(len(nodes))
 			for i, _ := range nodes {
 				node := nodes[i]
@@ -142,8 +156,30 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}
 			wg.Wait()
 
-			By("Check there is still one failing enactment and the rest are aborted")
+			By("Check there is up to maxUnavailable failing enactments and the rest are aborted")
 			checkEnactmentCounts(TestPolicy)
+		})
+
+		It("should mark policy as Degraded as soon as first enactment fails", func() {
+			failingEnactmentsCount := func(policy string) int {
+				failingConditions := 0
+				for _, node := range nodes {
+					conditionList := enactmentConditionsStatus(node, TestPolicy)
+					found, _ := matchConditionsFrom(enactmentconditions.SetFailedToConfigure).Match(conditionList)
+					if found {
+						failingConditions++
+					}
+				}
+				return failingConditions
+			}
+
+			By("Waiting for first enactment to fail")
+			Eventually(func() int {
+				return failingEnactmentsCount(TestPolicy)
+			}).Should(BeNumerically(">=", 1))
+
+			By("Checking the policy is marked as Degraded")
+			Expect(policyConditionsStatus(TestPolicy)).Should(containPolicyDegraded(), "policy should be marked as Degraded")
 		})
 	})
 })


### PR DESCRIPTION
Cherry-pick of https://github.com/nmstate/kubernetes-nmstate/pull/877
Don't wait for all enactments to finish, set the Degraded
condition as soon as first Failing enactment appears.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
Set NNCP Degraded condition as soon as first Failing enactment appears 
```
