### PR TITLE
Don't wait for node boot when waiting for nncp transition

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -103,8 +103,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			// Restart only first node that it's a control-plane if other node is restarted it will stuck in NotReady state
 			nodeToReboot := nodes[0]
 			Byf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot)
-			err := restartNode(nodeToReboot)
-			Expect(err).ToNot(HaveOccurred())
+			restartNodeWithoutWaiting(nodeToReboot)
 
 			By("Wait for policy re-reconciled after node reboot")
 			waitForPolicyTransitionUpdate(TestPolicy)

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -137,8 +137,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 			It("should keep the default IP address after node reboot", func() {
 				nodeToReboot := nodes[0]
 
-				err := restartNode(nodeToReboot)
-				Expect(err).ToNot(HaveOccurred())
+				restartNodeWithoutWaiting(nodeToReboot)
 
 				By("Wait for policy re-reconciled after node reboot")
 				waitForPolicyTransitionUpdate(DefaultNetwork)


### PR DESCRIPTION
The function waiting for node reboot is checking if ssh connects
every 5 seconds, which seems to be enough for a simple policy to
start reconciling and even finish, meaning that subsequent
check, that waits for a NNCP transition timestamp to be updated
fails (as no more transitions happen).

This change doesn't wait for the node to boot and relies only on
the transition timestamp update.

Also, fixed restartNodeWithoutWaiting which didn't return an error

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Fixes flake that occured in https://github.com/nmstate/kubernetes-nmstate/pull/914
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
