### PR TITLE
Use nmcli to obtain NetworkManager version

### DIFF
--- a/controllers/handler/node_controller.go
+++ b/controllers/handler/node_controller.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -117,10 +118,13 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 }
 
 func (r *NodeReconciler) getDependencyVersions() *nmstate.DependencyVersions {
-	handlerNetworkManagerVersion, err := nmstate.ExecuteCommand("NetworkManager", "--version")
+	handlerNetworkManagerVersion, err := nmstate.ExecuteCommand("nmcli", "--version")
 	if err != nil {
 		r.Log.Info("error retrieving handler NetworkManager version: %s", err.Error())
 	}
+	// remove leading characters up to last space
+	split := strings.Split(handlerNetworkManagerVersion, " ")
+	handlerNetworkManagerVersion = split[len(split)-1]
 
 	handlerNmstateVersion, err := nmstate.ExecuteCommand("nmstatectl", "--version")
 	if err != nil {


### PR DESCRIPTION
'NetworkManager' command might not be available at nodes, which may lead to failing tests. The 'nmcli' command should not cause this issue.

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
