### PR TITLE
Whitespace linter: remove unnecessary newlines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,4 +85,4 @@ linters:
       #- unparam
       #- unused
     - varcheck
-      #- whitespace
+    - whitespace

--- a/controllers/handler/node_controller.go
+++ b/controllers/handler/node_controller.go
@@ -155,7 +155,6 @@ func (r *NodeReconciler) getDependencyVersions() *nmstate.DependencyVersions {
 }
 
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
 	r.nmstateUpdater = nmstate.CreateOrUpdateNodeNetworkState
 	r.nmstatectlShow = nmstatectl.Show
 	r.deviceInfo = state.DeviceInfo{}

--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -72,7 +72,6 @@ func CreateOrUpdateNodeNetworkState(client client.Client, node *corev1.Node, obs
 }
 
 func UpdateCurrentState(client client.Client, nodeNetworkState *nmstatev1beta1.NodeNetworkState, observedState shared.State, versions *DependencyVersions) error {
-
 	if observedState.String() == nodeNetworkState.Status.CurrentState.String() {
 		log.Info("Skipping NodeNetworkState update, node network configuration not changed")
 		return nil

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -33,13 +33,11 @@ func nmstatectlWithInput(arguments []string, input string) (string, error) {
 				fmt.Printf("failed to write input into stdin: %v\n", err)
 			}
 		}()
-
 	}
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to execute %s %s: '%v' '%s' '%s'", nmstateCommand, strings.Join(arguments, " "), err, stdout.String(), stderr.String())
 	}
 	return stdout.String(), nil
-
 }
 
 func nmstatectl(arguments []string) (string, error) {

--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -54,7 +54,6 @@ func currentStateAsGJson() (gjson.Result, error) {
 		return gjson.Result{}, errors.Wrap(err, "failed to convert current state to JSON")
 	}
 	return gjson.ParseBytes(currentState), nil
-
 }
 
 func ping(target string, timeout time.Duration) (string, error) {
@@ -259,7 +258,6 @@ func Run(client client.Client, probes []Probe) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed runnig probe '%s' with after network reconfiguration -> currentState: %s", p.name, currentState)
 		}
-
 	}
 	return nil
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/conditions_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/conditions_test.go
@@ -30,7 +30,6 @@ func expectConditionsUnknown(policy nmstatev1.NodeNetworkConfigurationPolicy) {
 }
 
 func callHook(hook *webhook.Admission, request webhook.AdmissionRequest) webhook.AdmissionResponse {
-
 	response := hook.Handle(context.TODO(), request)
 	for _, patch := range response.Patches {
 		_, err := patch.MarshalJSON()

--- a/pkg/webhook/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_suite_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/nodenetworkconfigurationpolicy_suite_test.go
@@ -29,8 +29,8 @@ func requestForPolicy(policy nmstatev1.NodeNetworkConfigurationPolicy) webhook.A
 	}
 	return request
 }
-func patchPolicy(policy nmstatev1.NodeNetworkConfigurationPolicy, response webhook.AdmissionResponse) nmstatev1.NodeNetworkConfigurationPolicy {
 
+func patchPolicy(policy nmstatev1.NodeNetworkConfigurationPolicy, response webhook.AdmissionResponse) nmstatev1.NodeNetworkConfigurationPolicy {
 	patch, err := jsonpatch.DecodePatch(response.Patch)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 

--- a/test/e2e/handler/linuxbridge/gjson.go
+++ b/test/e2e/handler/linuxbridge/gjson.go
@@ -8,7 +8,6 @@ import (
 // to filter `bridge -j vlan show` by interface and vlan, there
 // are two json versions possible it tries to guess which one is.
 func BuildGJsonExpression(bridgeVlans string) string {
-
 	if strings.Contains(bridgeVlans, "ifname") {
 		return "#(ifname==%s).vlans.#(vlan==%d)"
 	}

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -94,7 +94,6 @@ func TestE2E(t *testing.T) {
 	}
 
 	RunSpecsWithDefaultAndCustomReporters(t, "E2E Test Suite", reporters)
-
 }
 
 var _ = BeforeEach(func() {

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -197,7 +197,6 @@ func deletePolicy(name string) {
 			return apierrors.IsNotFound(err)
 		}, enactmentsDeleteTimeout, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Enactment %s not deleted", enactmentKey.Name))
 	}
-
 }
 
 func restartNode(node string) error {
@@ -378,7 +377,6 @@ func getVLANFlagsEventually(node string, connection string, vlan int) AsyncAsser
 }
 
 func hasVlans(node string, connection string, minVlan int, maxVlan int) AsyncAssertion {
-
 	ExpectWithOffset(1, minVlan).To(BeNumerically(">", 0))
 	ExpectWithOffset(1, maxVlan).To(BeNumerically(">", 0))
 	ExpectWithOffset(1, maxVlan).To(BeNumerically(">=", minVlan))
@@ -421,7 +419,6 @@ func vlansCardinality(node string, connection string) AsyncAssertion {
 
 		return len(gjson.Parse(bridgeVlans).Get(connection).Array()), nil
 	}, ReadTimeout, ReadInterval)
-
 }
 
 func bridgeDescription(node string, bridgeName string) AsyncAssertion {

--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -149,7 +149,6 @@ func eventuallyOperandIsNotFound(testData operatorTestData) {
 		err := testenv.Client.List(context.TODO(), &podList, &client.ListOptions{Namespace: testData.ns, LabelSelector: labels.Set{"app": "kubernetes-nmstate"}.AsSelector()})
 		return podList.Items, err
 	}, 120*time.Second, time.Second).Should(BeEmpty(), "should terminate all the pods")
-
 }
 
 func eventuallyOperandIsFound(testData operatorTestData) {

--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -132,7 +132,6 @@ func (r *KubernetesNMStateReporter) logNetworkManager(testName string, sinceTime
 }
 
 func (r *KubernetesNMStateReporter) logPods(testName string, sinceTime time.Time) error {
-
 	// Let's print the pods logs to the GinkgoWriter so
 	// we see the failure directly at prow junit output without opening files
 	r.OpenTestLogFile("pods", testName, podLogsWriter(r.namespace, sinceTime))


### PR DESCRIPTION
Solved warnings from whitespace linter - removed extra trailing/leading whitespaces.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
