### PR TITLE
Intergrate nmpolicy

### DIFF
--- a/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/api/shared/nodenetworkconfigurationenactment_types.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -13,10 +14,27 @@ type NodeNetworkConfigurationEnactmentStatus struct {
 	// the policy desiredState as template
 	DesiredState State `json:"desiredState,omitempty"`
 
+	DesiredStateMetaInfo NodeNetworkConfigurationEnactmentMetaInfo `json:"desiredStateMetaInfo,omitempty"`
+
+	// A cache containing the resolved captures after processing the capture at NNCP
+	CapturedStates map[string]NodeNetworkConfigurationEnactmentCapturedState `json:"capturedStates,omitempty"`
+
 	// The generation from policy needed to check if an enactment
 	// condition status belongs to the same policy version
-	PolicyGeneration int64         `json:"policyGeneration,omitempty"`
-	Conditions       ConditionList `json:"conditions,omitempty"`
+	PolicyGeneration int64 `json:"policyGeneration,omitempty"`
+
+	Conditions ConditionList `json:"conditions,omitempty"`
+}
+
+type NodeNetworkConfigurationEnactmentCapturedState struct {
+	// +kubebuilder:validation:XPreserveUnknownFields
+	State    State                                     `json:"state,omitempty"`
+	MetaInfo NodeNetworkConfigurationEnactmentMetaInfo `json:"metaInfo,omitempty"`
+}
+
+type NodeNetworkConfigurationEnactmentMetaInfo struct {
+	Version   string      `json:"version,omitempty"`
+	TimeStamp metav1.Time `json:"time,omitempty"`
 }
 
 const (

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -13,6 +13,11 @@ type NodeNetworkConfigurationPolicySpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// Capture contains expressions with an associated name than can be referenced
+	// at the DesiredState.
+	// +optional
+	Capture map[string]string `json:"capture,omitempty"`
+
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// The desired configuration of the policy
 	DesiredState State `json:"desiredState,omitempty"`

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -52,6 +52,7 @@ import (
 	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
 	"github.com/nmstate/kubernetes-nmstate/pkg/environment"
 	nmstate "github.com/nmstate/kubernetes-nmstate/pkg/helper"
+	"github.com/nmstate/kubernetes-nmstate/pkg/nmpolicy"
 	"github.com/nmstate/kubernetes-nmstate/pkg/node"
 	"github.com/nmstate/kubernetes-nmstate/pkg/policyconditions"
 	"github.com/nmstate/kubernetes-nmstate/pkg/probe"
@@ -288,9 +289,19 @@ func (r *NodeNetworkConfigurationPolicyReconciler) initializeEnactment(policy nm
 		enactmentConditions := enactmentconditions.New(r.APIClient, enactmentKey)
 		enactmentConditions.Reset()
 	}
+	nns, err := r.readNNS(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	capturedStates, desiredStateMetaInfo, desiredState, err := nmpolicy.GenerateState(desiredStateWithDefaults, policy.Spec, nns.Status.CurrentState, enactment.Status.CapturedStates)
+	if err != nil {
+		return nil, err
+	}
 
 	return &enactment.Status.Conditions, enactmentstatus.Update(r.APIClient, enactmentKey, func(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus) {
-		status.DesiredState = desiredStateWithDefaults
+		status.DesiredState = desiredState
+		status.DesiredStateMetaInfo = desiredStateMetaInfo
+		status.CapturedStates = capturedStates
 		status.PolicyGeneration = policy.Generation
 	})
 }
@@ -399,8 +410,7 @@ func tryDecrementingUnavailableNodeCount(statusWriterClient client.StatusClient,
 func (r *NodeNetworkConfigurationPolicyReconciler) forceNNSRefresh(name string) {
 	log := r.Log.WithName("forceNNSRefresh").WithValues("node", name)
 	log.Info("forcing NodeNetworkState refresh after NNCP applied")
-	nns := &nmstatev1beta1.NodeNetworkState{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name}, nns)
+	nns, err := r.readNNS(name)
 	if err != nil {
 		log.WithValues("error", err).Info("WARNING: failed retrieving NodeNetworkState to force refresh, it will be refreshed after regular period")
 		return
@@ -414,4 +424,13 @@ func (r *NodeNetworkConfigurationPolicyReconciler) forceNNSRefresh(name string) 
 	if err != nil {
 		log.WithValues("error", err).Info("WARNING: failed forcing NNS refresh, it will be refreshed after regular period")
 	}
+}
+
+func (r *NodeNetworkConfigurationPolicyReconciler) readNNS(name string) (*nmstatev1beta1.NodeNetworkState, error) {
+	nns := &nmstatev1beta1.NodeNetworkState{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name}, nns)
+	if err != nil {
+		return nil, err
+	}
+	return nns, nil
 }

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -81,6 +82,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 			reconciler := NodeNetworkConfigurationPolicyReconciler{}
 			s := scheme.Scheme
 			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NodeNetworkState{},
 				&nmstatev1beta1.NodeNetworkConfigurationEnactment{},
 				&nmstatev1beta1.NodeNetworkConfigurationEnactmentList{},
 			)
@@ -93,6 +95,13 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 					Name: nodeName,
 				},
 			}
+
+			nns := nmstatev1beta1.NodeNetworkState{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+
 			nncp := nmstatev1.NodeNetworkConfigurationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -111,7 +120,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 			// simulate NNCE existnce/non-existence by setting conditions
 			c.previousEnactmentConditions(&nnce.Status.Conditions, "")
 
-			objs := []runtime.Object{&nncp, &nnce, &node}
+			objs := []runtime.Object{&nncp, &nnce, &nns, &node}
 
 			// Create a fake client to mock API calls.
 			clb := fake.ClientBuilder{}

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
@@ -46,6 +46,27 @@ spec:
             description: NodeNetworkConfigurationEnactmentStatus defines the observed
               state of NodeNetworkConfigurationEnactment
             properties:
+              capturedStates:
+                additionalProperties:
+                  properties:
+                    metaInfo:
+                      properties:
+                        time:
+                          format: date-time
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    state:
+                      description: "State contains the namestatectl yaml [1] as string
+                        instead of golang struct so we don't need to be in sync with
+                        the schema. \n [1] https://github.com/nmstate/nmstate/blob/base/libnmstate/schemas/operational-state.yaml"
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: A cache containing the resolved captures after processing
+                  the capture at NNCP
+                type: object
               conditions:
                 items:
                   properties:
@@ -75,6 +96,14 @@ spec:
                   the policy desiredState as template
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              desiredStateMetaInfo:
+                properties:
+                  time:
+                    format: date-time
+                    type: string
+                  version:
+                    type: string
+                type: object
               policyGeneration:
                 description: The generation from policy needed to check if an enactment
                   condition status belongs to the same policy version
@@ -113,6 +142,27 @@ spec:
             description: NodeNetworkConfigurationEnactmentStatus defines the observed
               state of NodeNetworkConfigurationEnactment
             properties:
+              capturedStates:
+                additionalProperties:
+                  properties:
+                    metaInfo:
+                      properties:
+                        time:
+                          format: date-time
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    state:
+                      description: "State contains the namestatectl yaml [1] as string
+                        instead of golang struct so we don't need to be in sync with
+                        the schema. \n [1] https://github.com/nmstate/nmstate/blob/base/libnmstate/schemas/operational-state.yaml"
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: A cache containing the resolved captures after processing
+                  the capture at NNCP
+                type: object
               conditions:
                 items:
                   properties:
@@ -142,6 +192,14 @@ spec:
                   the policy desiredState as template
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              desiredStateMetaInfo:
+                properties:
+                  time:
+                    format: date-time
+                    type: string
+                  version:
+                    type: string
+                type: object
               policyGeneration:
                 description: The generation from policy needed to check if an enactment
                   condition status belongs to the same policy version

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -45,6 +45,12 @@ spec:
             description: NodeNetworkConfigurationPolicySpec defines the desired state
               of NodeNetworkConfigurationPolicy
             properties:
+              capture:
+                additionalProperties:
+                  type: string
+                description: Capture contains expressions with an associated name
+                  than can be referenced at the DesiredState.
+                type: object
               desiredState:
                 description: The desired configuration of the policy
                 type: object
@@ -135,6 +141,12 @@ spec:
             description: NodeNetworkConfigurationPolicySpec defines the desired state
               of NodeNetworkConfigurationPolicy
             properties:
+              capture:
+                additionalProperties:
+                  type: string
+                description: Capture contains expressions with an associated name
+                  than can be referenced at the DesiredState.
+                type: object
               desiredState:
                 description: The desired configuration of the policy
                 type: object
@@ -225,6 +237,12 @@ spec:
             description: NodeNetworkConfigurationPolicySpec defines the desired state
               of NodeNetworkConfigurationPolicy
             properties:
+              capture:
+                additionalProperties:
+                  type: string
+                description: Capture contains expressions with an associated name
+                  than can be referenced at the DesiredState.
+                type: object
               desiredState:
                 description: The desired configuration of the policy
                 type: object

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
+	github.com/nmstate/nmpolicy v0.1.0-alpha.3
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1174,6 +1174,16 @@ github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86w
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nmstate/nmpolicy v0.0.0-20211104121538-bce7aa71e17c h1:r3b7sxKeW1la+wMCfd4q8Z7eFFf+xMP+ZbW/oMmQTLg=
+github.com/nmstate/nmpolicy v0.0.0-20211104121538-bce7aa71e17c/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
+github.com/nmstate/nmpolicy v0.0.0-20211118114510-24193b65a736 h1:m+kXkBA6SZBHgmxf0LnIjtCQu4KEPU59KZcPJXhVY20=
+github.com/nmstate/nmpolicy v0.0.0-20211118114510-24193b65a736/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
+github.com/nmstate/nmpolicy v0.1.0-alpha.1 h1:ZZGKbrzxMFoO6kggmUwj/fqEaNYNN5HIUNtaZA9mSd4=
+github.com/nmstate/nmpolicy v0.1.0-alpha.1/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
+github.com/nmstate/nmpolicy v0.1.0-alpha.2 h1:U57+tmghM7aF9Z/OTwlSiMbwa+wQ0zqjGzHEUtS4dZQ=
+github.com/nmstate/nmpolicy v0.1.0-alpha.2/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
+github.com/nmstate/nmpolicy v0.1.0-alpha.3 h1:jBQX+KBCzQBYTrlYnC0kdNKQEIkV0eiFlWTkaHD6G1k=
+github.com/nmstate/nmpolicy v0.1.0-alpha.3/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=

--- a/pkg/enactmentstatus/conditions/conditions.go
+++ b/pkg/enactmentstatus/conditions/conditions.go
@@ -29,12 +29,12 @@ func New(client client.Client, enactmentKey types.NamespacedName) EnactmentCondi
 	return conditions
 }
 
