### PR TITLE
[release-0.64] Don't involve notReady nodes in status calculation

### DIFF
--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -67,6 +67,25 @@ func NodesRunningNmstate(cli client.Reader, nodeSelector map[string]string) ([]c
 	return filteredNodes, nil
 }
 
+func FilterReady(nodes []corev1.Node) []corev1.Node {
+	filteredNodes := []corev1.Node{}
+	for _, node := range nodes {
+		if isReady(node) {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	return filteredNodes
+}
+
+func isReady(node corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
 func MaxUnavailableNodeCount(cli client.Reader, policy *nmstatev1.NodeNetworkConfigurationPolicy) (int, error) {
 	enactmentsTotal, _, err := enactment.CountByPolicy(cli, policy)
 	if err != nil {

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -146,27 +146,67 @@ func update(apiWriter client.Client, apiReader client.Reader, policyReader clien
 			return errors.Wrap(err, "getting nodes running kubernets-nmstate pods failed")
 		}
 		numberOfNmstateMatchingNodes := len(nmstateMatchingNodes)
+		numberOfReadyNmstateMatchingNodes := len(node.FilterReady(nmstateMatchingNodes))
+		numberOfNotReadyNmstateMatchingNodes := numberOfNmstateMatchingNodes - numberOfReadyNmstateMatchingNodes
 
 		// Let's get conditions with true status count filtered by policy generation
 		enactmentsCountByCondition := enactmentconditions.Count(enactments, policy.Generation)
 
 		numberOfFinishedEnactments := enactmentsCountByCondition.Available() + enactmentsCountByCondition.Failed() + enactmentsCountByCondition.Aborted()
 
-		logger.Info(fmt.Sprintf("numberOfNmstateMatchingNodes: %d, enactments count: %s", numberOfNmstateMatchingNodes, enactmentsCountByCondition))
+		logger.Info(
+			fmt.Sprintf("numberOfNmstateMatchingNodes: %d, enactments count: %s",
+				numberOfNmstateMatchingNodes,
+				enactmentsCountByCondition),
+		)
+
+		var message string
+		informOfNotReadyNodes := func(notReadyNodesCount int) {
+			if notReadyNodesCount > 0 {
+				message += fmt.Sprintf(
+					", %d nodes ignored due to NotReady state",
+					notReadyNodesCount,
+				)
+			}
+		}
+		informOfAbortedEnactments := func(abortedEnactmentsCount int) {
+			if abortedEnactmentsCount > 0 {
+				message += fmt.Sprintf(
+					", %d nodes aborted configuration",
+					abortedEnactmentsCount,
+				)
+			}
+		}
 
 		if numberOfNmstateMatchingNodes == 0 {
-			message := "Policy does not match any node"
+			message = "Policy does not match any node"
 			SetPolicyNotMatching(&policy.Status.Conditions, message)
 		} else if enactmentsCountByCondition.Failed() > 0 || enactmentsCountByCondition.Aborted() > 0 {
-			message := fmt.Sprintf("%d/%d nodes failed to configure", enactmentsCountByCondition.Failed(), numberOfNmstateMatchingNodes)
-			if enactmentsCountByCondition.Aborted() > 0 {
-				message += fmt.Sprintf(", %d nodes aborted configuration", enactmentsCountByCondition.Aborted())
-			}
+			message = fmt.Sprintf(
+				"%d/%d nodes failed to configure",
+				enactmentsCountByCondition.Failed(),
+				numberOfNmstateMatchingNodes,
+			)
+			informOfAbortedEnactments(enactmentsCountByCondition.Aborted())
 			SetPolicyFailedToConfigure(&policy.Status.Conditions, message)
-		} else if numberOfFinishedEnactments < numberOfNmstateMatchingNodes {
-			SetPolicyProgressing(&policy.Status.Conditions, fmt.Sprintf("Policy is progressing %d/%d nodes finished", numberOfFinishedEnactments, numberOfNmstateMatchingNodes))
+		} else if numberOfFinishedEnactments < numberOfReadyNmstateMatchingNodes {
+			message = fmt.Sprintf(
+				"Policy is progressing %d/%d nodes finished",
+				numberOfFinishedEnactments,
+				numberOfReadyNmstateMatchingNodes,
+			)
+			informOfNotReadyNodes(numberOfNotReadyNmstateMatchingNodes)
+			SetPolicyProgressing(
+				&policy.Status.Conditions,
+				message,
+			)
 		} else {
-			message := fmt.Sprintf("%d/%d nodes successfully configured", enactmentsCountByCondition.Available(), enactmentsCountByCondition.Available())
+			message = fmt.Sprintf(
+				"%d/%d nodes successfully configured",
+				enactmentsCountByCondition.Available(),
+				numberOfNmstateMatchingNodes,
+			)
+			informOfNotReadyNodes(numberOfNotReadyNmstateMatchingNodes)
 			SetPolicySuccess(&policy.Status.Conditions, message)
 		}
 

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -88,6 +88,35 @@ func newNode(idx int) corev1.Node {
 				"kubernetes.io/hostname": nodeName,
 			},
 		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	return node
+}
+
+func newNotReadyNode(idx int) corev1.Node {
+	nodeName := nodeName(idx)
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Labels: map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
 	}
 	return node
 }
@@ -303,6 +332,21 @@ var _ = Describe("Policy Conditions", func() {
 				newNonNmstatePodAtNode(4),
 			},
 			Policy: p(SetPolicySuccess, "3/3 nodes successfully configured"),
+		}),
+		Entry("when there is a NotReady node, ignore it for policy conditions calculations", ConditionsCase{
+			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
+			},
+			Nodes: []corev1.Node{
+				newNode(1),
+				newNode(2),
+				newNode(3),
+				newNotReadyNode(4),
+			},
+			Pods:   newNmstatePods(4),
+			Policy: p(SetPolicySuccess, "3/4 nodes successfully configured, 1 nodes ignored due to NotReady state"),
 		}),
 	)
 })


### PR DESCRIPTION
Manual cherry-pick of https://github.com/nmstate/kubernetes-nmstate/pull/981

In big clusters, it's possible that some nodes are not ready, either
due to maintenance or networking issue. This change excludes NotReady
nodes from NNCP Status calculation, so that policy is considered
as Available, when it successfully applies to all Ready nodes.

When NotReady node turns Ready, it re-reconciles and updates the policy
accordingly.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NNCP doesn't turn Degraded when NotReady nodes don't apply enactments
```
