### PR TITLE
Don't involve notReady nodes in NNCP status calculation

### DIFF
--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -67,6 +67,25 @@ func NodesRunningNmstate(cli client.Reader, nodeSelector map[string]string) ([]c
 	return filteredNodes, nil
 }
 
+func FilterReady(nodes []corev1.Node) []corev1.Node {
+	filteredNodes := []corev1.Node{}
+	for _, node := range nodes {
+		if isReady(node) {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	return filteredNodes
+}
+
+func isReady(node corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
 func MaxUnavailableNodeCount(cli client.Reader, policy *nmstatev1.NodeNetworkConfigurationPolicy) (int, error) {
 	enactmentsTotal, _, err := enactment.CountByPolicy(cli, policy)
 	if err != nil {


### PR DESCRIPTION
In big clusters, it's possible that some nodes are not ready, either
due to maintenance or networking issue. This change excludes NotReady
nodes from NNCP Status calculation, so that policy is considered
as Available, when it successfully applies to all Ready nodes.

When NotReady node turns Ready, it re-reconciles and updates the policy
accordingly.

If there already is Available enactment on a node, that becomes NotReady afterwards,
the calculation is not affected, because we only consider enactments for
current `policyGeneration`.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NNCP doesn't turn Degraded when NotReady nodes don't apply enactments
```
