### PR TITLE
Fix nnce formatting

### DIFF
--- a/pkg/enactmentstatus/message.go
+++ b/pkg/enactmentstatus/message.go
@@ -51,15 +51,23 @@ func FormatErrorString(errorMessage string) string {
 
 // Loops over all lines in error message and selects lines that should be kept
 func formatLines(index int, errorLines []string, sb *strings.Builder) {
+	shouldFormatLine := true
 	for index < len(errorLines) {
-		formatLine(&errorLines[index], sb)
+		if errorLines[index] == "---" {
+			shouldFormatLine = false
+		}
+		processLine(&errorLines[index], sb, shouldFormatLine)
 		index++
 		index = skipLines(errorLines, index)
 	}
 }
 
 // Simplifies a line that should be kept in the error message
-func formatLine(errorLine *string, sb *strings.Builder) {
+func processLine(errorLine *string, sb *strings.Builder, shouldFormatLine bool) {
+	if !shouldFormatLine {
+		sb.WriteString(*errorLine + "\n")
+		return
+	}
 	lineSplitByColon := strings.Split(strings.TrimRight(*errorLine, " "), ": ")
 	indent := ""
 	for _, lineSection := range lineSplitByColon {

--- a/pkg/enactmentstatus/message_test.go
+++ b/pkg/enactmentstatus/message_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Error messages formatting", func() {
 		pingInvalidOutput      = "      \n  failed to retrieve default gw at runProbes\n    timed out waiting for the condition\n"
 		pingValidInput         = "rolling back desired state configuration: failed runnig probes after network changes: failed runnig probe 'ping' with after network reconfiguration.\nThe rest of the message should be kept.\n"
 		pingValidOutput        = "rolling back desired state configuration\n  failed runnig probes after network changes\n    failed runnig probe 'ping' with after network reconfiguration.\nThe rest of the message should be kept.\n"
+		desiredStateYaml       = "libnmstate.error.NmstateVerificationError:\n      desired\n      =======\n---\n      name: eth1\n      type: ethernet\n      state: up\n"
 	)
 
 	Context("With DEBUG text", func() {
@@ -50,6 +51,11 @@ var _ = Describe("Error messages formatting", func() {
 		})
 		It("Should keep message", func() {
 			Expect(FormatErrorString(pingValidInput)).To(Equal(pingValidOutput))
+		})
+	})
+	Context("With yaml states", func() {
+		It("Should keep the original message", func() {
+			Expect(FormatErrorString(desiredStateYaml)).To(Equal(desiredStateYaml))
 		})
 	})
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
When the error message of NNCE was being formatted, it also affected the desiredState. However, the original yaml-like formatting was more readable and we would like to keep that.
The NNCE now yields the same formatting as nmstatectl.

resolves #930 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
