### PR TITLE
[release-0.47] Fix applying vlan filtering via nmcli

### DIFF
--- a/pkg/helper/bridges_test.go
+++ b/pkg/helper/bridges_test.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
@@ -341,4 +342,179 @@ var _ = Describe("test listing linux bridges with ports", func() {
 				Not(HaveKey("br7")),
 			))
 	})
+})
+
+var _ = Describe("test listing linux bridges with ports", func() {
+	currentState := nmstate.NewState(`interfaces:
+  - name: br22
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: test-veth1
+        vlan:
+          enable-native: true
+  - name: br3
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: eth2
+      - name: eth3
+      - name: eth4
+      - name: eth5
+  - name: br4
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: eth4
+  - name: br5
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: eth5
+  - name: br7
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: eth777
+  - name: br8
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+      - name: eth888
+`)
+	desiredState := nmstate.NewState(`interfaces:
+- name: br3
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth2
+    - name: eth3
+- name: br4
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth4
+- name: br5
+  type: linux-bridge
+  state: up
+  bridge:
+    port: []
+- name: br6
+  type: linux-bridge
+  state: down
+  bridge:
+    port:
+    - name: eth666
+- name: br7
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth777
+    - name: eth778
+    - name: eth779
+- name: br8
+  type: linux-bridge
+  state: absent
+  bridge:
+    port:
+    - name: eth888
+`)
+	expectedFilteredExistingBridgesWithPorts := map[string][]string{
+		"br3": {"eth2", "eth3"},
+		"br4": {"eth4"},
+		"br7": {"eth777"},
+	}
+	It("should filter correct bridges and ports", func() {
+		upBridgesWithPortsAtCurrentState, err := GetUpLinuxBridgesWithPorts(currentState)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		filteredExistingUpBridgesWithPorts, err := filterExistingLinuxBridgesWithPorts(upBridgesWithPortsAtCurrentState, desiredState)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(filteredExistingUpBridgesWithPorts).To(Equal(expectedFilteredExistingBridgesWithPorts))
+	})
+})
+
+var _ = Describe("testing slice intersection", func() {
+	type intersectionCase struct {
+		s1                   []string
+		s2                   []string
+		expectedIntersection []string
+	}
+
+	table.DescribeTable("Slice intersection cases",
+		func(c intersectionCase) {
+			result := intersectSlices(c.s1, c.s2)
+			Expect(result).To(Equal(c.expectedIntersection))
+		},
+		table.Entry(
+			"Both slices empty",
+			intersectionCase{
+				s1:                   []string{},
+				s2:                   []string{},
+				expectedIntersection: []string{},
+			}),
+		table.Entry("Empty first slice",
+			intersectionCase{
+				s1:                   []string{},
+				s2:                   []string{"foo"},
+				expectedIntersection: []string{},
+			}),
+		table.Entry("Empty second slice",
+			intersectionCase{
+				s1:                   []string{"foo"},
+				s2:                   []string{},
+				expectedIntersection: []string{},
+			}),
+		table.Entry("No common elements",
+			intersectionCase{
+				s1:                   []string{"foo"},
+				s2:                   []string{"bar"},
+				expectedIntersection: []string{},
+			}),
+		table.Entry("One common element with extra in first slice",
+			intersectionCase{
+				s1:                   []string{"foo", "bar"},
+				s2:                   []string{"bar"},
+				expectedIntersection: []string{"bar"},
+			}),
+		table.Entry("One common element with extra in first slice",
+			intersectionCase{
+				s1:                   []string{"bar"},
+				s2:                   []string{"bar", "foo"},
+				expectedIntersection: []string{"bar"},
+			}),
+		table.Entry("One common element with extra in first slice",
+			intersectionCase{
+				s1:                   []string{"bar"},
+				s2:                   []string{"bar", "foo"},
+				expectedIntersection: []string{"bar"},
+			}),
+		table.Entry("Both identical with two elements",
+			intersectionCase{
+				s1:                   []string{"foo", "bar"},
+				s2:                   []string{"bar", "foo"},
+				expectedIntersection: []string{"bar", "foo"},
+			}),
+		table.Entry("Duplicates in first slice",
+			intersectionCase{
+				s1:                   []string{"foo", "bar", "one", "two", "three", "one", "two", "three"},
+				s2:                   []string{"bar", "foo", "three", "one"},
+				expectedIntersection: []string{"bar", "foo", "three", "one"},
+			}),
+		table.Entry("Duplicates in second slice",
+			intersectionCase{
+				s1:                   []string{"bar", "foo", "three", "one"},
+				s2:                   []string{"foo", "bar", "one", "two", "three", "one", "two", "three"},
+				expectedIntersection: []string{"foo", "bar", "one", "three"},
+			}),
+	)
 })

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -103,7 +103,7 @@ func ApplyDesiredState(client client.Client, desiredState shared.State) (string,
 		return "Ignoring empty desired state", nil
 	}
 
-	out, err := EnableVlanFiltering()
+	out, err := EnableVlanFiltering(desiredState)
 	if err != nil {
 		return out, fmt.Errorf("failed to enable vlan filtering via nmcli: %s", err.Error())
 	}


### PR DESCRIPTION
Backport of https://github.com/nmstate/kubernetes-nmstate/pull/901
Only apply vlan filtering via nmcli to bridges and ports
that are listed in desiredState and also exist in current
state.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