-func (ec *EnactmentConditions) NotifyNodeSelectorFailure(err error) {
-	ec.logger.Info("NotifyNodeSelectorFailure")
-	message := fmt.Sprintf("failure checking node selectors : %v", err)
+func (ec *EnactmentConditions) NotifyGenerateFailure(err error) {
+	ec.logger.Info("NotifyGenerateFailure")
+	message := fmt.Sprintf("failure generating desiredState and capturedStates: %v", err)
 	err = ec.updateEnactmentConditions(SetFailedToConfigure, message)
 	if err != nil {
-		ec.logger.Error(err, "Error notifying state NodeSelectorNotMatching with failure")
+		ec.logger.Error(err, "Error notifying state generate captures with failure")
 	}
 }
 

--- a/pkg/nmpolicy/generate.go
+++ b/pkg/nmpolicy/generate.go
@@ -1,0 +1,68 @@
+package nmpolicy
+
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nmstateapi "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+func GenerateState(desiredState nmstateapi.State,
+	policySpec nmstateapi.NodeNetworkConfigurationPolicySpec,
+	currentState nmstateapi.State,
+	cachedState map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState) (map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState,
+	nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo, nmstateapi.State, error) {
+	nmpolicySpec := nmpolicytypes.PolicySpec{
+		Capture:      policySpec.Capture,
+		DesiredState: []byte(desiredState.Raw),
+	}
+	nmpolicyGeneratedState, err := nmpolicy.GenerateState(nmpolicySpec, currentState.Raw, convertCachedStateFromEnactment(cachedState))
+	if err != nil {
+		return map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{}, nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{}, nmstateapi.State{}, err
+	}
+
+	capturedStates, desriedStateMetaInfo, desiredState := convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState)
+	return capturedStates, desriedStateMetaInfo, desiredState, nil
+}
+
+func convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState nmpolicytypes.GeneratedState) (map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState,
+	nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo,
+	nmstateapi.State) {
+	desiredStateMetaInfo := convertMetaInfoToEnactment(nmpolicyGeneratedState.MetaInfo)
+	capturedStates := make(map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState)
+
+	for captureKey, capturedState := range nmpolicyGeneratedState.Cache.Capture {
+		capturedState := nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{
+			State: nmstateapi.State{
+				Raw: capturedState.State,
+			},
+			MetaInfo: convertMetaInfoToEnactment(capturedState.MetaInfo),
+		}
+		capturedStates[captureKey] = capturedState
+	}
+	return capturedStates, desiredStateMetaInfo, nmstateapi.State{Raw: nmpolicyGeneratedState.DesiredState}
+}
+
+func convertCachedStateFromEnactment(enactmentCachedState map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState) nmpolicytypes.CachedState {
+	cachedState := nmpolicytypes.CachedState{Capture: make(map[string]nmpolicytypes.CaptureState)}
+	for captureKey, capturedState := range enactmentCachedState {
+		capturedState := nmpolicytypes.CaptureState{
+			State: capturedState.State.Raw,
+			MetaInfo: nmpolicytypes.MetaInfo{
+				Version:   capturedState.MetaInfo.Version,
+				TimeStamp: capturedState.MetaInfo.TimeStamp.Time,
+			},
+		}
+		cachedState.Capture[captureKey] = capturedState
+	}
+	return cachedState
+}
+
+func convertMetaInfoToEnactment(metaInfo nmpolicytypes.MetaInfo) nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo {
+	return nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{
+		Version:   metaInfo.Version,
+		TimeStamp: metav1.NewTime(metaInfo.TimeStamp),
+	}
+}

--- a/pkg/nmpolicy/generate_test.go
+++ b/pkg/nmpolicy/generate_test.go
@@ -1,0 +1,86 @@
+package nmpolicy
+
+import (
+	"fmt"
+	"time"
+
+	nmstateapi "github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NMPolicy GenerateState", func() {
+	When("fails", func() {
+		It("Should return an error", func() {
+			capturedState, desiredStateMetaInfo, desiredState, err := GenerateStateWithStateGenerator(nmpolicyStub{shouldFail: true}, nmstateapi.State{},
+				nmstateapi.NodeNetworkConfigurationPolicySpec{},
+				nmstateapi.State{},
+				map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{})
+			Expect(err).To(HaveOccurred())
+			Expect(capturedState).To(Equal(map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{}))
+			Expect(desiredStateMetaInfo).To(Equal(nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{}))
+			Expect(desiredState).To(Equal(nmstateapi.State{}))
+		})
+
+	})
+
+	When("succeeds", func() {
+		const desiredStateYaml = `desire state yaml`
+		const captureYaml1 = `default-gw expression`
+		const captureYaml2 = `base-iface expression`
+		const metaVersion = "5"
+		metaTime := time.Now()
+
+		nmpolicyMetaInfo := nmpolicytypes.MetaInfo{
+			Version:   metaVersion,
+			TimeStamp: metaTime,
+		}
+
+		generatedState := nmpolicytypes.GeneratedState{
+			MetaInfo:     nmpolicyMetaInfo,
+			DesiredState: []byte(desiredStateYaml),
+			Cache: nmpolicytypes.CachedState{
+				Capture: map[string]nmpolicytypes.CaptureState{
+					"default-gw": {State: []byte(captureYaml1), MetaInfo: nmpolicyMetaInfo},
+					"base-iface": {State: []byte(captureYaml2)},
+				},
+			},
+		}
+
+		capturedStates, desiredStateMetaInfo, desiredState, err := GenerateStateWithStateGenerator(nmpolicyStub{output: generatedState}, nmstateapi.State{},
+			nmstateapi.NodeNetworkConfigurationPolicySpec{},
+			nmstateapi.State{},
+			map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{})
+
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedMetaInfo := nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{
+			Version:   metaVersion,
+			TimeStamp: metav1.NewTime(metaTime),
+		}
+
+		expectedcCaptureCache := map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{
+			"default-gw": {State: nmstateapi.State{Raw: []byte(captureYaml1)}, MetaInfo: expectedMetaInfo},
+			"base-iface": {State: nmstateapi.State{Raw: []byte(captureYaml2)}},
+		}
+
+		Expect(capturedStates).To(Equal(expectedcCaptureCache))
+		Expect(desiredStateMetaInfo).To(Equal(expectedMetaInfo))
+		Expect(desiredState).To(Equal(nmstateapi.State{Raw: []byte(desiredStateYaml)}))
+	})
+})
+
+type nmpolicyStub struct {
+	shouldFail bool
+	output     nmpolicytypes.GeneratedState
+}
+
+func (n nmpolicyStub) GenerateState(nmpolicySpec nmpolicytypes.PolicySpec, currentState []byte, cache nmpolicytypes.CachedState) (nmpolicytypes.GeneratedState, error) {
+	if n.shouldFail {
+		return nmpolicytypes.GeneratedState{}, fmt.Errorf("GenerateStateFailed")
+	}
+	return n.output, nil
+}

--- a/pkg/nmpolicy/nmpolicy_suite_test.go
+++ b/pkg/nmpolicy/nmpolicy_suite_test.go
@@ -1,0 +1,16 @@
+package nmpolicy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.nmpolicy_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "NMPolicy Test Suite", []Reporter{junitReporter})
+}

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -112,26 +112,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				resetDesiredStateForNodes()
 			})
 
