### PR TITLE
e2e: Add dhcp unaware DNS tests

### DIFF
--- a/test/e2e/handler/dns_test.go
+++ b/test/e2e/handler/dns_test.go
@@ -19,6 +19,7 @@ package handler
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,7 +27,7 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 )
 
-func dnsConfig(searchDomain1, searchDomain2, server1, server2, ipFamily, ipFamily1, dnsTestNic string) nmstate.State {
+func dhcpAwareDNSConfig(searchDomain1, searchDomain2, server1, server2, dnsTestNic string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`dns-resolver:
   config:
    search:
@@ -39,34 +40,117 @@ interfaces:
 - name: %s
   type: ethernet
   state: up
-  %s:
+  ipv4:
     auto-dns: false
     enabled: true
     dhcp: true
-  %s:
+  ipv6:
     enabled: true
     dhcp: true
     auto-dns: false
-
-`, searchDomain1, searchDomain2, server1, server2, dnsTestNic, ipFamily, ipFamily1))
+`, searchDomain1, searchDomain2, server1, server2, dnsTestNic))
 }
 
-func dnsAbsent(dnsTestNic string) nmstate.State {
-	return nmstate.NewState(fmt.Sprintf(`dns-resolver:
+func staticIPAndGwConfig(searchDomain1, searchDomain2, server1, server2, dnsTestNic, dnsTestNicIP string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`
+dns-resolver:
   config:
-    state: absent
+   search:
+   - %s
+   - %s
+   server:
+   - %s
+   - %s
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    metric: 100
+    next-hop-address: %s
+    next-hop-interface: %s
+    table-id: 253
+  - destination: 0::/0
+    metric: 100
+    next-hop-address: fd80:0:0:0::1
+    next-hop-interface: eth1
+    table-id: 253
 interfaces:
 - name: %s
   type: ethernet
   state: up
   ipv4:
-    dhcp: true
+    address:
+    - ip: %s
+      prefix-length: 24
     enabled: true
-    auto-dns: true
+    dhcp: false
+    auto-dns: false
+- name: eth1
+  type: ethernet
+  state: up
   ipv6:
-    dhcp: true
     enabled: true
+    dhcp: false
+    auto-dns: false
+    address:
+    - ip: 2001:db8::1:1
+      prefix-length: 64
+`, searchDomain1, searchDomain2, server1, server2, dnsTestNicIP, dnsTestNic, dnsTestNic, dnsTestNicIP))
+}
+
+func staticIPAbsentAndRoutesAbsent(dnsTestNic, dnsTestNicIP string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`dns-resolver:
+  config:
+    server: []
+    search: []
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    metric: 100
+    state: absent
+    next-hop-address: %s
+    next-hop-interface: %s
+    table-id: 253
+  - destination: 0::/0
+    state: absent
+    metric: 100
+    next-hop-address: fd80:0:0:0::1
+    next-hop-interface: eth1
+    table-id: 253
+interfaces:
+- name: %s
+  type: ethernet
+  state: up
+  ipv4:
     auto-dns: true
+    enabled: true
+    dhcp: true
+  ipv6:
+    auto-dns: true
+    enabled: true
+    dhcp: true
+- name: eth1
+  type: ethernet
+  state: down
+`, dnsTestNicIP, dnsTestNic, dnsTestNic))
+}
+
+func dhcpAwareDNSAbsent(dnsTestNic string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`dns-resolver:
+  config:
+    server: []
+    search: []
+interfaces:
+- name: %s
+  type: ethernet
+  state: up
+  ipv4:
+    auto-dns: true
+    enabled: true
+    dhcp: true
+  ipv6:
+    auto-dns: true
+    enabled: true
+    dhcp: true
 `, dnsTestNic))
 }
 
@@ -78,51 +162,140 @@ var _ = Describe("Dns configuration", func() {
 			server1V4     = "8.8.9.9"
 			server1V6     = "2001:db8::1:2"
 		)
+		extractDNSServerAddress := func(dnsServer string) string {
+			return strings.Split(dnsServer, "%")[0]
+		}
 
-		Context("with V4 upstream servers", func() {
-			BeforeEach(func() {
-				// read primary DNS server from one of the nodes
-				serverList := dnsResolverForNode(nodes[0], "dns-resolver.running.server")
-				updateDesiredStateAndWait(dnsConfig(searchDomain1, searchDomain2, serverList[0], server1V4, "ipv4", "ipv6", dnsTestNic))
+		Context("with DHCP aware interface", func() {
+			Context("with V4 upstream servers", func() {
+				BeforeEach(func() {
+					// read primary DNS server from one of the nodes
+					serverList := dnsResolverForNode(nodes[0], "dns-resolver.running.server")
+					updateDesiredStateAndWait(
+						dhcpAwareDNSConfig(
+							searchDomain1,
+							searchDomain2,
+							extractDNSServerAddress(serverList[0]),
+							server1V4,
+							dnsTestNic,
+						),
+					)
+				})
+				AfterEach(func() {
+					updateDesiredStateAndWait(dhcpAwareDNSAbsent(dnsTestNic))
+					for _, node := range nodes {
+						dnsResolverServerForNodeEventually(node).ShouldNot(ContainElement(server1V4))
+						dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain1))
+						dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain2))
+					}
+					resetDesiredStateForNodes()
+				})
+				It("should have the static V4 address", func() {
+					for _, node := range nodes {
+						dnsResolverServerForNodeEventually(node).Should(ContainElement(server1V4))
+						dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain1))
+						dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain2))
+					}
+				})
 			})
