### PR TITLE
[release-0.52] Add timeout when waiting for an enactment to fail

### DIFF
--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -174,7 +175,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Waiting for first enactment to fail")
 			Eventually(func() int {
 				return failingEnactmentsCount(TestPolicy)
-			}).Should(BeNumerically(">=", 1))
+			}, 180*time.Second, 1*time.Second).Should(BeNumerically(">=", 1))
 
 			By("Checking the policy is marked as Degraded")
 			Eventually(policyConditionsStatus(TestPolicy)).Should(containPolicyDegraded(), "policy should be marked as Degraded")


### PR DESCRIPTION
Backport of https://github.com/nmstate/kubernetes-nmstate/pull/914

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
