### PR TITLE
compile: Disable CGO for operator/handler

### DIFF
--- a/hack/build-manager.sh
+++ b/hack/build-manager.sh
@@ -6,6 +6,7 @@ name=$1
 destdir=$2
 
 export GOOS=linux
+export CGO_ENABLED=0
 
 if [ "$ARCHS" == "" ]; then
     go build -o $destdir/$name.manager.$GOOS-$(go env GOARCH) ./cmd/$name


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
CGO is not needed by the project right now and it involve linking to
libc, that could be a problem. This change disable CGO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Disable CGO at compilation.
```
