### PR TITLE
[release-0.52] Fix periodic re-reconciles of NNCPs with name equal to node (#957)

### DIFF
--- a/controllers/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/nodenetworkconfigurationpolicy_controller.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	builder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -241,13 +241,19 @@ func (r *NodeNetworkConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Man
 
 	// Reconcile all NNCPs if Node is updated (for example labels are changed), node creation event
 	// is not needed since all NNCPs are going to be Reconcile at node startup.
-	err = ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}).
-		Watches(&source.Kind{Type: &corev1.Node{}}, handler.EnqueueRequestsFromMapFunc(allPolicies), builder.WithPredicates(onLabelsUpdatedForThisNode)).
-		Complete(r)
+	c, err := controller.New("node_labels", mgr, controller.Options{Reconciler: r})
 	if err != nil {
-		return errors.Wrap(err, "failed to add controller to NNCP Reconciler listening Node events")
+		return errors.Wrap(err, "failed to create node_labels controller to NNCP Reconciler watching node label changes")
 	}
+	err = c.Watch(
+		&source.Kind{Type: &corev1.Node{}},
+		handler.EnqueueRequestsFromMapFunc(allPolicies),
+		onLabelsUpdatedForThisNode,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to add watch to enqueue NNCPs reconcile on node label change")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Manual rebase of https://github.com/nmstate/kubernetes-nmstate/pull/957

Policies that are named the same as worker nodes are getting
periodically re-reconciled.
It seems that the For(&corev1.Node{}) creates a watch of it's own
that overrides the builder.WithPredicates(onLabelsUpdatedForThisNode)
defined in the subsequent Watches(...) statement.

This commit creates the controller manually without using
controller-runtime builder.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix issue with NNCP named the same as nodes geting periodically re-reconciled
```
