### PR TITLE
Fix ignoring the error if the probe fails during rollback

### DIFF
--- a/pkg/helper/client.go
+++ b/pkg/helper/client.go
@@ -135,7 +135,7 @@ func rollback(client client.Client, probes []probe.Probe, cause error) error {
 	// wait for system to settle after rollback
 	probesErr := probe.Run(client, probes)
 	if probesErr != nil {
-		return errors.Wrap(errors.Wrap(err, "failed running probes after rollback"), message)
+		return errors.Wrap(errors.Wrap(probesErr, "failed running probes after rollback"), message)
 	}
 	return errors.New(message)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

If the probe also fails during the rollback, a nil error is
returned and hence the operation/nnce is marked as successful
although  the probe failed while applying the conf and during
the rollback.

Signed-off-by: Nijin Ashok <nashok@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```
Fix ignoring the error if the probe fails during rollback
```
