### PR TITLE
deps: Bump NMPolicy to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
-	github.com/nmstate/nmpolicy v0.1.1
+	github.com/nmstate/nmpolicy v0.1.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86w
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nmstate/nmpolicy v0.1.1 h1:pIjawf4kHx69JwtaWI3D9av0d5D8G+scRd0xJqpedxo=
-github.com/nmstate/nmpolicy v0.1.1/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
+github.com/nmstate/nmpolicy v0.1.2 h1:3g5zkJK+K7uM74MS7eu9ikotVHsz9enODD0+v70lMaw=
+github.com/nmstate/nmpolicy v0.1.2/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkUPjnpy6Is=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/filter.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/filter.go
@@ -56,7 +56,7 @@ func isEqual(obtainedValue interface{}, desiredValue ast.Node) (bool, error) {
 func mapContainsValue(mapToFilter map[string]interface{}, filterKey string, expectedNode ast.Node) (interface{}, error) {
 	obtainedValue, ok := mapToFilter[filterKey]
 	if !ok {
-		return nil, fmt.Errorf("cannot find key %s in %v", filterKey, mapToFilter)
+		return nil, nil
 	}
 	valueIsEqual, err := isEqual(obtainedValue, expectedNode)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -463,7 +463,7 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
-# github.com/nmstate/nmpolicy v0.1.1
+# github.com/nmstate/nmpolicy v0.1.2
 ## explicit
 github.com/nmstate/nmpolicy/nmpolicy
 github.com/nmstate/nmpolicy/nmpolicy/internal


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
There is a bug at NMPolicy that prevent using optional fields at eq
filter. This change bump the dependency to v0.1.2

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump nmpolicy to v0.1.2
```
