### PR TITLE
operator: Add "resources.requests" for CPU and Mem

### DIFF
--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -33,6 +33,10 @@ spec:
           imagePullPolicy: {{ .OperatorPullPolicy }}
           command:
           - manager
+          resources:
+            requests:
+              cpu: 60m
+              memory: 30Mi
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
Following best practices for pods configuration and the status quo at
handler. This change ad the resources requests for CPU and memory
following the output of `crictl stats` on the operator container.

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:
The `crictl stats` output peak is

Idle
```bash
CONTAINER           CPU %               MEM                 DISK                INODES
e96d731fdb8e4       0.03                25.02MB             6B                  1
```

Install
```bash
CONTAINER           CPU %               MEM                 DISK                INODES
e96d731fdb8e4       4.00                 25.02MB             6B                  1
```

Delete
```bash
CONTAINER           CPU %               MEM                 DISK                INODES
e96d731fdb8e4       0.06                 25.02MB             6B                  1
```

Tested locally adding also `limits` and it works fine.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set resources requests for CPU and Memory
```
