### PR TITLE
cluster: Install only ovs repo

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,9 +23,8 @@ done
 
 echo 'Installing Open vSwitch and NetworkManager 1.34 on nodes'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-    ./cluster/cli.sh ssh ${node} -- sudo dnf config-manager --set-enabled powertools
-    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y epel-release centos-release-openstack-wallaby
-    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch libibverbs NetworkManager-ovs-1.34.0 NetworkManager-1.34.0
+    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y centos-release-nfv-openvswitch
+    ./cluster/cli.sh ssh ${node} -- sudo dnf install -y openvswitch2.16 libibverbs NetworkManager-1.34.0 NetworkManager-ovs-1.34.0
     ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
     ./cluster/cli.sh ssh ${node} -- sudo systemctl enable openvswitch
     ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The openstack repos does not support centos 8 stream. This change pin to
just the OVS repo.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
