### PR TITLE
deps: Pin nmstate to 1.0-x

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ RUN env
 COPY build/_output/bin/handler.manager.linux-$TARGETARCH /usr/local/bin/manager
 
 RUN dnf install -b -y dnf-plugins-core && \
-    dnf install -b -y -x "*alpha*" -x "*beta*" nmstate && \
+    dnf install -b -y -x "*alpha*" -x "*beta*" nmstate-1.0.2 && \
     dnf install -b -y iproute iputils && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
The latest nmstate 1.2.0 has a bug that breaks k8s connectivity [1].
This change pin to a working version

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2037411

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Pin nmstate to 1.1.0
```
