### PR TITLE
e2e: don't wait for reboot when testing default bridge IP

### DIFF
--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -138,8 +138,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
 			It("should keep the default IP address after node reboot", func() {
 				nodeToReboot := nodes[0]
 
-				err := restartNode(nodeToReboot)
-				Expect(err).ToNot(HaveOccurred())
+				restartNodeWithoutWaiting(nodeToReboot)
 
 				By("Wait for policy re-reconciled after node reboot")
 				waitForPolicyTransitionUpdate(DefaultNetwork)


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

Don't wait for node to come up when checking that IP is kept on a bridge
after node reboot.
We're checking NNS transition time, and due to waiting for the node to finish
reboot, we may miss the transition.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
