### PR TITLE
e2e: check error msg is well formatted in single spec

### DIFF
--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -184,8 +184,7 @@ var _ = Describe("NodeNetworkState", func() {
 			deletePolicy("test-policy")
 		})
 
-		It("should discard disarranged parts of the message", func() {
-
+		It("should discard disarranged parts of the message and keep desired parts of the message", func() {
 			for _, unwantedMessage := range messagesToRemove {
 				Expect(
 					enactmentConditionsStatus(
@@ -195,9 +194,6 @@ var _ = Describe("NodeNetworkState", func() {
 						Message,
 				).NotTo(ContainSubstring(unwantedMessage))
 			}
-		})
-
-		It("should keep desired parts of the message", func() {
 			for _, desiredMessage := range messagesToKeep {
 				Expect(
 					enactmentConditionsStatus(


### PR DESCRIPTION
E2E tests for error message check whether error message
returned when ping probe fails is correctly formatted
in two specs, meaning a failing policy needs to be created
twice. Since the test setup takes more than 2 minutes,
it seems worth to do the checks within single spec.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