-			AfterEach(func() {
-				updateDesiredStateAndWait(dnsAbsent(dnsTestNic))
-				for _, node := range nodes {
-					dnsResolverServerForNodeEventually(node).ShouldNot(ContainElement(server1V4))
-					dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain1))
-					dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain2))
-				}
-				resetDesiredStateForNodes()
-			})
-			It("should have the static V4 address", func() {
-				for _, node := range nodes {
-					dnsResolverServerForNodeEventually(node).Should(ContainElement(server1V4))
-					dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain1))
-					dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain2))
-				}
+			Context("with V6 upstream servers", func() {
+				BeforeEach(func() {
+					// read primary DNS server from one of the nodes
+					serverList := dnsResolverForNode(nodes[0], "dns-resolver.running.server")
+					updateDesiredStateAndWait(
+						dhcpAwareDNSConfig(
+							searchDomain1,
+							searchDomain2,
+							extractDNSServerAddress(serverList[0]),
+							server1V6,
+							dnsTestNic,
+						),
+					)
+				})
+				AfterEach(func() {
+					updateDesiredStateAndWait(dhcpAwareDNSAbsent(dnsTestNic))
+					for _, node := range nodes {
+						dnsResolverServerForNodeEventually(node).ShouldNot(ContainElement(server1V6))
+						dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain1))
+						dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain2))
+					}
+					resetDesiredStateForNodes()
+				})
+				It("should have the static V6 address", func() {
+					for _, node := range nodes {
+						dnsResolverServerForNodeEventually(node).Should(ContainElement(server1V6))
+						dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain1))
+						dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain2))
+					}
+				})
 			})
 		})
-		Context("with V6 upstream servers", func() {
+		Context("with DHCP unaware interface", func() {
+			var (
+				designatedNode   string
+				designatedNodeIP string
+			)
 			BeforeEach(func() {
-				// read primary DNS server from one of the nodes
-				serverList := dnsResolverForNode(nodes[0], "dns-resolver.running.server")
-				updateDesiredStateAndWait(dnsConfig(searchDomain1, searchDomain2, serverList[0], server1V6, "ipv6", "ipv4", dnsTestNic))
+				designatedNode = nodes[0]
+				designatedNodeIP = ipv4Address(designatedNode, dnsTestNic)
 			})
-			AfterEach(func() {
-				updateDesiredStateAndWait(dnsAbsent(dnsTestNic))
-				for _, node := range nodes {
-					dnsResolverServerForNodeEventually(node).ShouldNot(ContainElement(server1V6))
-					dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain1))
-					dnsResolverSearchForNodeEventually(node).ShouldNot(ContainElement(searchDomain2))
-				}
-				resetDesiredStateForNodes()
+			Context("with V4 upstream servers", func() {
+				BeforeEach(func() {
+					// read primary DNS server from one of the nodes
+					serverList := dnsResolverForNode(designatedNode, "dns-resolver.running.server")
+					updateDesiredStateAtNodeAndWait(
+						designatedNode,
+						staticIPAndGwConfig(
+							searchDomain1,
+							searchDomain2,
+							extractDNSServerAddress(serverList[0]),
+							server1V4,
+							dnsTestNic,
+							designatedNodeIP,
+						),
+					)
+				})
+				AfterEach(func() {
+					updateDesiredStateAtNodeAndWait(designatedNode, staticIPAbsentAndRoutesAbsent(dnsTestNic, designatedNodeIP))
+					dnsResolverServerForNodeEventually(designatedNode).ShouldNot(ContainElement(server1V4))
+					dnsResolverSearchForNodeEventually(designatedNode).ShouldNot(ContainElement(searchDomain1))
+					dnsResolverSearchForNodeEventually(designatedNode).ShouldNot(ContainElement(searchDomain2))
+					resetDesiredStateForNodes()
+				})
+				It("should have the static V4 address", func() {
+					dnsResolverServerForNodeEventually(designatedNode).Should(ContainElement(server1V4))
+					dnsResolverSearchForNodeEventually(designatedNode).Should(ContainElement(searchDomain1))
+					dnsResolverSearchForNodeEventually(designatedNode).Should(ContainElement(searchDomain2))
+				})
 			})
-			It("should have the static V6 address", func() {
-				for _, node := range nodes {
-					dnsResolverServerForNodeEventually(node).Should(ContainElement(server1V6))
-					dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain1))
-					dnsResolverSearchForNodeEventually(node).Should(ContainElement(searchDomain2))
-				}
+			Context("with V6 upstream servers", func() {
+				BeforeEach(func() {
+					// read primary DNS server from one of the nodes
+					serverList := dnsResolverForNode(designatedNode, "dns-resolver.running.server")
+					updateDesiredStateAtNodeAndWait(
+						designatedNode,
+						staticIPAndGwConfig(
+							searchDomain1,
+							searchDomain2,
+							extractDNSServerAddress(serverList[0]),
+							server1V6,
+							dnsTestNic,
+							designatedNodeIP,
+						),
+					)
+				})
+				AfterEach(func() {
+					updateDesiredStateAtNodeAndWait(designatedNode, staticIPAbsentAndRoutesAbsent(dnsTestNic, designatedNodeIP))
+					dnsResolverServerForNodeEventually(designatedNode).ShouldNot(ContainElement(server1V6))
+					dnsResolverSearchForNodeEventually(designatedNode).ShouldNot(ContainElement(searchDomain1))
+					dnsResolverSearchForNodeEventually(designatedNode).ShouldNot(ContainElement(searchDomain2))
+					resetDesiredStateForNodes()
+				})
+				It("should have the static V6 address", func() {
+					dnsResolverServerForNodeEventually(designatedNode).Should(ContainElement(server1V6))
+					dnsResolverSearchForNodeEventually(designatedNode).Should(ContainElement(searchDomain1))
+					dnsResolverSearchForNodeEventually(designatedNode).Should(ContainElement(searchDomain2))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR adds e2e tests for DNS configuration on DHCP unaware interface

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
