### PR TITLE
[release-0.52] Fix defaulting of maxUnavailable when wrong input is provided (#885)

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -348,7 +348,9 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 	}
 	maxUnavailable, err := node.MaxUnavailableNodeCount(r.APIClient, policy)
 	if err != nil {
-		return err
+		r.Log.Info(
+			fmt.Sprintf("failed calculating limit of max unavailable nodes, defaulting to %d, err: %s", maxUnavailable, err.Error()),
+		)
 	}
 	if policy.Status.UnavailableNodeCount >= maxUnavailable {
 		return apierrors.NewConflict(schema.GroupResource{Resource: "nodenetworkconfigurationpolicies"}, policy.Name, fmt.Errorf("maximal number of %d nodes are already processing policy configuration", policy.Status.UnavailableNodeCount))

--- a/pkg/node/node_suite_test.go
+++ b/pkg/node/node_suite_test.go
@@ -1,0 +1,16 @@
+package node
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.controller-nodenetworkconfigurationpolicy-node-node_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Node Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/node/nodes_test.go
+++ b/pkg/node/nodes_test.go
@@ -1,0 +1,81 @@
+package node
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("MaxUnavailable nodes", func() {
+	type maxUnavailableCase struct {
+		nmstateEnabledNodes          int
+		maxUnavailable               intstr.IntOrString
+		expectedScaledMaxUnavailable int
+		expectedError                types.GomegaMatcher
+	}
+	DescribeTable("testing ScaledMaxUnavailableNodeCount",
+		func(c maxUnavailableCase) {
+			maxUnavailable, err := ScaledMaxUnavailableNodeCount(c.nmstateEnabledNodes, c.maxUnavailable)
+			Expect(err).To(c.expectedError)
+			Expect(maxUnavailable).To(Equal(c.expectedScaledMaxUnavailable))
+		},
+		Entry("Default maxUnavailable with odd number of nodes",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString(DEFAULT_MAXUNAVAILABLE),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Default maxUnavailable with even number of nodes",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          6,
+				maxUnavailable:               intstr.FromString(DEFAULT_MAXUNAVAILABLE),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Absolute maxUnavailable with odd number of nodes",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromInt(3),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Absolute maxUnavailable with even number of nodes",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          6,
+				maxUnavailable:               intstr.FromInt(3),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Wrong string value",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("asdf"),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                HaveOccurred(),
+			}),
+		Entry("Absolute value in string",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("42"),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                HaveOccurred(),
+			}),
+		Entry("Zero percent",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("0%"),
+				expectedScaledMaxUnavailable: 1,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Zero value",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromInt(0),
+				expectedScaledMaxUnavailable: 1,
+				expectedError:                Not(HaveOccurred()),
+			}))
+})


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
