### PR TITLE
operator: Use priority class cluster critical

### DIFF
--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -24,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+      priorityClassName: system-cluster-critical
       containers:
         - name: nmstate-operator
           args:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The operator can be replaced by a pod running at different node. This
change represent that by setting priority class at operator to
`system-cluster-critical`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use system-cluster-critical as priority class for the operator
```
