### PR TITLE
Fix issues in DNS tests

### DIFF
--- a/test/e2e/handler/dns_test.go
+++ b/test/e2e/handler/dns_test.go
@@ -27,6 +27,8 @@ interfaces:
     enabled: true
     dhcp: true
   %s:
+    enabled: true
+    dhcp: true
     auto-dns: false
 
 `, searchDomain1, searchDomain2, server1, server2, dnsTestNic, ipFamily, ipFamily1))
@@ -41,8 +43,12 @@ interfaces:
   type: ethernet
   state: up
   ipv4:
+    dhcp: true
+    enabled: true
     auto-dns: true
   ipv6:
+    dhcp: true
+    enabled: true
     auto-dns: true
 `, dnsTestNic))
 }
@@ -55,10 +61,6 @@ var _ = Describe("Dns configuration", func() {
 			server1V4     = "8.8.9.9"
 			server1V6     = "2001:db8::1:2"
 		)
-
-		BeforeEach(func() {
-			Skip("https://github.com/nmstate/kubernetes-nmstate/issues/927")
-		})
 
 		Context("with V4 upstream servers", func() {
 			BeforeEach(func() {

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -164,18 +164,14 @@ func ifaceUpWithStaticIP(iface string, ipAddress string, prefixLen string) nmsta
 `, iface, ipAddress, prefixLen))
 }
 
-func ifaceUpWithStaticIPAbsent(firstSecondaryNic, ipAddress, prefixLen string) nmstate.State {
+func ifaceUpWithStaticIPAbsent(firstSecondaryNic string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
   - name: %s
     type: ethernet
     state: up
     ipv4:
-      address:
-      - ip: %s
-        prefix-length: %s
-      state: absent
       enabled: false
-`, firstSecondaryNic, ipAddress, prefixLen))
+`, firstSecondaryNic))
 }
 
 func ifaceUpWithVlanUp(iface string, vlanID string) nmstate.State {


### PR DESCRIPTION
Addresses https://github.com/nmstate/kubernetes-nmstate/issues/927

Following issues are causing the tests to fail:
1. removing of IP address from an interface was done by using
`absent` withing ipv4 subtree. This is likely a bug in nmstate
as this subtree doesn't specify such property.
2. in static_addr_and_route_test, one IP address was assigned
to all worker nodes. This change designates only one worker
node to have the NNCPs configured. This reduction
doesn't limit our coverage as it shouldn't matter if this configuration
is applied to one node or more.
3. some policies missed ipv4/6.enabled: true, which may not be causing
an issue, but this change specifies the enabled property explicitly.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Fixes https://github.com/nmstate/kubernetes-nmstate/issues/927
**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
