### PR TITLE
[release-0.52] Retry when incrementing maxUnavailable

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -40,7 +40,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -183,7 +182,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	if r.shouldIncrementUnavailableNodeCount(previousConditions) {
 		err = r.incrementUnavailableNodeCount(instance)
 		if err != nil {
-			if apierrors.IsConflict(err) {
+			if apierrors.IsConflict(err) || errors.Is(err, node.MaxUnavailableLimitReachedError{}) {
 				enactmentConditions.NotifyPending()
 				log.Info(err.Error())
 				return ctrl.Result{RequeueAfter: nodeRunningUpdateRetryTime}, nil
@@ -342,25 +341,23 @@ func (r *NodeNetworkConfigurationPolicyReconciler) shouldIncrementUnavailableNod
 
 func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) error {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
-	err := r.Client.Get(context.TODO(), policyKey, policy)
-	if err != nil {
-		return err
-	}
-	maxUnavailable, err := node.MaxUnavailableNodeCount(r.APIClient, policy)
-	if err != nil {
-		r.Log.Info(
-			fmt.Sprintf("failed calculating limit of max unavailable nodes, defaulting to %d, err: %s", maxUnavailable, err.Error()),
-		)
-	}
-	if policy.Status.UnavailableNodeCount >= maxUnavailable {
-		return apierrors.NewConflict(schema.GroupResource{Resource: "nodenetworkconfigurationpolicies"}, policy.Name, fmt.Errorf("maximal number of %d nodes are already processing policy configuration", policy.Status.UnavailableNodeCount))
-	}
-	policy.Status.UnavailableNodeCount += 1
-	err = r.Client.Status().Update(context.TODO(), policy)
-	if err != nil {
-		return err
-	}
-	return nil
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := r.Client.Get(context.TODO(), policyKey, policy)
+		if err != nil {
+			return err
+		}
+		maxUnavailable, err := node.MaxUnavailableNodeCount(r.APIClient, policy)
+		if err != nil {
+			r.Log.Info(
+				fmt.Sprintf("failed calculating limit of max unavailable nodes, defaulting to %d, err: %s", maxUnavailable, err.Error()),
+			)
+		}
+		if policy.Status.UnavailableNodeCount >= maxUnavailable {
+			return node.MaxUnavailableLimitReachedError{}
+		}
+		policy.Status.UnavailableNodeCount += 1
+		return r.Client.Status().Update(context.TODO(), policy)
+	})
 }
 
 func (r *NodeNetworkConfigurationPolicyReconciler) decrementUnavailableNodeCount(policy *nmstatev1beta1.NodeNetworkConfigurationPolicy) {

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -18,6 +18,12 @@ const (
 	MIN_MAXUNAVAILABLE     = 1
 )
 
+type MaxUnavailableLimitReachedError struct{}
+
+func (f MaxUnavailableLimitReachedError) Error() string {
+	return "maximal number of nodes are already processing policy configuration"
+}
+
 func NodesRunningNmstate(cli client.Reader, nodeSelector map[string]string) ([]corev1.Node, error) {
 	nodes := corev1.NodeList{}
 	err := cli.List(context.TODO(), &nodes, client.MatchingLabels(nodeSelector))


### PR DESCRIPTION
Backport of https://github.com/nmstate/kubernetes-nmstate/pull/934

Status update in incrementUnavailableNodeCount may fail due to a conflict.
It doesn't look good especially when maxUnavailable is set to 100%, as
seeing enactment in Pending state is not expected.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