-			checkThatBridgeTookOverTheDefaultIP := func(nodesToCheck []string) {
-				By("Verifying that the bridge obtained node's default IP")
-				for _, node := range nodesToCheck {
-					Eventually(func() string {
-						return ipv4Address(node, "brext")
-					}, 15*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface brext has not take over the %s address", primaryNic))
-				}
-
-				By("Verify that next-hop-interface for default route is brext")
-				for _, node := range nodesToCheck {
-					defaultRouteNextHopInterface(node).Should(Equal("brext"))
-
-					By("Verify that VLAN configuration is done properly")
-					hasVlans(node, primaryNic, 2, 4094).Should(Succeed())
-					getVLANFlagsEventually(node, "brext", 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-				}
-			}
-
 			It("should successfully move default IP address on top of the bridge", func() {
-				checkThatBridgeTookOverTheDefaultIP(nodes)
+				checkThatBridgeTookOverTheDefaultIP(nodes, "brext", addressByNode)
 			})
 
 			It("should keep the default IP address after node reboot", func() {
@@ -144,7 +126,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				waitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)
-				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot})
+				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot}, "brext", addressByNode)
 			})
 		})
 	})
@@ -177,5 +159,23 @@ func waitForNodesReady() {
 		EventuallyWithOffset(1, func() (corev1.ConditionStatus, error) {
 			return nodeReadyConditionStatus(node)
 		}, 5*time.Minute, 10*time.Second).Should(Equal(corev1.ConditionTrue))
+	}
+}
+
+func checkThatBridgeTookOverTheDefaultIP(nodesToCheck []string, bridgeName string, addressByNode map[string]string) {
+	By("Verifying that the bridge obtained node's default IP")
+	for _, node := range nodesToCheck {
+		Eventually(func() string {
+			return ipv4Address(node, bridgeName)
+		}, 15*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s has not take over the %s address", bridgeName, primaryNic))
+	}
+
+	By("Verify that next-hop-interface for default route is the bridge")
+	for _, node := range nodesToCheck {
+		defaultRouteNextHopInterface(node).Should(Equal(bridgeName))
+
+		By("Verify that VLAN configuration is done properly")
+		hasVlans(node, primaryNic, 2, 4094).Should(Succeed())
+		getVLANFlagsEventually(node, bridgeName, 1).Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
 	}
 }

--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -42,7 +42,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
   - name: brext
     type: linux-bridge
     state: up
-    mac-address: "{{ capture.base-iface.interfaces.0.mac }}"
+    mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
     ipv4:
       dhcp: true
       enabled: true

--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -1,0 +1,133 @@
+package handler
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nmpolicy", func() {
+	var (
+		DefaultNetwork = "default-network"
+	)
+	Context("when there is a default interface with dynamic address", func() {
+		addressByNode := map[string]string{}
+
+		BeforeEach(func() {
+			Byf("Check %s is the default route interface and has dynamic address", primaryNic)
+			for _, node := range nodes {
+				defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
+				Expect(dhcpFlag(node, primaryNic)).Should(BeTrue())
+			}
+
+			By("Fetching current IP address")
+			for _, node := range nodes {
+				address := ""
+				Eventually(func() string {
+					address = ipv4Address(node, primaryNic)
+					return address
+				}, 15*time.Second, 1*time.Second).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s has no ipv4 address", primaryNic))
+				addressByNode[node] = address
+			}
+		})
+
+		Context("and linux bridge is configured on top of the default interface", func() {
+			BeforeEach(func() {
+				By("Creating the policy")
+				bridgeOnTheDefaultInterfaceState := nmstate.NewState(`interfaces:
+  - name: brext
+    type: linux-bridge
+    state: up
+    mac-address: "{{ capture.base-iface.interfaces.0.mac }}"
+    ipv4:
+      dhcp: true
+      enabled: true
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+      - name: "{{ capture.base-iface.interfaces.0.name }}"
+`)
+				capture := map[string]string{
+					"default-gw": `routes.running.destination=="0.0.0.0/0"`,
+					"base-iface": `interfaces.name==capture.default-gw.routes.running.0.next-hop-interface`,
+				}
+				setDesiredStateWithPolicyAndCapture(DefaultNetwork, bridgeOnTheDefaultInterfaceState, capture)
+
+				By("Waiting until the node becomes ready again")
+				waitForNodesReady()
+
+				By("Waiting for policy to be ready")
+				waitForAvailablePolicy(DefaultNetwork)
+			})
+
+			AfterEach(func() {
+				resetDefaultInterfaceState := nmstate.NewState(`interfaces:
+  - name: "{{ capture.brext-bridge.interfaces.0.bridge.port.0.name }}"
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+  - name: brext
+    type: linux-bridge
+    state: absent
+`)
+
+				capture := map[string]string{
+					"brext-bridge": `interfaces.name=="brext"`,
+				}
+
+				Byf("Removing bridge and configuring %s with dhcp", primaryNic)
+				setDesiredStateWithPolicyAndCapture(DefaultNetwork, resetDefaultInterfaceState, capture)
+
+				By("Waiting until the node becomes ready again")
+				waitForNodesReady()
+
+				By("Wait for policy to be ready")
+				waitForAvailablePolicy(DefaultNetwork)
+
+				Byf("Check %s has the default ip address", primaryNic)
+				for _, node := range nodes {
+					Eventually(func() string {
+						return ipv4Address(node, primaryNic)
+					}, 30*time.Second, 1*time.Second).Should(Equal(addressByNode[node]), fmt.Sprintf("Interface %s address is not the original one", primaryNic))
+				}
+
+				Byf("Check %s is back as the default route interface", primaryNic)
+				for _, node := range nodes {
+					defaultRouteNextHopInterface(node).Should(Equal(primaryNic))
+				}
+
+				By("Remove the policy")
+				deletePolicy(DefaultNetwork)
+
+				By("Reset desired state at all nodes")
+				resetDesiredStateForNodes()
+			})
+
+			It("should successfully move default IP address on top of the bridge", func() {
+				checkThatBridgeTookOverTheDefaultIP(nodes, "brext", addressByNode)
+			})
+
+			It("should keep the default IP address after node reboot", func() {
+				nodeToReboot := nodes[0]
+
+				err := restartNode(nodeToReboot)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait for policy re-reconciled after node reboot")
+				waitForPolicyTransitionUpdate(DefaultNetwork)
+				waitForAvailablePolicy(DefaultNetwork)
+
+				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)
+				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot}, "brext", addressByNode)
+			})
+		})
+	})
+})

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationenactment_types.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -13,10 +14,27 @@ type NodeNetworkConfigurationEnactmentStatus struct {
 	// the policy desiredState as template
 	DesiredState State `json:"desiredState,omitempty"`
 
+	DesiredStateMetaInfo NodeNetworkConfigurationEnactmentMetaInfo `json:"desiredStateMetaInfo,omitempty"`
+
+	// A cache containing the resolved captures after processing the capture at NNCP
+	CapturedStates map[string]NodeNetworkConfigurationEnactmentCapturedState `json:"capturedStates,omitempty"`
+
 	// The generation from policy needed to check if an enactment
 	// condition status belongs to the same policy version
-	PolicyGeneration int64         `json:"policyGeneration,omitempty"`
-	Conditions       ConditionList `json:"conditions,omitempty"`
+	PolicyGeneration int64 `json:"policyGeneration,omitempty"`
+
+	Conditions ConditionList `json:"conditions,omitempty"`
+}
+
+type NodeNetworkConfigurationEnactmentCapturedState struct {
+	// +kubebuilder:validation:XPreserveUnknownFields
+	State    State                                     `json:"state,omitempty"`
+	MetaInfo NodeNetworkConfigurationEnactmentMetaInfo `json:"metaInfo,omitempty"`
+}
+
+type NodeNetworkConfigurationEnactmentMetaInfo struct {
+	Version   string      `json:"version,omitempty"`
+	TimeStamp metav1.Time `json:"time,omitempty"`
 }
 
 const (

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -13,6 +13,11 @@ type NodeNetworkConfigurationPolicySpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// Capture contains expressions with an associated name than can be referenced
+	// at the DesiredState.
+	// +optional
+	Capture map[string]string `json:"capture,omitempty"`
+
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// The desired configuration of the policy
 	DesiredState State `json:"desiredState,omitempty"`

--- a/vendor/github.com/nmstate/nmpolicy/LICENSE
+++ b/vendor/github.com/nmstate/nmpolicy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/equal.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/equal.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+func deepEqualStringPtr(lhs, rhs *string) bool {
+	if lhs == rhs {
+		return true
+	}
+	if rhs != nil && lhs != nil {
+		return *lhs == *rhs
+	}
+	return false
+}
+
+func (lhs Terminal) DeepEqual(rhs Terminal) bool {
+	return deepEqualStringPtr(rhs.Identity, lhs.Identity) &&
+		deepEqualStringPtr(rhs.String, lhs.String)
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+type Meta struct {
+	Position int `json:"pos"`
+}
+
+type TernaryOperator [3]Node
+type VariadicOperator []Node
+type Terminal struct {
+	String   *string `json:"string,omitempty"`
+	Identity *string `json:"identity,omitempty"`
+	Number   *int    `json:"number,omitempty"`
+}
+
+type Node struct {
+	Meta
+	EqFilter *TernaryOperator  `json:"eqfilter,omitempty"`
+	Path     *VariadicOperator `json:"path,omitempty"`
+	Terminal
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/values.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/values.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+func CurrentStateIdentity() Terminal {
+	literal := "currentState"
+	return Terminal{
+		Identity: &literal,
+	}
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/capture/capture.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/capture/capture.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+)
+
+type Capture struct {
+	lexer    Lexer
+	parser   Parser
+	resolver Resolver
+}
+
+type Lexer interface {
+	Lex(expression string) ([]lexer.Token, error)
+}
+
+type Parser interface {
+	Parse([]lexer.Token) (ast.Node, error)
+}
+
+type Resolver interface {
+	Resolve(captureASTPool types.CaptureASTPool, state types.NMState, capturedStates types.CapturedStates) (types.CapturedStates, error)
+	ResolveCaptureEntryPath(captureEntryPathAST ast.Node, capturedStates types.CapturedStates) (interface{}, error)
+}
+
+func New(leXer Lexer, parser Parser, resolver Resolver) Capture {
+	return Capture{
+		lexer:    leXer,
+		parser:   parser,
+		resolver: resolver,
+	}
+}
+
+func (c Capture) Resolve(
+	capturesExpr types.CaptureExpressions,
+	capturesCache types.CapturedStates,
+	state types.NMState) (types.CapturedStates, error) {
+	if len(capturesExpr) == 0 || len(state) == 0 && len(capturesCache) == 0 {
+		return nil, nil
+	}
+
+	capturesState := filterCacheBasedOnExprCaptures(capturesCache, capturesExpr)
+	capturesExpr = filterOutExprBasedOnCachedCaptures(capturesExpr, capturesCache)
+
+	astPool := types.CaptureASTPool{}
+	for capID, capExpr := range capturesExpr {
+		tokens, err := c.lexer.Lex(capExpr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
+		}
+
+		astRoot, err := c.parser.Parse(tokens)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
+		}
+
+		astPool[capID] = astRoot
+	}
+
+	resolvedCapturedStates, err := c.resolver.Resolve(astPool, state, capturesState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve capture expression, err: %v", err)
+	}
+
+	return resolvedCapturedStates, nil
+}
+
+func filterOutExprBasedOnCachedCaptures(capturesExpr types.CaptureExpressions,
+	capturesCache types.CapturedStates) types.CaptureExpressions {
+	for capID := range capturesCache {
+		delete(capturesExpr, capID)
+	}
+	return capturesExpr
+}
+
+func filterCacheBasedOnExprCaptures(capsState types.CapturedStates,
+	capsExpr types.CaptureExpressions) types.CapturedStates {
+	caps := types.CapturedStates{}
+
+	for capID := range capsExpr {
+		if capState, ok := capsState[capID]; ok {
+			caps[capID] = capState
+		}
+	}
+	return caps
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/capture/capture_entry.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/capture/capture_entry.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+)
+
+type CaptureEntry struct {
+	capturedStates types.CapturedStates
+	lexer          Lexer
+	parser         Parser
+	resolver       Resolver
+}
+
+func NewCaptureEntryWithLexerParserResolver(capturedStates types.CapturedStates,
+	l Lexer, p Parser, r Resolver) (CaptureEntry, error) {
+	return CaptureEntry{
+		capturedStates: capturedStates,
+		lexer:          l,
+		parser:         p,
+		resolver:       r,
+	}, nil
+}
+
+func NewCaptureEntry(capturedStates types.CapturedStates) (CaptureEntry, error) {
+	return NewCaptureEntryWithLexerParserResolver(capturedStates, lexer.New(), parser.New(), resolver.New())
+}
+
+func (c CaptureEntry) ResolveCaptureEntryPath(
+	captureEntryPathExpression string) (interface{}, error) {
+	captureEntryPathTokens, err := c.lexer.Lex(captureEntryPathExpression)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
+	}
+
+	captureEntryPathAST, err := c.parser.Parse(captureEntryPathTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
+	}
+
+	resolvedCaptureEntryPath, err := c.resolver.ResolveCaptureEntryPath(captureEntryPathAST, c.capturedStates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve capture entry path expression: %v", err)
+	}
+
+	return resolvedCaptureEntryPath, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/expander/state_expander.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/expander/state_expander.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package expander
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+)
+
+type StateExpander struct {
+	capResolver CapturePathResolver
+}
+
+type CapturePathResolver interface {
+	ResolveCaptureEntryPath(capturePath string) (interface{}, error)
+}
+
+func New(capResolver CapturePathResolver) StateExpander {
+	return StateExpander{capResolver: capResolver}
+}
+
+func (c StateExpander) Expand(desiredState types.NMState) (types.NMState, error) {
+	expandedState, err := c.expandState(map[string]interface{}(desiredState))
+	if err != nil {
+		return nil, fmt.Errorf("failed expanding desired state: %v", err)
+	}
+	return types.NMState(expandedState.(map[string]interface{})), nil
+}
+
+func (c StateExpander) expandState(state interface{}) (interface{}, error) {
+	switch stateValue := state.(type) {
+	case nil:
+		return state, nil
+	case string:
+		return c.expandString(stateValue)
+	case map[string]interface{}:
+		return c.expandMap(stateValue)
+	case []interface{}:
+		return c.exapndSlice(stateValue)
+	default:
+		return state, nil
+	}
+}
+
+func (c StateExpander) exapndSlice(sliceState []interface{}) ([]interface{}, error) {
+	for i, value := range sliceState {
+		expandedValue, err := c.expandState(value)
+		if err != nil {
+			return nil, err
+		}
+		sliceState[i] = expandedValue
+	}
+	return sliceState, nil
+}
+
+func (c StateExpander) expandMap(mapState map[string]interface{}) (map[string]interface{}, error) {
+	for key, value := range mapState {
+		expandedValue, err := c.expandState(value)
+		mapState[key] = expandedValue
+		if err != nil {
+			return nil, err
+		}
+	}
+	return mapState, nil
+}
+
+func (c StateExpander) expandString(stringState string) (interface{}, error) {
+	re := regexp.MustCompile(`^{{ (.*) }}$`)
+	submatch := re.FindStringSubmatch(stringState)
+
+	if len(submatch) == 0 {
+		return stringState, nil
+	}
+
+	const captureSubmatchLength = 2
+	if len(submatch) != captureSubmatchLength {
+		return nil, fmt.Errorf("the capture expression has wrong format %s", stringState)
+	}
+
+	capturePath := submatch[1]
+	resolvedPath, err := c.capResolver.ResolveCaptureEntryPath(capturePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resolvedPath, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/lexer.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/lexer.go
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner"
+)
+
+// Lexer struct is used to tokenize values returned by a reader.
+type Lexer struct{}
+
+type lexer struct {
+	scn *scanner.Scanner
+}
+
+// NewLexer construct a Lexer using reader as the input.
+func New() Lexer {
+	return Lexer{}
+}
+
+func newLexer(expression string) *lexer {
+	return &lexer{scn: scanner.New(strings.NewReader(expression))}
+}
+
+// Lex scans the input for the next token.
+// It returns a Token struct with position, type, and the literal value.
+func (Lexer) Lex(expression string) ([]Token, error) {
+	return newLexer(expression).Lex()
+}
+
+// Lex scans the input for the next token.
+// It returns a Token struct with position, type, and the literal value.
+func (l *lexer) Lex() ([]Token, error) {
+	// keep looping until we return a token
+	tokens := []Token{}
+	for {
+		token, err := l.lex()
+		if err != nil {
+			return nil, err
+		}
+		if token == nil {
+			continue
+		}
+		tokens = append(tokens, *token)
+		if token.Type == EOF {
+			break
+		}
+	}
+	return tokens, nil
+}
+
+func (l *lexer) lex() (*Token, error) {
+	for {
+		err := l.scn.Next()
+		if err != nil {
+			return nil, err
+		}
+		token, err := l.lexCurrentRune()
+		if err != nil {
+			return nil, err
+		}
+		if token == nil {
+			continue
+		}
+		return token, nil
+	}
+}
+
+func (l *lexer) lexCurrentRune() (*Token, error) {
+	if l.isEOF() {
+		return &Token{l.scn.Position(), EOF, ""}, nil
+	} else if l.isSpace() {
+		return nil, nil
+	} else if l.isDigit() {
+		return l.lexNumber()
+	} else if l.isString() {
+		return l.lexString()
+	} else if l.isLetter() {
+		return l.lexIdentity()
+	} else if l.isDot() {
+		return &Token{l.scn.Position(), DOT, string(l.scn.Rune())}, nil
+	} else if l.isColon() {
+		return l.lexEqualAs(REPLACE)
+	} else if l.isEqual() {
+		return l.lexEqualAs(EQFILTER)
+	} else if l.isPlus() {
+		return &Token{l.scn.Position(), MERGE, string(l.scn.Rune())}, nil
+	} else if l.isPipe() {
+		return &Token{l.scn.Position(), PIPE, string(l.scn.Rune())}, nil
+	}
+	return nil, fmt.Errorf("illegal rune %s", string(l.scn.Rune()))
+}
+
+func (l *lexer) lexNumber() (*Token, error) {
+	token := &Token{l.scn.Position(), NUMBER, string(l.scn.Rune())}
+	for {
+		if err := l.scn.Next(); err != nil {
+			return nil, err
+		}
+
+		if l.isEOF() || l.isSpace() {
+			// If it's EOF or space we have finish here
+			return token, nil
+		} else if l.isDot() || l.isPipe() {
+			if err := l.scn.Prev(); err != nil {
+				return nil, fmt.Errorf("failed lexing number: %w", err)
+			}
+			return token, nil
+		} else if l.isDigit() {
+			token.Literal += string(l.scn.Rune())
+		} else {
+			// nmpolicy supports only simple numbers with just digist
+			return nil, fmt.Errorf("invalid number format (%s is not a digit)", string(l.scn.Rune()))
+		}
+	}
+}
+
+func (l *lexer) lexString() (*Token, error) {
+	token := &Token{l.scn.Position(), STRING, ""}
+	// Strings should close with the same rune they have started
+	expectedTerminator := l.scn.Rune()
+	for {
+		if err := l.scn.Next(); err != nil {
+			return nil, err
+		}
+
+		if l.isEOF() {
+			return nil, fmt.Errorf("invalid string format (missing %s terminator)", string(expectedTerminator))
+		} else if l.scn.Rune() == expectedTerminator {
+			return token, nil
+		} else {
+			token.Literal += string(l.scn.Rune())
+		}
+	}
+}
+
+func (l *lexer) lexIdentity() (*Token, error) {
+	token := &Token{l.scn.Position(), IDENTITY, string(l.scn.Rune())}
+	for {
+		if err := l.scn.Next(); err != nil {
+			return nil, err
+		}
+
+		if l.isEOF() || l.isSpace() {
+			return token, nil
+		} else if l.isDot() || l.isEqual() || l.isColon() || l.isPlus() || l.isPipe() {
+			if err := l.scn.Prev(); err != nil {
+				return nil, fmt.Errorf("failed lexing identity: %w", err)
+			}
+			return token, nil
+		} else if l.isDigit() || l.isLetter() || l.scn.Rune() == '-' {
+			token.Literal += string(l.scn.Rune())
+		} else {
+			return nil, fmt.Errorf("invalid identity format (%s is not a digit, letter or -)", string(l.scn.Rune()))
+		}
+	}
+}
+
+func (l *lexer) lexEqualAs(tokenType TokenType) (*Token, error) {
+	var literal strings.Builder
+	literal.WriteRune(l.scn.Rune())
+	if err := l.scn.Next(); err != nil {
+		return nil, err
+	}
+	if l.isEqual() {
+		literal.WriteRune(l.scn.Rune())
+		return &Token{l.scn.Position() - 1, tokenType, literal.String()}, nil
+	} else {
+		return nil, fmt.Errorf("invalid %s operation format (%s is not equal char)", tokenType, string(l.scn.Rune()))
+	}
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner"
+)
+
+func (l *lexer) isDigit() bool {
+	return unicode.IsDigit(l.scn.Rune())
+}
+
+func (l *lexer) isSpace() bool {
+	return unicode.IsSpace(l.scn.Rune())
+}
+
+func (l *lexer) isEOF() bool {
+	return l.scn.Rune() == scanner.EOF
+}
+
+func (l *lexer) isString() bool {
+	return strings.ContainsRune(`"'`, l.scn.Rune())
+}
+
+func (l *lexer) isLetter() bool {
+	return unicode.IsLetter(l.scn.Rune())
+}
+
+func (l *lexer) isDot() bool {
+	return l.scn.Rune() == '.'
+}
+
+func (l *lexer) isEqual() bool {
+	return l.scn.Rune() == '='
+}
+
+func (l *lexer) isColon() bool {
+	return l.scn.Rune() == ':'
+}
+
+func (l *lexer) isPlus() bool {
+	return l.scn.Rune() == '+'
+}
+
+func (l *lexer) isPipe() bool {
+	return l.scn.Rune() == '|'
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner/scanner.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner/scanner.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scanner
+
+import (
+	"io"
+)
+
+const (
+	EOF rune = -1
+)
+
+type Scanner struct {
+	reader      io.RuneScanner
+	currentRune rune
+	prevRune    rune
+	pos         int
+}
+
+func New(reader io.RuneScanner) *Scanner {
+	return &Scanner{
+		reader: reader,
+	}
+}
+
+func (s *Scanner) Next() error {
+	rn, err := s.next()
+	if err != nil {
+		return err
+	}
+	s.prevRune = s.currentRune
+	s.currentRune = rn
+	if rn != EOF {
+		s.pos++
+	}
+	return nil
+}
+
+func (s *Scanner) Rune() rune {
+	return s.currentRune
+}
+
+func (s *Scanner) Prev() error {
+	if err := s.reader.UnreadRune(); err != nil {
+		return err
+	}
+	s.currentRune = s.prevRune
+	s.pos--
+	return nil
+}
+
+func (s *Scanner) Position() int {
+	return s.pos - 1
+}
+
+func (s *Scanner) next() (rune, error) {
+	rn, _, err := s.reader.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			return EOF, nil
+		}
+		return EOF, err
+	}
+	return rn, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lexer
+
+type TokenType int
+
+const (
+	EOF TokenType = iota
+	IDENTITY
+	NUMBER
+	STRING
+
+	DOT  // .
+	PIPE // |
+
+	REPLACE  // :=
+	EQFILTER // ==
+	MERGE    // +
+
+	TRUE  // true
+	FALSE // false
+)
+
+var tokens = []string{
+	EOF:      "EOF",
+	IDENTITY: "IDENTITY",
+	NUMBER:   "NUMBER",
+	STRING:   "STRING",
+
+	DOT:  "DOT",
+	PIPE: "PIPE",
+
+	REPLACE:  "REPLACE",
+	EQFILTER: "EQFILTER",
+	MERGE:    "MERGE",
+
+	TRUE:  "TRUE",
+	FALSE: "FALSE",
+}
+
+func (t TokenType) String() string {
+	return tokens[t]
+}
+
+type Token struct {
+	Position int
+	Type     TokenType
+	Literal  string
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/operations.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/operations.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/capture"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/expander"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cachedState types.CachedState) (types.GeneratedState, error) {
+	var (
+		capturedStates types.CapturedStates
+		desiredState   types.NMState
+	)
+
+	if policySpec.DesiredState != nil {
+		capResolver := capture.New(lexer.New(), parser.New(), resolver.New())
+		var err error
+		capturedStates, err = capResolver.Resolve(policySpec.Capture, cachedState.CapturedStates, currentState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+
+		captureEntryPathResolver, err := capture.NewCaptureEntry(capturedStates)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+
+		stateExpander := expander.New(captureEntryPathResolver)
+		desiredState, err = stateExpander.Expand(policySpec.DesiredState)
+		if err != nil {
+			return types.GeneratedState{}, fmt.Errorf("failed to generate state, err: %v", err)
+		}
+	}
+
+	timestamp := time.Now().UTC()
+	timestampCapturesState(capturedStates, timestamp)
+	return types.GeneratedState{
+		Cache:        types.CachedState{CapturedStates: capturedStates},
+		DesiredState: desiredState,
+		MetaInfo: nmpolicytypes.MetaInfo{
+			Version:   "0",
+			TimeStamp: timestamp,
+		},
+	}, nil
+}
+
+func timestampCapturesState(capturedStates types.CapturedStates, timeStamp time.Time) {
+	for captureID, capturedState := range capturedStates {
+		if capturedState.MetaInfo.TimeStamp.IsZero() {
+			capturedState.MetaInfo.TimeStamp = timeStamp
+			capturedStates[captureID] = capturedState
+		}
+	}
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/errors.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/errors.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"strings"
+)
+
+type parserError struct {
+	prefix string
+	inner  error
+	msg    string
+}
+
+func (p parserError) Unwrap() error {
+	return p.inner
+}
+
+func (p parserError) Error() string {
+	errorMsg := strings.Builder{}
+	errorMsg.WriteString(p.prefix)
+	errorMsg.WriteString(": ")
+	if p.inner != nil {
+		errorMsg.WriteString(p.inner.Error())
+	} else {
+		errorMsg.WriteString(p.msg)
+	}
+	return errorMsg.String()
+}
+
+const invalidPathErrorPrefix = "invalid path"
+
+func wrapWithInvalidPathError(err error) *parserError {
+	return &parserError{
+		prefix: invalidPathErrorPrefix,
+		inner:  err,
+	}
+}
+
+func invalidPathError(msg string) *parserError {
+	return &parserError{
+		prefix: invalidPathErrorPrefix,
+		msg:    msg,
+	}
+}
+
+func invalidEqualityFilterError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid equality filter",
+		msg:    msg,
+	}
+}
+
+func invalidExpressionError(msg string) *parserError {
+	return &parserError{
+		prefix: "invalid expression",
+		msg:    msg,
+	}
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/parser.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/parser.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/lexer"
+)
+
+type Parser struct{}
+
+type parser struct {
+	tokens          []lexer.Token
+	currentTokenIdx int
+	lastNode        *ast.Node
+}
+
+func New() Parser {
+	return Parser{}
+}
+
+func newParser(tokens []lexer.Token) *parser {
+	return &parser{tokens: tokens}
+}
+
+func (Parser) Parse(tokens []lexer.Token) (ast.Node, error) {
+	return newParser(tokens).Parse()
+}
+
+func (p *parser) Parse() (ast.Node, error) {
+	node, err := p.parse()
+	if err != nil {
+		return ast.Node{}, err
+	}
+	return node, nil
+}
+
+func (p *parser) parse() (ast.Node, error) {
+	for {
+		if p.currentToken() == nil {
+			return ast.Node{}, nil
+		} else if p.currentToken().Type == lexer.EOF {
+			break
+		} else if p.currentToken().Type == lexer.STRING {
+			if err := p.parseString(); err != nil {
+				return ast.Node{}, err
+			}
+		} else if p.currentToken().Type == lexer.IDENTITY {
+			if err := p.parsePath(); err != nil {
+				return ast.Node{}, err
+			}
+		} else if p.currentToken().Type == lexer.EQFILTER {
+			if err := p.parseEqFilter(); err != nil {
+				return ast.Node{}, err
+			}
+		} else {
+			return ast.Node{}, invalidExpressionError(fmt.Sprintf("unexpected token `%+v`", p.currentToken().Literal))
+		}
+		p.nextToken()
+	}
+	if p.lastNode == nil {
+		return ast.Node{}, nil
+	}
+	return *p.lastNode, nil
+}
+
+func (p *parser) nextToken() {
+	if len(p.tokens) == 0 {
+		return
+	}
+	if p.currentTokenIdx >= len(p.tokens)-1 {
+		p.currentTokenIdx = len(p.tokens) - 1
+	} else {
+		p.currentTokenIdx++
+	}
+}
+
+func (p *parser) prevToken() {
+	if len(p.tokens) == 0 {
+		return
+	}
+	if p.currentTokenIdx > 0 {
+		p.currentTokenIdx--
+	}
+	if p.currentTokenIdx >= len(p.tokens)-1 {
+		p.currentTokenIdx = len(p.tokens) - 1
+	}
+}
+
+func (p *parser) currentToken() *lexer.Token {
+	if len(p.tokens) == 0 || p.currentTokenIdx >= len(p.tokens) {
+		return nil
+	}
+	return &p.tokens[p.currentTokenIdx]
+}
+
+func (p *parser) parseIdentity() error {
+	p.lastNode = &ast.Node{
+		Meta:     ast.Meta{Position: p.currentToken().Position},
+		Terminal: ast.Terminal{Identity: &p.currentToken().Literal},
+	}
+	return nil
+}
+
+func (p *parser) parseString() error {
+	p.lastNode = &ast.Node{
+		Meta:     ast.Meta{Position: p.currentToken().Position},
+		Terminal: ast.Terminal{String: &p.currentToken().Literal},
+	}
+	return nil
+}
+
+func (p *parser) parseNumber() error {
+	number, err := strconv.Atoi(p.currentToken().Literal)
+	if err != nil {
+		return err
+	}
+	p.lastNode = &ast.Node{
+		Meta:     ast.Meta{Position: p.currentToken().Position},
+		Terminal: ast.Terminal{Number: &number},
+	}
+	return nil
+}
+
+func (p *parser) parsePath() error {
+	if err := p.parseIdentity(); err != nil {
+		return err
+	}
+	operator := &ast.Node{
+		Meta: ast.Meta{Position: p.currentToken().Position},
+		Path: &ast.VariadicOperator{*p.lastNode},
+	}
+	for {
+		p.nextToken()
+		if p.currentToken().Type == lexer.DOT {
+			p.nextToken()
+			if p.currentToken().Type == lexer.IDENTITY {
+				if err := p.parseIdentity(); err != nil {
+					return err
+				}
+			} else if p.currentToken().Type == lexer.NUMBER {
+				if err := p.parseNumber(); err != nil {
+					return wrapWithInvalidPathError(err)
+				}
+			} else {
+				return invalidPathError("missing identity or number after dot")
+			}
+			path := append(*operator.Path, *p.lastNode)
+			operator.Path = &path
+		} else if p.currentToken().Type != lexer.EOF && p.currentToken().Type != lexer.EQFILTER {
+			return invalidPathError("missing dot")
+		} else {
+			// Token has not being consumed let's go back.
+			p.prevToken()
+			break
+		}
+	}
+	p.lastNode = operator
+	return nil
+}
+
+func (p *parser) parseEqFilter() error {
+	operator := &ast.Node{
+		Meta:     ast.Meta{Position: p.currentToken().Position},
+		EqFilter: &ast.TernaryOperator{},
+	}
+	if p.lastNode == nil {
+		return invalidEqualityFilterError("missing left hand argument")
+	}
+	if p.lastNode.Path == nil {
+		return invalidEqualityFilterError("left hand argument is not a path")
+	}
+	operator.EqFilter[0].Terminal = ast.CurrentStateIdentity()
+	operator.EqFilter[1] = *p.lastNode
+
+	p.nextToken()
+
+	if p.currentToken().Type == lexer.STRING {
+		if err := p.parseString(); err != nil {
+			return err
+		}
+		operator.EqFilter[2] = *p.lastNode
+	} else if p.currentToken().Type == lexer.IDENTITY {
+		err := p.parsePath()
+		if err != nil {
+			return err
+		}
+		operator.EqFilter[2] = *p.lastNode
+	} else if p.currentToken().Type != lexer.EOF {
+		return invalidEqualityFilterError("right hand argument is not a string or identity")
+	}
+	p.lastNode = operator
+	return nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/errors.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/errors.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import "fmt"
+
+func pathError(format string, a ...interface{}) error {
+	return fmt.Errorf("invalid path: %v", fmt.Errorf(format, a...))
+}
+
+func wrapWithResolveError(err error) error {
+	return fmt.Errorf("resolve error: %v", err)
+}
+
+func wrapWithEqFilterError(err error) error {
+	return fmt.Errorf("eqfilter error: %v", err)
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/filter.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/filter.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func filter(inputState map[string]interface{}, path ast.VariadicOperator, expectedNode ast.Node) (map[string]interface{}, error) {
+	filtered, err := applyFuncOnPath(inputState, path, expectedNode, mapContainsValue, true)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed applying operation on the path: %v", err)
+	}
+
+	if filtered == nil {
+		return nil, nil
+	}
+
+	filteredMap, ok := filtered.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed converting filtering result to a map")
+	}
+	return filteredMap, nil
+}
+
+func isEqual(obtainedValue interface{}, desiredValue ast.Node) (bool, error) {
+	if desiredValue.String != nil {
+		stringToCompare, ok := obtainedValue.(string)
+		if !ok {
+			return false, fmt.Errorf("the value %v of type %T not supported,"+
+				"curretly only string values are supported", obtainedValue, obtainedValue)
+		}
+		return stringToCompare == *desiredValue.String, nil
+	}
+
+	return false, fmt.Errorf("the desired value %v is not supported. Curretly only string values are supported", desiredValue)
+}
+
+func mapContainsValue(mapToFilter map[string]interface{}, filterKey string, expectedNode ast.Node) (interface{}, error) {
+	obtainedValue, ok := mapToFilter[filterKey]
+	if !ok {
+		return nil, fmt.Errorf("cannot find key %s in %v", filterKey, mapToFilter)
+	}
+	valueIsEqual, err := isEqual(obtainedValue, expectedNode)
+	if err != nil {
+		return nil, fmt.Errorf("error comparing the expected and obtained values : %v", err)
+	}
+	if valueIsEqual {
+		return mapToFilter, nil
+	}
+	return nil, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/path.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/path.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+type captureEntryNameAndSteps struct {
+	captureEntryName string
+	steps            ast.VariadicOperator
+}
+
+func applyFuncOnPath(inputState interface{},
+	path []ast.Node,
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	if len(path) == 0 {
+		return inputState, nil
+	}
+	originalMap, isMap := inputState.(map[string]interface{})
+	if isMap {
+		if len(path) == 1 {
+			return applyFuncOnLastMapOnPath(path, originalMap, expectedNode, inputState, funcToApply)
+		}
+		return applyFuncOnMap(path, originalMap, expectedNode, funcToApply, shouldFilterSlice)
+	}
+
+	originalSlice, isSlice := inputState.([]interface{})
+	if isSlice {
+		return applyFuncOnSlice(originalSlice, path, expectedNode, funcToApply, shouldFilterSlice)
+	}
+
+	return nil, pathError("invalid type %T for identity step '%v'", inputState, path[0])
+}
+
+func applyFuncOnSlice(originalSlice []interface{},
+	path []ast.Node,
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	filteredSlice := []interface{}{}
+	for _, valueToCheck := range originalSlice {
+		value, err := applyFuncOnPath(valueToCheck, path, expectedNode, funcToApply, false)
+		if err != nil {
+			return nil, err
+		}
+		if value != nil {
+			filteredSlice = append(filteredSlice, valueToCheck)
+		}
+	}
+
+	if len(filteredSlice) == 0 {
+		return nil, nil
+	}
+
+	if shouldFilterSlice {
+		return filteredSlice, nil
+	}
+	return originalSlice, nil
+}
+
+func applyFuncOnMap(path []ast.Node,
+	originalMap map[string]interface{},
+	expectedNode ast.Node,
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error),
+	shouldFilterSlice bool) (interface{}, error) {
+	currentStep := path[0]
+	if currentStep.Identity == nil {
+		return nil, pathError("%v has unsupported fromat", currentStep)
+	}
+
+	nextPath := path[1:]
+	key := *currentStep.Identity
+
+	value, ok := originalMap[key]
+	if !ok {
+		return nil, pathError("cannot find key %s in %v", key, originalMap)
+	}
+
+	adjuctedValue, err := applyFuncOnPath(value, nextPath, expectedNode, funcToApply, shouldFilterSlice)
+	if err != nil {
+		return nil, err
+	}
+	if adjuctedValue != nil {
+		return map[string]interface{}{key: adjuctedValue}, nil
+	}
+	return nil, nil
+}
+
+func applyFuncOnLastMapOnPath(path []ast.Node,
+	originalMap map[string]interface{},
+	expectedNode ast.Node,
+	inputState interface{},
+	funcToApply func(map[string]interface{}, string, ast.Node) (interface{}, error)) (interface{}, error) {
+	if funcToApply != nil {
+		key := *path[0].Identity
+		outputState, err := funcToApply(originalMap, key, expectedNode)
+		if err != nil {
+			return nil, err
+		}
+		return outputState, nil
+	}
+	return inputState, nil
+}
+
+func (p captureEntryNameAndSteps) walkState(stateToWalk map[string]interface{}) (interface{}, error) {
+	var (
+		walkedState interface{}
+		walkedPath  []string
+	)
+	walkedState = stateToWalk
+	for _, step := range p.steps {
+		if step.Identity != nil {
+			identityStep := *step.Identity
+			walkedPath = append(walkedPath, identityStep)
+			walkedStateMap, ok := walkedState.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed walking non map state '%+v' with path '%+v'", walkedState, walkedPath)
+			}
+			walkedState, ok = walkedStateMap[identityStep]
+			if !ok {
+				return nil, fmt.Errorf("step '%s' from path '%s' not found at map state '%+v'", identityStep, walkedPath, walkedStateMap)
+			}
+		} else if step.Number != nil {
+			numberStep := *step.Number
+			walkedPath = append(walkedPath, strconv.Itoa(numberStep))
+			walkedStateSlice, ok := walkedState.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("failed walking non slice state '%+v' with path '%+v'", walkedState, walkedPath)
+			}
+			if len(walkedStateSlice) == 0 || numberStep >= len(walkedStateSlice) {
+				return nil, fmt.Errorf("step '%d' from path '%s' not found at slice state '%+v'", numberStep, walkedPath, walkedStateSlice)
+			}
+			walkedState = walkedStateSlice[numberStep]
+		}
+	}
+	return walkedState, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+)
+
+type Resolver struct{}
+
+type resolver struct {
+	currentState   types.NMState
+	capturedStates types.CapturedStates
+	captureASTPool types.CaptureASTPool
+}
+
+func New() Resolver {
+	return Resolver{}
+}
+
+func newResolver() *resolver {
+	return &resolver{
+		currentState:   types.NMState{},
+		capturedStates: types.CapturedStates{},
+		captureASTPool: types.CaptureASTPool{},
+	}
+}
+
+func (Resolver) Resolve(captureASTPool types.CaptureASTPool,
+	currentState types.NMState,
+	capturedStates types.CapturedStates) (types.CapturedStates, error) {
+	r := newResolver()
+	r.currentState = currentState
+	r.captureASTPool = captureASTPool
+	if capturedStates != nil {
+		r.capturedStates = capturedStates
+	}
+	return r.resolve()
+}
+
+func (Resolver) ResolveCaptureEntryPath(captureEntryPathAST ast.Node,
+	capturedStates types.CapturedStates) (interface{}, error) {
+	r := newResolver()
+	r.capturedStates = capturedStates
+	return r.resolveCaptureEntryPath(captureEntryPathAST)
+}
+
+func (r *resolver) resolve() (types.CapturedStates, error) {
+	for captureEntryName := range r.captureASTPool {
+		if _, err := r.resolveCaptureEntryName(captureEntryName); err != nil {
+			return nil, wrapWithResolveError(err)
+		}
+	}
+	return r.capturedStates, nil
+}
+
+func (r *resolver) resolveCaptureEntryName(captureEntryName string) (types.NMState, error) {
+	capturedStateEntry, ok := r.capturedStates[captureEntryName]
+	if ok {
+		return capturedStateEntry.State, nil
+	}
+	captureASTEntry, ok := r.captureASTPool[captureEntryName]
+	if !ok {
+		return nil, fmt.Errorf("capture entry '%s' not found", captureEntryName)
+	}
+	var err error
+	capturedStateEntry = types.CapturedState{}
+	capturedStateEntry.State, err = r.resolveCaptureASTEntry(captureASTEntry)
+	if err != nil {
+		return nil, err
+	}
+	r.capturedStates[captureEntryName] = capturedStateEntry
+	return capturedStateEntry.State, nil
+}
+
+func (r resolver) resolveCaptureASTEntry(captureASTEntry ast.Node) (types.NMState, error) {
+	if captureASTEntry.EqFilter != nil {
+		return r.resolveEqFilter(captureASTEntry.EqFilter)
+	}
+	return nil, fmt.Errorf("root node has unsupported operation : %v", captureASTEntry)
+}
+
+func (r resolver) resolveEqFilter(operator *ast.TernaryOperator) (types.NMState, error) {
+	inputSource, err := r.resolveInputSource((*operator)[0], r.currentState)
+	if err != nil {
+		return nil, wrapWithEqFilterError(err)
+	}
+
+	path, err := r.resolvePath((*operator)[1])
+	if err != nil {
+		return nil, wrapWithEqFilterError(err)
+	}
+	filteredValue, err := r.resolveFilteredValue((*operator)[2])
+	if err != nil {
+		return nil, wrapWithEqFilterError(err)
+	}
+	filteredState, err := filter(inputSource, path.steps, *filteredValue)
+	if err != nil {
+		return nil, wrapWithEqFilterError(err)
+	}
+	return filteredState, nil
+}
+
+func (r resolver) resolveInputSource(inputSourceNode ast.Node,
+	currentState types.NMState) (types.NMState, error) {
+	if ast.CurrentStateIdentity().DeepEqual(inputSourceNode.Terminal) {
+		return currentState, nil
+	}
+
+	return nil, fmt.Errorf("not supported input source %v. Only the current state is supported", inputSourceNode)
+}
+
+func (r resolver) resolveFilteredValue(filteredValueNode ast.Node) (*ast.Node, error) {
+	if filteredValueNode.String != nil {
+		return &filteredValueNode, nil
+	} else if filteredValueNode.Path != nil {
+		resolvedCaptureEntryPath, err := r.resolveCaptureEntryPath(filteredValueNode)
+		if err != nil {
+			return nil, err
+		}
+		terminal, err := newTerminalFromInterface(resolvedCaptureEntryPath)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.Node{
+			Terminal: *terminal,
+		}, nil
+	} else {
+		return nil, fmt.Errorf("not supported filtered value. Only string or paths are supported")
+	}
+}
+
+func (r resolver) resolveCaptureEntryPath(pathNode ast.Node) (interface{}, error) {
+	resolvedPath, err := r.resolvePath(pathNode)
+	if err != nil {
+		return nil, err
+	}
+	if resolvedPath.captureEntryName == "" {
+		return nil, fmt.Errorf("not supported filtered value path. Only paths with a capture entry reference are supported")
+	}
+	capturedStateEntry, err := r.resolveCaptureEntryName(resolvedPath.captureEntryName)
+	if err != nil {
+		return nil, err
+	}
+	return resolvedPath.walkState(capturedStateEntry)
+}
+
+func (r resolver) resolvePath(pathNode ast.Node) (*captureEntryNameAndSteps, error) {
+	if pathNode.Path == nil {
+		return nil, fmt.Errorf("invalid path type %T", pathNode)
+	} else if len(*pathNode.Path) == 0 {
+		return nil, fmt.Errorf("empty path length")
+	} else if (*pathNode.Path)[0].Identity == nil {
+		return nil, fmt.Errorf("path first step has to be an identity")
+	}
+	resolvedPath := captureEntryNameAndSteps{
+		steps: *pathNode.Path,
+	}
+	if *resolvedPath.steps[0].Identity == "capture" {
+		const captureRefSize = 2
+		if len(resolvedPath.steps) < captureRefSize || resolvedPath.steps[1].Identity == nil {
+			return nil, fmt.Errorf("path capture ref is missing capture entry name")
+		}
+		resolvedPath.captureEntryName = *resolvedPath.steps[1].Identity
+		if len(resolvedPath.steps) > captureRefSize {
+			resolvedPath.steps = resolvedPath.steps[2:len(resolvedPath.steps)]
+		}
+	}
+	return &resolvedPath, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/terminal.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/terminal.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2001 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func newTerminalFromInterface(iface interface{}) (*ast.Terminal, error) {
+	switch v := iface.(type) {
+	case string:
+		return &ast.Terminal{String: &v}, nil
+	default:
+		return nil, fmt.Errorf("unexpected terminal type %T", v)
+	}
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/types/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/types/types.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+type NMState map[string]interface{}
+type CaptureExpressions map[string]string
+type CapturedStates map[string]CapturedState
+type CaptureASTPool map[string]ast.Node
+
+type PolicySpec struct {
+	Capture      CaptureExpressions
+	DesiredState NMState
+}
+
+type CachedState struct {
+	CapturedStates CapturedStates
+}
+
+type GeneratedState struct {
+	Cache        CachedState
+	DesiredState NMState
+	MetaInfo     nmpolicytypes.MetaInfo
+}
+
+type CapturedState struct {
+	State    NMState
+	MetaInfo nmpolicytypes.MetaInfo
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/operations.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/operations.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nmpolicy
+
+import (
+	"fmt"
+
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal"
+	internaltypes "github.com/nmstate/nmpolicy/nmpolicy/internal/types"
+	"github.com/nmstate/nmpolicy/nmpolicy/types"
+)
+
+// GenerateState creates a NMPolicy state based on the given input data:
+// - NMPolicy spec.
+// - NMState state, representing a given current state.
+// - Cache state which includes (already resolved) named captures.
+//
+// GenerateState returns a generated state which includes:
+// - Desired State: The NMState state which has been built by the policy.
+// - Cache: Named NMState states which have been resolved by the policy.
+//          Can be saved for use as cache data (passed as input).
+// - Meta Info: Extended information about the generated state (e.g. the policy version).
+//
+// On failure, an error is returned.
+func GenerateState(policySpec types.PolicySpec,
+	currentState []byte, cachedState types.CachedState) (generatedState types.GeneratedState, err error) {
+	internalPolicySpec, err := toInternalPolicySpec(policySpec)
+	if err != nil {
+		return generatedState, err
+	}
+	internalCurrentState, err := toInternalNMState(currentState)
+	if err != nil {
+		return generatedState, err
+	}
+	internalCachedState, err := toInternalCachedState(cachedState)
+	if err != nil {
+		return generatedState, err
+	}
+
+	internalGeneratedState, err := internal.GenerateState(internalPolicySpec, internalCurrentState, internalCachedState)
+	if err != nil {
+		return generatedState, err
+	}
+
+	generatedState, err = toGeneratedState(internalGeneratedState)
+	if err != nil {
+		return generatedState, err
+	}
+	return generatedState, nil
+}
+
+func toInternalPolicySpec(policySpec types.PolicySpec) (internaltypes.PolicySpec, error) {
+	internalDesiredState, err := toInternalNMState(policySpec.DesiredState)
+	if err != nil {
+		return internaltypes.PolicySpec{}, err
+	}
+	return internaltypes.PolicySpec{
+		DesiredState: internalDesiredState,
+		Capture:      internaltypes.CaptureExpressions(policySpec.Capture),
+	}, nil
+}
+
+func toInternalNMState(nmState []byte) (internaltypes.NMState, error) {
+	internalNMState := internaltypes.NMState{}
+	if err := yaml.Unmarshal(nmState, &internalNMState); err != nil {
+		return nil, fmt.Errorf("failed converting to internal NMState: %w", err)
+	}
+	return internalNMState, nil
+}
+
+func toNMState(internalNMState internaltypes.NMState) ([]byte, error) {
+	if len(internalNMState) == 0 {
+		return nil, nil
+	}
+	nmState, err := yaml.Marshal(internalNMState)
+	if err != nil {
+		return nil, fmt.Errorf("failed converting from internal NMState: %w", err)
+	}
+	return nmState, nil
+}
+
+func toInternalCapturedState(capturedState types.CaptureState) (internaltypes.CapturedState, error) {
+	internalState, err := toInternalNMState(capturedState.State)
+	if err != nil {
+		return internaltypes.CapturedState{}, err
+	}
+	return internaltypes.CapturedState{
+		State:    internalState,
+		MetaInfo: capturedState.MetaInfo,
+	}, nil
+}
+
+func toCapturedState(internalCapturedState internaltypes.CapturedState) (types.CaptureState, error) {
+	state, err := toNMState(internalCapturedState.State)
+	if err != nil {
+		return types.CaptureState{}, err
+	}
+	return types.CaptureState{
+		State:    state,
+		MetaInfo: internalCapturedState.MetaInfo,
+	}, nil
+}
+
+func toInternalCachedState(cachedState types.CachedState) (internaltypes.CachedState, error) {
+	internalCachedState := internaltypes.CachedState{
+		CapturedStates: internaltypes.CapturedStates{},
+	}
+	for captureEntryName, capturedState := range cachedState.Capture {
+		internalCapturedState, err := toInternalCapturedState(capturedState)
+		if err != nil {
+			return internaltypes.CachedState{}, err
+		}
+		internalCachedState.CapturedStates[captureEntryName] = internalCapturedState
+	}
+	return internalCachedState, nil
+}
+
+func toCachedState(internalCachedState internaltypes.CachedState) (types.CachedState, error) {
+	if len(internalCachedState.CapturedStates) == 0 {
+		return types.CachedState{}, nil
+	}
+	cachedState := types.CachedState{
+		Capture: map[string]types.CaptureState{},
+	}
+	for captureEntryName, internalCapturedState := range internalCachedState.CapturedStates {
+		capturedState, err := toCapturedState(internalCapturedState)
+		if err != nil {
+			return types.CachedState{}, err
+		}
+		cachedState.Capture[captureEntryName] = capturedState
+	}
+	return cachedState, nil
+}
+
+func toGeneratedState(internalGeneratedState internaltypes.GeneratedState) (types.GeneratedState, error) {
+	desiredState, err := toNMState(internalGeneratedState.DesiredState)
+	if err != nil {
+		return types.GeneratedState{}, err
+	}
+	cachedState, err := toCachedState(internalGeneratedState.Cache)
+	if err != nil {
+		return types.GeneratedState{}, err
+	}
+	return types.GeneratedState{
+		MetaInfo:     internalGeneratedState.MetaInfo,
+		DesiredState: desiredState,
+		Cache:        cachedState,
+	}, nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/types/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/types/types.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import "time"
+
+type PolicySpec struct {
+	Capture      map[string]string
+	DesiredState []byte
+}
+
+type CachedState struct {
+	Capture map[string]CaptureState
+}
+
+type GeneratedState struct {
+	Cache        CachedState
+	DesiredState []byte
+	MetaInfo     MetaInfo
+}
+
+type CaptureState struct {
+	State    []byte
+	MetaInfo MetaInfo
+}
+
+type MetaInfo struct {
+	Version   string
+	TimeStamp time.Time
+}
+
+func NoCache() CachedState { return CachedState{} }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -462,6 +462,19 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
+# github.com/nmstate/nmpolicy v0.1.0-alpha.3
+## explicit
+github.com/nmstate/nmpolicy/nmpolicy
+github.com/nmstate/nmpolicy/nmpolicy/internal
+github.com/nmstate/nmpolicy/nmpolicy/internal/ast
+github.com/nmstate/nmpolicy/nmpolicy/internal/capture
+github.com/nmstate/nmpolicy/nmpolicy/internal/expander
+github.com/nmstate/nmpolicy/nmpolicy/internal/lexer
+github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/scanner
+github.com/nmstate/nmpolicy/nmpolicy/internal/parser
+github.com/nmstate/nmpolicy/nmpolicy/internal/resolver
+github.com/nmstate/nmpolicy/nmpolicy/internal/types
+github.com/nmstate/nmpolicy/nmpolicy/types
 # github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 github.com/nozzle/throttler
 # github.com/nxadm/tail v1.4.8


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
The PR is intoducing `nncp.spec.capture` which can include a map (string -> string) of captureIDs to expressions that can be referenced at desiredState and at another capture.

The captures and the desired state references are resolved by invoking `nmpolicy.GenerateState` (NMPolicy - https://github.com/nmstate/nmpolicy).

The resolved captures cache is stored on the enactment (nnce.status.nmpolicyStatus.cache.capture) and passed to the `nmpolicy.GenerateState` in case the nncp is updated.

**Special notes for your reviewer**:
The PR doesn't take care of input validation and reconcile corner cases (reboot of the node while the policy is applied, etc...).
A follow-up PRs will take of of these.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allows adding captures to node network configuration policy spec
```
