### PR TITLE
Add progressing condition to NNCP

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -42,13 +42,15 @@ type NodeNetworkConfigurationPolicyStatus struct {
 }
 
 const (
-	NodeNetworkConfigurationPolicyConditionAvailable ConditionType = "Available"
-	NodeNetworkConfigurationPolicyConditionDegraded  ConditionType = "Degraded"
+	NodeNetworkConfigurationPolicyConditionAvailable  ConditionType = "Available"
+	NodeNetworkConfigurationPolicyConditionDegraded   ConditionType = "Degraded"
+	NodeNetwrkConfigurationPOlicyConditionProgressing ConditionType = "Progressing"
 )
 
 var NodeNetworkConfigurationPolicyConditionTypes = [...]ConditionType{
 	NodeNetworkConfigurationPolicyConditionAvailable,
 	NodeNetworkConfigurationPolicyConditionDegraded,
+	NodeNetwrkConfigurationPOlicyConditionProgressing,
 }
 
 const (

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -136,7 +136,9 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(_ context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	policyconditions.Reset(r.Client, request.NamespacedName)
+	if !policyconditions.IsProgressing(&instance.Status.Conditions) {
+		policyconditions.Reset(r.Client, request.NamespacedName)
+	}
 
 	// Policy conditions will be updated at the end so updating it
 	// does not impact at applying state, it will increase just

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -53,6 +53,12 @@ func SetPolicyProgressing(conditions *nmstate.ConditionList, message string) {
 		nmstate.NodeNetworkConfigurationPolicyConditionAvailable,
 		corev1.ConditionUnknown,
 		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
+		corev1.ConditionTrue,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
 		message,
 	)
 }
@@ -71,6 +77,12 @@ func SetPolicySuccess(conditions *nmstate.ConditionList, message string) {
 		nmstate.NodeNetworkConfigurationPolicyConditionSuccessfullyConfigured,
 		message,
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
+	)
 }
 
 func SetPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
@@ -86,6 +98,12 @@ func SetPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
 		corev1.ConditionTrue,
 		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationNoMatchingNode,
 		message,
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
 	)
 }
 
@@ -103,6 +121,20 @@ func SetPolicyFailedToConfigure(conditions *nmstate.ConditionList, message strin
 		nmstate.NodeNetworkConfigurationPolicyConditionFailedToConfigure,
 		"",
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
+	)
+}
+
+func IsProgressing(conditions *nmstate.ConditionList) bool {
+	progressingCondition := conditions.Find(nmstate.NodeNetworkConfigurationPolicyConditionProgressing)
+	if progressingCondition == nil {
+		return false
+	}
+	return progressingCondition.Status == corev1.ConditionTrue
 }
 
 func Update(cli client.Client, apiReader client.Reader, policyKey types.NamespacedName) error {

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -42,13 +42,15 @@ type NodeNetworkConfigurationPolicyStatus struct {
 }
 
 const (
-	NodeNetworkConfigurationPolicyConditionAvailable ConditionType = "Available"
-	NodeNetworkConfigurationPolicyConditionDegraded  ConditionType = "Degraded"
+	NodeNetworkConfigurationPolicyConditionAvailable   ConditionType = "Available"
+	NodeNetworkConfigurationPolicyConditionDegraded    ConditionType = "Degraded"
+	NodeNetworkConfigurationPolicyConditionProgressing ConditionType = "Progressing"
 )
 
 var NodeNetworkConfigurationPolicyConditionTypes = [...]ConditionType{
 	NodeNetworkConfigurationPolicyConditionAvailable,
 	NodeNetworkConfigurationPolicyConditionDegraded,
+	NodeNetworkConfigurationPolicyConditionProgressing,
 }
 
 const (


### PR DESCRIPTION
Add a new condition to NNCP: Progressing.
Progressing condition is set to true
when at least one enactment is still in progress.

To avoid clearing the Progressing condition by Pending enactments,
NNCP conditions are reset only when it's not progress.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NNCP has a new Progressing conditon set to true while enactments are in progress
```
