### PR TITLE
e2e: Increse time for checking policy is degraded

### DIFF
--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -178,7 +178,9 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 180*time.Second, 1*time.Second).Should(BeNumerically(">=", 1))
 
 			By("Checking the policy is marked as Degraded")
-			Eventually(policyConditionsStatus(TestPolicy)).Should(containPolicyDegraded(), "policy should be marked as Degraded")
+			Eventually(func() nmstate.ConditionList {
+				return policyConditionsStatus(TestPolicy)
+			}, 2*time.Second, 100*time.Millisecond).Should(containPolicyDegraded(), "policy should be marked as Degraded")
 		})
 	})
 })


### PR DESCRIPTION
In case conflicts occur, it may take over one second
to update policy status. Increasing to 2 seconds.
We can't increase the timeout too much as then the
test wouldn't test what we need.

It would be better to use a transition timestamp,
but currently, transition timestamp is updated also
when Reason changes, so we lose the time when the
policy actually turned Degraded/Available.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
