### PR TITLE
Set DNS_TEST_NIC default to primaryNic

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 	primaryNic = environment.GetVarWithDefault("PRIMARY_NIC", "eth0")
 	firstSecondaryNic = environment.GetVarWithDefault("FIRST_SECONDARY_NIC", "eth1")
 	secondSecondaryNic = environment.GetVarWithDefault("SECOND_SECONDARY_NIC", "eth2")
-	dnsTestNic = environment.GetVarWithDefault("DNS_TEST_NIC", "eth0")
+	dnsTestNic = environment.GetVarWithDefault("DNS_TEST_NIC", primaryNic)
 
 	testenv.Start()
 


### PR DESCRIPTION
Eliminate the need to define DNS_TEST_NIC for platforms (like OCP) that use primaryNic for DNS testing.
So, they only need to configure PRIMARY_NIC env var.

Signed-off-by: Yossi Boaron  <yboaron@redhat.comt>




**What this PR does / why we need it**:
Eliminate the need to define DNS_TEST_NIC for platforms (like OCP) that use primaryNic for handler e2e DNS testing

**Release note**:
NONE
```
