### PR TITLE
webhook: Deny NNCP update if capture is modified

### DIFF
--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation.go
@@ -78,6 +78,18 @@ func validatePolicyName(policy nmstatev1.NodeNetworkConfigurationPolicy, current
 	return causes
 }
 
+func validatePolicyCaptureNotModified(policy nmstatev1.NodeNetworkConfigurationPolicy, currentPolicy nmstatev1.NodeNetworkConfigurationPolicy) []metav1.StatusCause {
+	causes := []metav1.StatusCause{}
+	if !reflect.DeepEqual(policy.Spec.Capture, currentPolicy.Spec.Capture) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: "invalid policy operation: capture field cannot be modified",
+			Field:   "capture",
+		})
+	}
+	return causes
+}
+
 func validatePolicyUpdateHook(cli client.Client) *webhook.Admission {
 	return &webhook.Admission{
 		Handler: admission.MultiValidatingHandler(
@@ -86,6 +98,7 @@ func validatePolicyUpdateHook(cli client.Client) *webhook.Admission {
 				onPolicySpecChange,
 				validatePolicyNotInProgressHook,
 				validatePolicyNodeSelector,
+				validatePolicyCaptureNotModified,
 			),
 		),
 	}

--- a/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/validation_test.go
@@ -125,5 +125,61 @@ var _ = Describe("NNCP Conditions Validation Admission Webhook", func() {
 				Field:   "name",
 			}},
 		}),
+		Entry("policy cannot create capture field", ValidationWebhookCase{
+			currentPolicy: nmstatev1.NodeNetworkConfigurationPolicy{},
+			policy: nmstatev1.NodeNetworkConfigurationPolicy{
+				Spec: shared.NodeNetworkConfigurationPolicySpec{
+					Capture: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			validationFn: validatePolicyCaptureNotModified,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueNotSupported,
+				Message: "invalid policy operation: capture field cannot be modified",
+				Field:   "capture",
+			}},
+		}),
+		Entry("policy cannot modify capture field", ValidationWebhookCase{
+			currentPolicy: nmstatev1.NodeNetworkConfigurationPolicy{
+				Spec: shared.NodeNetworkConfigurationPolicySpec{
+					Capture: map[string]string{
+						"foo": "bar",
+						"bar": "dar",
+					},
+				},
+			},
+			policy: nmstatev1.NodeNetworkConfigurationPolicy{
+				Spec: shared.NodeNetworkConfigurationPolicySpec{
+					Capture: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			validationFn: validatePolicyCaptureNotModified,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueNotSupported,
+				Message: "invalid policy operation: capture field cannot be modified",
+				Field:   "capture",
+			}},
+		}),
+		Entry("policy cannot delete capture field", ValidationWebhookCase{
+			currentPolicy: nmstatev1.NodeNetworkConfigurationPolicy{
+				Spec: shared.NodeNetworkConfigurationPolicySpec{
+					Capture: map[string]string{
+						"foo": "bar",
+						"bar": "dar",
+					},
+				},
+			},
+			policy:       nmstatev1.NodeNetworkConfigurationPolicy{},
+			validationFn: validatePolicyCaptureNotModified,
+			validationResult: []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueNotSupported,
+				Message: "invalid policy operation: capture field cannot be modified",
+				Field:   "capture",
+			}},
+		}),
 	)
 })

--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -83,6 +83,9 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
 					"brext-bridge": `interfaces.name=="brext"`,
 				}
 
+				Byf("Removeing %s NNCP since capture cannot be modified", DefaultNetwork)
+				deletePolicy(DefaultNetwork)
+
 				Byf("Removing bridge and configuring %s with dhcp", primaryNic)
 				setDesiredStateWithPolicyAndCapture(DefaultNetwork, resetDefaultInterfaceState, capture)
 

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -86,4 +86,20 @@ var _ = Describe("Validation Admission Webhook", func() {
 			Expect(err).To(MatchError("admission webhook \"nodenetworkconfigurationpolicies-create-validate.nmstate.io\" denied the request: failed to admit NodeNetworkConfigurationPolicy this-is-longer-than-sixty-three-characters-hostnames-bar-bar.com: message: invalid policy name: \"this-is-longer-than-sixty-three-characters-hostnames-bar-bar.com\": must be no more than 63 characters. "))
 		})
 	})
+	Context("When a policy capture field is updated", func() {
+		BeforeEach(func() {
+			By("Create a policy without capture field")
+			updateDesiredStateAndWait(linuxBrUp(bridge1))
+		})
+		It("should deny creating the capture field", func() {
+			By("Add capture field to the NNCP")
+			capture := map[string]string{"default-gw": `routes.running.destination=="0.0.0.0/0"`}
+			err := setDesiredStateWithPolicyAndCaptureAndNodeSelector(TestPolicy, linuxBrUpNoPorts(bridge1), capture, map[string]string{})
+			Expect(err).To(MatchError(`admission webhook "nodenetworkconfigurationpolicies-update-validate.nmstate.io" denied the request: failed to admit NodeNetworkConfigurationPolicy test-policy: message: invalid policy operation: capture field cannot be modified. `))
+		})
+		AfterEach(func() {
+			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
+			resetDesiredStateForNodes()
+		})
+	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Updateing the capture field at NNCP can break scenarios where nodes are
rebooted and NetworkManager configuration is not presistent. This change
prevent that but just disallow update capture field, if it need to be
modified the NNCP has to be re-created.


**Special notes for your reviewer**:
This is a first step before implementing a better solution.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Deny capture field update at webhook level.
```
