### PR TITLE
Add linux os nodeSelector to handler by default

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -178,6 +178,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 		archAndCRNodeSelector = map[string]string{}
 	}
 	archAndCRNodeSelector["beta.kubernetes.io/arch"] = goruntime.GOARCH
+	archAndCRNodeSelector["kubernetes.io/os"] = "linux"
 
 	handlerTolerations := instance.Spec.Tolerations
 	if handlerTolerations == nil {

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -190,8 +190,6 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-handler
       annotations:
         description: kubernetes-nmstate-handler configures and presents node networking, reconciling declerative NNCP and reports with NNS and NNCE
-      nodeSelector:
-        kubernetes.io/os: linux
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.


### PR DESCRIPTION
Fix adding linux nodeSelector to handler pods.
Add a unit test verifying that default nodeSelectors
are configured.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
