### PR TITLE
Provide a way to skip the image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ INDEX_VERSION ?= 1.0.0
 # Default index image tag
 INDEX_IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO)/kubernetes-nmstate-operator-index:$(INDEX_VERSION)
 
+SKIP_IMAGE_BUILD ?= false
+
 all: check handler
 
 check: vet whitespace-check gofmt-check
@@ -143,13 +145,13 @@ handler: SKIP_PUSH=true
 handler: push-handler
 
 push-handler: handler-manager
-	SKIP_PUSH=$(SKIP_PUSH) IMAGE=${HANDLER_IMAGE} hack/build-push-container.${IMAGE_BUILDER}.sh . -f build/$(HANDLER_DOCKERFILE)
+	SKIP_PUSH=$(SKIP_PUSH) SKIP_IMAGE_BUILD=$(SKIP_IMAGE_BUILD) IMAGE=${HANDLER_IMAGE} hack/build-push-container.${IMAGE_BUILDER}.sh . -f build/$(HANDLER_DOCKERFILE)
 
 operator: SKIP_PUSH=true
 operator: push-operator
 
 push-operator: operator-manager
-	SKIP_PUSH=$(SKIP_PUSH) IMAGE=${OPERATOR_IMAGE} hack/build-push-container.${IMAGE_BUILDER}.sh  . -f build/Dockerfile.operator
+	SKIP_PUSH=$(SKIP_PUSH) SKIP_IMAGE_BUILD=$(SKIP_IMAGE_BUILD) IMAGE=${OPERATOR_IMAGE} hack/build-push-container.${IMAGE_BUILDER}.sh  . -f build/Dockerfile.operator
 
 push: push-handler push-operator
 

--- a/hack/build-push-container.docker.sh
+++ b/hack/build-push-container.docker.sh
@@ -2,6 +2,11 @@
 
 set -x -o errexit -o nounset -o pipefail
 
+if [ "$SKIP_IMAGE_BUILD" == "true" ]; then
+    echo "skipping image build"
+    exit 0
+fi
+
 hack/init-buildx.sh
 
 ARCHS=${ARCHS:-$(go env GOARCH)}

--- a/hack/build-push-container.podman.sh
+++ b/hack/build-push-container.podman.sh
@@ -15,7 +15,13 @@ podman manifest create ${IMAGE}
 IMAGES=${IMAGE}
 for arch in $ARCHS; do
     podman build --arch $arch --build-arg TARGETARCH=$arch -t $IMAGE.$arch $@
-    podman push --tls-verify=$TLS_VERIFY ${IMAGE}.$arch
     podman manifest add --tls-verify=$TLS_VERIFY ${IMAGE} docker://${IMAGE}.$arch
+
+    if [ ! "$SKIP_PUSH" == "true" ]; then
+        podman push --tls-verify=$TLS_VERIFY ${IMAGE}.$arch
+    fi
 done
+
+if [ ! "$SKIP_PUSH" == "true" ]; then
 podman manifest push --tls-verify=$TLS_VERIFY ${IMAGE} docker://${IMAGE}
+fi

--- a/hack/build-push-container.podman.sh
+++ b/hack/build-push-container.podman.sh
@@ -2,6 +2,11 @@
 
 set -x -o errexit -o nounset -o pipefail
 
+if [ "$SKIP_IMAGE_BUILD" == "true" ]; then
+    echo "skipping image build"
+    exit 0
+fi
+
 TLS_VERIFY=true
 if [[ $IMAGE_REGISTRY =~ localhost ]]; then
     TLS_VERIFY=false
@@ -23,5 +28,5 @@ for arch in $ARCHS; do
 done
 
 if [ ! "$SKIP_PUSH" == "true" ]; then
-podman manifest push --tls-verify=$TLS_VERIFY ${IMAGE} docker://${IMAGE}
+    podman manifest push --tls-verify=$TLS_VERIFY ${IMAGE} docker://${IMAGE}
 fi


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
Sometimes it is not needed (or even not possible) to build the images via `make push` (or `make handler` / `make operator`). E.g. some CI environments use their own builders and don't support calls to podman or docker. This PR addresses it and adds an option to skip the image builds via the `SKIP_IMAGE_BUILD` var. That way the builds via podman or docker can be skipped.

**Special notes for your reviewer**:
I also fixed the podman build (f3f8f5181a91d0ec4678ce49f8cec6c676f178a1), as it seemed not to respect the `SKIP_PUSH` var as done with docker: https://github.com/nmstate/kubernetes-nmstate/blob/e1eb3ecdb2fe8d570ba4d96f268c43328dde7017/hack/build-push-container.docker.sh#L23-L27

**Release note**:
```release-note
none
```
