### PR TITLE
Change NNCE error message encoding to Gzip

### DIFF
--- a/pkg/enactmentstatus/message.go
+++ b/pkg/enactmentstatus/message.go
@@ -19,7 +19,7 @@ package enactmentstatus
 
 import (
 	"bytes"
-	"compress/flate"
+	"compress/gzip"
 	b64 "encoding/base64"
 	"io"
 	"regexp"
@@ -129,12 +129,9 @@ func CompressAndEncodeMessage(message string) string {
 
 func compressMessage(message string) (bytes.Buffer, error) {
 	var buf bytes.Buffer
-	writer, err := flate.NewWriter(&buf, flate.BestCompression)
-	if err != nil {
-		return bytes.Buffer{}, err
-	}
+	writer := gzip.NewWriter(&buf)
 
-	_, err = writer.Write([]byte(message))
+	_, err := writer.Write([]byte(message))
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
@@ -162,7 +159,10 @@ func decodeMessage(encodedMessage string) []byte {
 
 func decompressMessage(data []byte) string {
 	bytesReader := bytes.NewReader(data)
-	flateReader := flate.NewReader(bytesReader)
-	decompressedMessage, _ := io.ReadAll(flateReader)
+	gzipReader, err := gzip.NewReader(bytesReader)
+	if err != nil {
+		return ""
+	}
+	decompressedMessage, _ := io.ReadAll(gzipReader)
 	return string(decompressedMessage)
 }


### PR DESCRIPTION
The NNCE encodedMessage is now encoded using Gzip, so it can be easily decompressed with standard linux utility.

resolves #931 

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
