### PR TITLE
Unconvert linter: remove unnecessary conversions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
       #- structcheck
       #- stylecheck
     - typecheck
-      #- unconvert
+    - unconvert
       #- unparam
       #- unused
     - varcheck

--- a/pkg/webhook/nodenetworkconfigurationpolicy/conditions.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/conditions.go
@@ -3,9 +3,8 @@ package nodenetworkconfigurationpolicy
 import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 )
 
@@ -32,20 +31,18 @@ func atEmptyConditions(policy nmstatev1.NodeNetworkConfigurationPolicy) bool {
 
 func deleteConditionsHook() *webhook.Admission {
 	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				always,
-				deleteConditions,
-			)),
+		Handler: mutatePolicyHandler(
+			always,
+			deleteConditions,
+		),
 	}
 }
 
 func setConditionsUnknownHook() *webhook.Admission {
 	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				atEmptyConditions,
-				setConditionsUnknown,
-			)),
+		Handler: mutatePolicyHandler(
+			atEmptyConditions,
+			setConditionsUnknown,
+		),
 	}
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/timestamp.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 )
@@ -25,10 +24,9 @@ func setTimestampAnnotation(policy nmstatev1.NodeNetworkConfigurationPolicy) nms
 
 func setTimestampAnnotationHook() *webhook.Admission {
 	return &webhook.Admission{
-		Handler: admission.HandlerFunc(
-			mutatePolicyHandler(
-				always,
-				setTimestampAnnotation,
-			)),
+		Handler: mutatePolicyHandler(
+			always,
+			setTimestampAnnotation,
+		),
 	}
 }

--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
@@ -81,12 +81,12 @@ func validatePolicyName(policy nmstatev1.NodeNetworkConfigurationPolicy, current
 func validatePolicyUpdateHook(cli client.Client) *webhook.Admission {
 	return &webhook.Admission{
 		Handler: admission.MultiValidatingHandler(
-			admission.HandlerFunc(validatePolicyHandler(
+			validatePolicyHandler(
 				cli,
 				onPolicySpecChange,
 				validatePolicyNotInProgressHook,
 				validatePolicyNodeSelector,
-			)),
+			),
 		),
 	}
 }
@@ -94,11 +94,11 @@ func validatePolicyUpdateHook(cli client.Client) *webhook.Admission {
 func validatePolicyCreateHook(cli client.Client) *webhook.Admission {
 	return &webhook.Admission{
 		Handler: admission.MultiValidatingHandler(
-			admission.HandlerFunc(validatePolicyHandler(
+			validatePolicyHandler(
 				cli,
 				onCreate,
 				validatePolicyName,
-			)),
+			),
 		),
 	}
 }

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -355,7 +355,7 @@ func getVLANFlagsEventually(node string, connection string, vlan int) AsyncAsser
 			// [1] https://bugs.centos.org/view.php?id=16533
 			output, err := cmd.Run("test/e2e/get-bridge-vlans-flags-el8.sh", false, node, connection, strconv.Itoa(vlan))
 			Expect(err).ToNot(HaveOccurred())
-			return strings.Split(string(output), " ")
+			return strings.Split(output, " ")
 		} else {
 			By("Getting vlan filtering from json output")
 			parsedBridgeVlans := gjson.Parse(bridgeVlans)


### PR DESCRIPTION
Solved warnings from unconvert linter - removed unnecessary conversions.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
