### PR TITLE
Use Eventually when waiting for policy to be set Degraded

### DIFF
--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -21,8 +21,6 @@ func invalidConfig(bridgeName string) nmstate.State {
 
 var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]EnactmentCondition", func() {
 	Context("when applying valid config", func() {
-		BeforeEach(func() {
-		})
 		AfterEach(func() {
 			By("Remove the bridge")
 			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
@@ -179,7 +177,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}).Should(BeNumerically(">=", 1))
 
 			By("Checking the policy is marked as Degraded")
-			Expect(policyConditionsStatus(TestPolicy)).Should(containPolicyDegraded(), "policy should be marked as Degraded")
+			Eventually(policyConditionsStatus(TestPolicy)).Should(containPolicyDegraded(), "policy should be marked as Degraded")
 		})
 	})
 })


### PR DESCRIPTION
This test checks that after first enactment fails configuration, the
policy is set to Degraded.
The problem is, Enactments update their status before the
policy status, so we need to wait for a bit.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
