### PR TITLE
e2e: kubernetes nmstate operator upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ test-e2e-handler:
 test-e2e-operator: manifests
 	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/operator ...
 
+test-e2e-upgrade: manifests
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) GINKGO="$(GINKGO)" ./hack/run-e2e-test-upgrade.sh $(e2e_test_args) $(E2E_TEST_SUITE_ARGS)
+
 test-e2e: test-e2e-operator test-e2e-handler
 
 cluster-up:

--- a/automation/check-patch.e2e-upgrade-k8s.sh
+++ b/automation/check-patch.e2e-upgrade-k8s.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -xe
+
+# This script should be able to execute functional tests against Kubernetes
+# cluster on any environment with basic dependencies listed in
+# check-patch.packages installed and docker running.
+#
+# yum -y install automation/check-patch.packages
+# automation/check-patch.e2e-k8s.sh
+
+teardown() {
+    make cluster-down
+    # Don't fail if there is no logs
+    cp -r ${E2E_LOGS}/operator/* ${ARTIFACTS} || true
+}
+
+main() {
+    export KUBEVIRT_NUM_NODES=2 # 1 control-plane, 1 worker
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+
+    # Let's fail fast if generated files differ
+    make check-gen
+
+    make cluster-down
+    make cluster-up
+    trap teardown EXIT SIGINT SIGTERM SIGSTOP
+    make cluster-sync
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="--no-color --output-dir=$ARTIFACTS --junit-report=junit.functest.xml" test-e2e-operator
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.e2e-upgrade-k8s.sh
+++ b/automation/check-patch.e2e-upgrade-k8s.sh
@@ -25,7 +25,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="--no-color --output-dir=$ARTIFACTS --junit-report=junit.functest.xml" test-e2e-operator
+    make E2E_TEST_TIMEOUT=1h E2E_TEST_ARGS="--no-color --output-dir=$ARTIFACTS --junit-report=junit.functest.xml" test-e2e-upgrade
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/licenseclassifier/v2 v2.0.0-alpha.1 // indirect
-	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
+	github.com/google/pprof v0.0.0-20210804190019-f964ff605595 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,9 @@ cloud.google.com/go v0.83.0/go.mod h1:Z7MJUsANfY0pYPdw0lbnivPx4/vhy/e2FEkSkF7vAV
 cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
 cloud.google.com/go v0.87.0/go.mod h1:TpDYlFy7vuLzZMMZ+B6iRiELaY7z/gJPaqbMx6mlWcY=
 cloud.google.com/go v0.90.0/go.mod h1:kRX0mNRHe0e2rC6oNakvwQqzyDmg57xJ+SZU1eT2aDQ=
+cloud.google.com/go v0.92.1/go.mod h1:cMc7asehN84LBi1JGTHo4n8wuaGuNAZ7lR7b1YNJBrE=
+cloud.google.com/go v0.92.2/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+YI=
+cloud.google.com/go v0.92.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+YI=
 cloud.google.com/go v0.93.3 h1:wPBktZFzYBcCZVARvwVKqH1uEj+aLXofJEtrb4oOsio=
 cloud.google.com/go v0.93.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+YI=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
@@ -34,9 +37,13 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/containeranalysis v0.1.0/go.mod h1:5sRtnKlcFzfRSArzgFEmrMCrAaR4pmjr+Sfn9A+PvoM=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/errorreporting v0.1.0/go.mod h1:cZSiBMvrnl0X13pD9DwKf9sQ8Eqy3EzHqkyKBZxiIrM=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
+cloud.google.com/go/grafeas v0.0.0-20210817223811-71387f0142a4/go.mod h1:JIjQPjT5tO2IieDgcDyhc1AvplAIo+FyYSKg3OvITsE=
+cloud.google.com/go/logging v1.4.2/go.mod h1:jco9QZSx8HiVVqLJReq7z7bVdj0P1Jb9PDFs63T+axo=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -47,6 +54,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.10.1-0.20200805182106-fcd132957b02/go.mod h1:bdhVveip9CJX75wUu7ALOTnCSKjv6PHRY0bCeBmePnw=
 cloud.google.com/go/storage v1.16.1 h1:sMEIc4wxvoY3NXG7Rn9iP7jb/2buJgWR1vNXCR/UPfs=
 cloud.google.com/go/storage v1.16.1/go.mod h1:LaNorbty3ehnU3rEjXSNV/NRgQA0O8Y+uh6bPe5UOk4=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
@@ -86,6 +94,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/GoogleCloudPlatform/testgrid v0.0.38/go.mod h1:KGQ3wqPuX1xCqeSHvcGmAafuMtV7cRNST9hZS7VCahA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
@@ -180,6 +189,7 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:o
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.37.6/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -216,6 +226,7 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABFQA=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
+github.com/carolynvs/magex v0.5.0/go.mod h1:i4bMWEmwGw2+W/u/0cEs5FTEyLtaN5DEKvVLV+KOEsc=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
 github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -224,6 +235,7 @@ github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEex
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -262,6 +274,7 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
+github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
@@ -554,6 +567,7 @@ github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
 github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
+github.com/go-git/go-git/v5 v5.2.0/go.mod h1:kh02eMX+wdqqxgNMEyq8YgwlIOsDOa9homkUq1PoTMs=
 github.com/go-git/go-git/v5 v5.3.0/go.mod h1:xdX4bWJ48aOrdhnl2XqHYstHbbp6+LFS4r4X+lNVprw=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
@@ -684,6 +698,7 @@ github.com/goccy/go-yaml v1.8.1/go.mod h1:wS4gNoLalDSJxo/SpngzPQ2BN4uuZVLCmbM4S3
 github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -792,7 +807,12 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.6.0 h1:niQ+8XD//kKgArIFwDVBXsWVWbde16LPdHMyNwSC8h4=
 github.com/google/go-containerregistry v0.6.0/go.mod h1:euCCtNbZ6tKqi1E72vwDj2xZcN5ttKpZLfa/wSo5iLw=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
+github.com/google/go-github/v34 v34.0.0/go.mod h1:w/2qlrXUfty+lbyO6tatnzIw97v1CM+/jZcwXMDiPQQ=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
+github.com/google/go-github/v39 v39.1.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -827,8 +847,9 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210804190019-f964ff605595 h1:uNrRgpnKjTfxu4qHaZAAs3eKTYV1EzGF3dAykpnxgDE=
+github.com/google/pprof v0.0.0-20210804190019-f964ff605595/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
@@ -839,6 +860,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -906,6 +928,7 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -913,6 +936,7 @@ github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
@@ -945,6 +969,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -967,6 +992,8 @@ github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod 
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
@@ -1002,6 +1029,7 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/rest v0.0.0-20210222204520-f7a2e216372f h1:AIRcGLQqg/FdPmErgrk19FNofLIo3gFPSRzXz6UUS6o=
 github.com/kevinburke/rest v0.0.0-20210222204520-f7a2e216372f/go.mod h1:pD+iEcdAGVXld5foVN4e24zb/6fnb60tgZPZ3P/3T/I=
+github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v1.1.0 h1:pH/t1WS9NzT8go394IqZeJTMHVm6Cr6ZJ6AQ+mdNo/o=
 github.com/kevinburke/ssh_config v1.1.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
@@ -1052,6 +1080,7 @@ github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lovoo/gcloud-opentracing v0.3.0/go.mod h1:ZFqk2y38kMDDikZPAK7ynTTGuyt17nSPdS3K5e+ZTBY=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1094,6 +1123,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -1106,6 +1137,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0/go.mod h1:fcEyUyXZXoV4Abw8DX0t7wyL8mCDxXyU4iAFZfT3IHw=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1/go.mod h1:DK1Cjkc0E49ShgRVs5jy5ASrM15svSnem3K/hiSGD8o=
 github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -1130,6 +1162,7 @@ github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
@@ -1200,6 +1233,7 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2/go.mod h1:rSAaSIOAGT9odnlyGlUfAJaoc5w2fSBUmeGDbRWPxyQ=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1216,6 +1250,7 @@ github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISq
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1306,6 +1341,7 @@ github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -1387,6 +1423,7 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/psampaz/go-mod-outdated v0.8.0/go.mod h1:o/o7wRSQWiSjKw8afZ7hq58J7IucGcSMbLWMG3veaQs=
 github.com/qinqon/kube-admission-webhook v0.18.0 h1:gv2OGWN8OPYjBAFOH0FGzUnhIgXG5+p4chBI/yDKOAw=
 github.com/qinqon/kube-admission-webhook v0.18.0/go.mod h1:eYJw+S+JSprEMLzGNmE0GFIlSrBQw0lAVES/ZjgM2FI=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
@@ -1425,12 +1462,15 @@ github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4Qn
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83/go.mod h1:vvbZ2Ae7AzSq3/kywjUDxSNq2SJ27RxCz2un0H3ePqE=
+github.com/sendgrid/rest v2.6.5+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.10.3+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shibumi/go-pathspec v1.2.0 h1:KVKEDHYk7bQolRMs7nfzjT3SBOCgcXFJzccnj9bsGbA=
 github.com/shibumi/go-pathspec v1.2.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
+github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada h1:WokF3GuxBeL+n4Lk4Fa8v9mbdjlrl7bHuneF4N1bk2I=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/gopsutil/v3 v3.21.10 h1:flTg1DrnV/UVrBqjLgVgDJzx6lf+91rC64/dBHmO2IA=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
@@ -1451,6 +1491,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1493,6 +1534,7 @@ github.com/spiegel-im-spiegel/errs v1.0.2 h1:v4amEwRDqRWjKHOILQnJSovYhZ4ZttEnBBX
 github.com/spiegel-im-spiegel/errs v1.0.2/go.mod h1:UoasJYYujMcdkbT9USv8dfZWoMyaY3btqQxoLJImw0A=
 github.com/spiegel-im-spiegel/go-cvss v0.4.0 h1:A+S9I01wkiEo6e66xFbxtz9LfXdsGUr5FppYozUAmmI=
 github.com/spiegel-im-spiegel/go-cvss v0.4.0/go.mod h1:VrcmtyfJ7OJF3/O08MQnxq+kqyPMjstExKdv02TPx+M=
+github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
@@ -1571,6 +1613,8 @@ github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2/go.mod h1:DGCI
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xanzy/go-gitlab v0.43.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -1593,6 +1637,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.4/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 h1:p7OofyZ509h8DmPLh8Hn+EIIZm/xYhdZHJ9GnXHdr6U=
 github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -1717,12 +1762,14 @@ golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1822,6 +1869,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201026091529-146b70c837a4/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -1853,10 +1901,12 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210112200429-01de73cf58bd/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -1886,6 +1936,7 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190102155601-82a175fd1598/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1983,6 +2034,7 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1995,6 +2047,7 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210909193231-528a39cd75f3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2051,6 +2104,7 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190813034749-528a2984e271/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -2154,6 +2208,7 @@ google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjR
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
 google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1AvkYD8=
+google.golang.org/api v0.46.0/go.mod h1:ceL4oozhkAiTID8XMmJBsIxID/9wMXJVVFXPg4ylg3I=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
 google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
@@ -2209,6 +2264,7 @@ google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200804151602-45615f50871c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2223,7 +2279,9 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
+google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
@@ -2326,6 +2384,9 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
+gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
+gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
@@ -2575,6 +2636,7 @@ sigs.k8s.io/controller-tools v0.6.0/go.mod h1:baRMVPrctU77F+rfAuH2uPqW93k6yQnZA2
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
+sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=
 sigs.k8s.io/kustomize/api v0.10.1 h1:KgU7hfYoscuqag84kxtzKdEC3mKMb99DPI3a0eaV1d0=
@@ -2588,13 +2650,17 @@ sigs.k8s.io/kustomize/kyaml v0.13.0 h1:9c+ETyNfSrVhxvphs+K2dzT3dh5oVPPEqPOE/cUpS
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/mdtoc v1.1.0 h1:q3YtqYzmC2e0hgLXRIOm7/QLuPux1CX3ZHCwlbABxZo=
 sigs.k8s.io/mdtoc v1.1.0/go.mod h1:QZLVEdHH2iNIR4uHAZyvFRtjloHgVItk8lo/mzCtq3w=
+sigs.k8s.io/promo-tools/v3 v3.2.1/go.mod h1:MQj3epgssCPeMJvB8Xqt4c2rBxVTUgPFE4ZYLkRwmUs=
+sigs.k8s.io/release-sdk v0.2.0/go.mod h1:zwNNQSkw9En31gqn2aRdCi0qxodxEaTgonDCINsdyoA=
 sigs.k8s.io/release-sdk v0.2.1-0.20211005095109-f50f5112261c h1:9oGz0w55WYVqwjtrHsWp8CArj+sV6qGfq9n+j+cEIaM=
 sigs.k8s.io/release-sdk v0.2.1-0.20211005095109-f50f5112261c/go.mod h1:m7EwAKZb9Hua+b8pXnJLMJ/5WY/Fs1CeqxBZYXx0u0A=
+sigs.k8s.io/release-utils v0.2.0/go.mod h1:9O5livl2h3Q56jUkoZ7UnV22XVRB6MuD4l/51C2vAPg=
 sigs.k8s.io/release-utils v0.3.0 h1:cyNeXvm+2lPn67f4MWmq9xapZDAI5hekpT7iQPRxta4=
 sigs.k8s.io/release-utils v0.3.0/go.mod h1:J9xpziRNRI4mAeMZxPRryDodQMoMudMu6yC1aViFHU4=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
+sigs.k8s.io/structured-merge-diff v1.0.2 h1:WiMoyniAVAYm03w+ImfF9IE2G23GLR/SwDnQyaNZvPk=
 sigs.k8s.io/structured-merge-diff v1.0.2/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
@@ -2609,6 +2675,7 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+sigs.k8s.io/zeitgeist v0.3.0/go.mod h1:JM9oeWgqf0Vhrkfaj1sHrKPYECxIjrorv7FdO2RvWok=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=
 vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/hack/previous-minor-version.sh
+++ b/hack/previous-minor-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+version_format="^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$"
+
+function git_tags_desc()
+{
+    git tag -l --sort=-v:refname | egrep $version_format
+}
+
+function latest_minor()
+{
+    git_tags_desc | head -n1
+}
+
+latest_minor

--- a/hack/run-e2e-test-upgrade.sh
+++ b/hack/run-e2e-test-upgrade.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -xe
+
+previous_minor_version=$(./hack/previous-minor-version.sh)
+
+knmstate_artifact_url="https://github.com/nmstate/kubernetes-nmstate/releases/download/${previous_minor_version}"
+
+test_e2e_updrade_manifests_dir="test/e2e/upgrade/manifests"
+test_e2e_updrade_examples_dir="test/e2e/upgrade/examples"
+
+e2e_test_args=$1
+E2E_TEST_SUITE_ARGS=$2
+
+mkdir -p $test_e2e_updrade_manifests_dir
+mkdir -p $test_e2e_updrade_examples_dir
+mkdir -p test_logs/e2e/upgrade
+
+# download example manifests
+(
+    examples_tar="examples.tar.gz"
+    cd $test_e2e_updrade_examples_dir
+    curl -k -L "${knmstate_artifact_url}/${examples_tar}" -o $examples_tar
+    tar -xvf $examples_tar
+    mv ./docs/examples/* .
+)
+
+# download manifests for deployment
+(
+    cd $test_e2e_updrade_manifests_dir
+    for manifest in "namespace.yaml" "service_account.yaml" "operator.yaml" "role.yaml" "role_binding.yaml"
+    do
+        curl -k -L "${knmstate_artifact_url}/$manifest" -o $manifest
+    done
+)
+
+KUBECONFIG=${KUBECONFIG} OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE} ${GINKGO} $e2e_test_args  $E2E_TEST_SUITE_ARGS ./test/e2e/upgrade

--- a/test/doc/examples.go
+++ b/test/doc/examples.go
@@ -1,0 +1,128 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doc
+
+import (
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+type ExampleSpec struct {
+	Name         string
+	FileName     string
+	PolicyName   string
+	IfaceNames   []string
+	CleanupState *nmstate.State
+}
+
+func ExampleSpecs() []ExampleSpec {
+	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
+    config:
+      search: []
+      server: []
+interfaces:
+- name: eth1
+  state: absent
+`)
+	return []ExampleSpec{
+		{
+			Name:       "Ethernet",
+			FileName:   "ethernet.yaml",
+			PolicyName: "ethernet",
+			IfaceNames: []string{"eth1"},
+		},
+		{
+			Name:       "Linux bridge",
+			FileName:   "linux-bridge.yaml",
+			PolicyName: "linux-bridge",
+			IfaceNames: []string{"br1"},
+		},
+		{
+			Name:       "Linux bridge with custom vlan",
+			FileName:   "linux-bridge-vlan.yaml",
+			PolicyName: "linux-bridge-vlan",
+			IfaceNames: []string{"br1"},
+		},
+		{
+			Name:       "Detach bridge port and restore its configuration",
+			FileName:   "detach-bridge-port-and-restore-eth.yaml",
+			PolicyName: "detach-bridge-port-and-restore-eth",
+			IfaceNames: []string{"br1"},
+		},
+		{
+			Name:       "OVS bridge",
+			FileName:   "ovs-bridge.yaml",
+			PolicyName: "ovs-bridge",
+			IfaceNames: []string{"br1"},
+		},
+		{
+			Name:       "OVS bridge with interface",
+			FileName:   "ovs-bridge-iface.yaml",
+			PolicyName: "ovs-bridge-iface",
+			IfaceNames: []string{"br1"},
+		},
+		{
+			Name:       "Linux bonding",
+			FileName:   "bond.yaml",
+			PolicyName: "bond",
+			IfaceNames: []string{"bond0"},
+		},
+		{
+			Name:       "Linux bonding and VLAN",
+			FileName:   "bond-vlan.yaml",
+			PolicyName: "bond-vlan",
+			IfaceNames: []string{"bond0.102", "bond0"},
+		},
+		{
+			Name:       "VLAN",
+			FileName:   "vlan.yaml",
+			PolicyName: "vlan",
+			IfaceNames: []string{"eth1.102", "eth1"},
+		},
+		{
+			Name:       "DHCP",
+			FileName:   "dhcp.yaml",
+			PolicyName: "dhcp",
+			IfaceNames: []string{"eth1"},
+		},
+		{
+			Name:       "Static IP",
+			FileName:   "static-ip.yaml",
+			PolicyName: "static-ip",
+			IfaceNames: []string{"eth1"},
+		},
+		{
+			Name:       "Route",
+			FileName:   "route.yaml",
+			PolicyName: "route",
+			IfaceNames: []string{"eth1"},
+		},
+		{
+			Name:         "DNS",
+			FileName:     "dns.yaml",
+			PolicyName:   "dns",
+			IfaceNames:   []string{},
+			CleanupState: &cleanDNSDesiredState,
+		},
+		{
+			Name:       "Worker selector",
+			FileName:   "worker-selector.yaml",
+			PolicyName: "worker-selector",
+			IfaceNames: []string{"eth1"},
+		},
+	}
+}

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 // TODO: When https://bugzilla.redhat.com/show_bug.cgi?id=1906307 is resolved, add firstSecondaryNic to the bond again
@@ -127,8 +128,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			restartNodeWithoutWaiting(nodeToReboot)
 
 			By("Wait for policy re-reconciled after node reboot")
-			waitForPolicyTransitionUpdate(TestPolicy)
-			waitForAvailablePolicy(TestPolicy)
+			policy.WaitForPolicyTransitionUpdate(TestPolicy)
+			policy.WaitForAvailablePolicy(TestPolicy)
 
 			Byf("Node %s was rebooted, verifying %s exists and ip was not changed", nodeToReboot, bond1)
 			verifyBondIsUpWithPrimaryNicIP(nodeToReboot, expectedBond, addressByNode[nodeToReboot])

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
 
@@ -97,7 +98,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				waitForNodesReady()
 
 				By("Waiting for policy to be ready")
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 			})
 
 			AfterEach(func() {
@@ -108,7 +109,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				waitForNodesReady()
 
 				By("Wait for policy to be ready")
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Check %s has the default ip address", primaryNic)
 				for _, node := range nodes {
@@ -143,8 +144,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				restartNodeWithoutWaiting(nodeToReboot)
 
 				By("Wait for policy re-reconciled after node reboot")
-				waitForPolicyTransitionUpdate(DefaultNetwork)
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForPolicyTransitionUpdate(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)
 				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot}, "brext", addressByNode)

--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nmpolicy", func() {
@@ -80,7 +81,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
 				waitForNodesReady()
 
 				By("Waiting for policy to be ready")
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 			})
 
 			AfterEach(func() {
@@ -110,7 +111,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
 				waitForNodesReady()
 
 				By("Wait for policy to be ready")
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Check %s has the default ip address", primaryNic)
 				for _, node := range nodes {
@@ -145,8 +146,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
 				restartNodeWithoutWaiting(nodeToReboot)
 
 				By("Wait for policy re-reconciled after node reboot")
-				waitForPolicyTransitionUpdate(DefaultNetwork)
-				waitForAvailablePolicy(DefaultNetwork)
+				policy.WaitForPolicyTransitionUpdate(DefaultNetwork)
+				policy.WaitForAvailablePolicy(DefaultNetwork)
 
 				Byf("Node %s was rebooted, verifying that bridge took over the default IP", nodeToReboot)
 				checkThatBridgeTookOverTheDefaultIP([]string{nodeToReboot}, "brext", addressByNode)

--- a/test/e2e/handler/default_ovs_bridged_network_test.go
+++ b/test/e2e/handler/default_ovs_bridged_network_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 func ovsBridgeWithTheDefaultInterface(ovsBridgeName, defaultInterfaceMac string) nmstate.State {
@@ -105,7 +106,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 					waitForNodesReady()
 
 					By("Waiting for policy to be ready")
-					waitForAvailablePolicy(ovsDefaultNetwork)
+					policy.WaitForAvailablePolicy(ovsDefaultNetwork)
 				})
 
 				AfterEach(func() {
@@ -116,7 +117,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 					waitForNodesReady()
 
 					By("Waiting for policy to be ready")
-					waitForAvailablePolicy(ovsDefaultNetwork)
+					policy.WaitForAvailablePolicy(ovsDefaultNetwork)
 
 					Byf("Check %s has the default ip address", primaryNic)
 					Eventually(func() string {
@@ -155,8 +156,8 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 					restartNodeWithoutWaiting(node)
 
 					By("Wait for policy re-reconciled after node reboot")
-					waitForPolicyTransitionUpdate(ovsDefaultNetwork)
-					waitForAvailablePolicy(ovsDefaultNetwork)
+					policy.WaitForPolicyTransitionUpdate(ovsDefaultNetwork)
+					policy.WaitForAvailablePolicy(ovsDefaultNetwork)
 
 					Byf("Node %s was rebooted, verifying that bridge took over the default IP", node)
 					checkThatOvsBridgeTookOverTheDefaultIP(node, ovsBridgeInternalPort)
@@ -228,7 +229,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 					map[string]string{"kubernetes.io/hostname": node},
 				)
 				By("Wait for the policy to fail")
-				waitForDegradedPolicy(ovsWrongIPPolicy)
+				policy.WaitForDegradedPolicy(ovsWrongIPPolicy)
 
 				Byf("Check %s still has the default ip address", primaryNic)
 				Eventually(func() string {

--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -20,10 +20,12 @@ package handler
 import (
 	"fmt"
 
-	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
-	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
+	policyconditions "github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 func createInterfaceWithNonExistingCapture() nmstate.State {
@@ -71,7 +73,7 @@ func createPolicyAndWaitForEnactmentCondition(policy string, desiredState func()
 	waitForNodesReady()
 
 	By("Waiting for enactment to be failing")
-	enactmentConditionsStatusEventually(nodes[0]).Should(matchConditionsFrom(enactmentconditions.SetFailedToConfigure))
+	policyconditions.EnactmentConditionsStatusEventually(nodes[0]).Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure))
 }
 
 var _ = Describe("NodeNetworkState", func() {
@@ -107,7 +109,7 @@ var _ = Describe("NodeNetworkState", func() {
 		It("should discard disarranged parts of the message", func() {
 			for _, unwantedMessage := range messagesToRemove {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -119,7 +121,7 @@ var _ = Describe("NodeNetworkState", func() {
 		It("should keep desired parts of the message", func() {
 			for _, desiredMessage := range messagesToKeep {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -145,7 +147,7 @@ var _ = Describe("NodeNetworkState", func() {
 		It("should discard disarranged parts of the message", func() {
 			for _, unwantedMessage := range messagesToRemove {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -157,7 +159,7 @@ var _ = Describe("NodeNetworkState", func() {
 		It("should keep desired parts of the message", func() {
 			for _, desiredMessage := range messagesToKeep {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -187,7 +189,7 @@ var _ = Describe("NodeNetworkState", func() {
 		It("should discard disarranged parts of the message and keep desired parts of the message", func() {
 			for _, unwantedMessage := range messagesToRemove {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -196,7 +198,7 @@ var _ = Describe("NodeNetworkState", func() {
 			}
 			for _, desiredMessage := range messagesToKeep {
 				Expect(
-					enactmentConditionsStatus(
+					policyconditions.EnactmentConditionsStatus(
 						nodes[0],
 						defaultPolicy,
 					).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).
@@ -218,7 +220,7 @@ var _ = Describe("NodeNetworkState", func() {
 
 		It("should contain the error message", func() {
 			Expect(
-				enactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message,
+				policyconditions.EnactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message,
 			).To(ContainSubstring("failure generating desiredState and capturedStates"))
 		})
 	})

--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -73,7 +73,9 @@ func createPolicyAndWaitForEnactmentCondition(policy string, desiredState func()
 	waitForNodesReady()
 
 	By("Waiting for enactment to be failing")
-	policyconditions.EnactmentConditionsStatusEventually(nodes[0]).Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure))
+	policyconditions.EnactmentConditionsStatusEventually(
+		nodes[0],
+	).Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure))
 }
 
 var _ = Describe("NodeNetworkState", func() {
@@ -220,7 +222,9 @@ var _ = Describe("NodeNetworkState", func() {
 
 		It("should contain the error message", func() {
 			Expect(
-				policyconditions.EnactmentConditionsStatus(nodes[0], defaultPolicy).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message,
+				policyconditions.EnactmentConditionsStatus(
+					nodes[0], defaultPolicy,
+				).Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing).Message,
 			).To(ContainSubstring("failure generating desiredState and capturedStates"))
 		})
 	})

--- a/test/e2e/handler/examples_test.go
+++ b/test/e2e/handler/examples_test.go
@@ -23,29 +23,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	example "github.com/nmstate/kubernetes-nmstate/test/doc"
 )
-
-type exampleSpec struct {
-	name         string
-	fileName     string
-	policyName   string
-	ifaceNames   []string
-	cleanupState *nmstate.State
-}
 
 // This suite checks that all examples in our docs can be successfully applied.
 // It only checks the top level API, hence it does not verify that the
 // configuration is indeed applied on nodes. That should be tested by dedicated
 // test suites for each feature.
 var _ = Describe("[user-guide] Examples", func() {
-	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
-    config:
-      search: []
-      server: []
-interfaces:
-- name: eth1
-  state: absent
-`)
 
 	beforeTestIfaceExample := func(fileName string) {
 		kubectlAndCheck("apply", "-f", fmt.Sprintf("docs/examples/%s", fileName))
@@ -71,113 +56,19 @@ interfaces:
 		resetDesiredStateForNodes()
 	}
 
-	examples := []exampleSpec{
-		{
-			name:       "Ethernet",
-			fileName:   "ethernet.yaml",
-			policyName: "ethernet",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Linux bridge",
-			fileName:   "linux-bridge.yaml",
-			policyName: "linux-bridge",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "Linux bridge with custom vlan",
-			fileName:   "linux-bridge-vlan.yaml",
-			policyName: "linux-bridge-vlan",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "Detach bridge port and restore its configuration",
-			fileName:   "detach-bridge-port-and-restore-eth.yaml",
-			policyName: "detach-bridge-port-and-restore-eth",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "OVS bridge",
-			fileName:   "ovs-bridge.yaml",
-			policyName: "ovs-bridge",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "OVS bridge with interface",
-			fileName:   "ovs-bridge-iface.yaml",
-			policyName: "ovs-bridge-iface",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "Linux bonding",
-			fileName:   "bond.yaml",
-			policyName: "bond",
-			ifaceNames: []string{"bond0"},
-		},
-		{
-			name:       "Linux bonding and VLAN",
-			fileName:   "bond-vlan.yaml",
-			policyName: "bond-vlan",
-			ifaceNames: []string{"bond0.102", "bond0"},
-		},
-		{
-			name:       "VLAN",
-			fileName:   "vlan.yaml",
-			policyName: "vlan",
-			ifaceNames: []string{"eth1.102", "eth1"},
-		},
-		{
-			name:       "DHCP",
-			fileName:   "dhcp.yaml",
-			policyName: "dhcp",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Static IP",
-			fileName:   "static-ip.yaml",
-			policyName: "static-ip",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Route",
-			fileName:   "route.yaml",
-			policyName: "route",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:         "DNS",
-			fileName:     "dns.yaml",
-			policyName:   "dns",
-			ifaceNames:   []string{},
-			cleanupState: &cleanDNSDesiredState,
-		},
-		{
-			name:       "Worker selector",
-			fileName:   "worker-selector.yaml",
-			policyName: "worker-selector",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "DNS cleanup",
-			fileName:   "dns-cleanup.yaml",
-			policyName: "dns-cleanup",
-			ifaceNames: []string{},
-		},
-	}
-
-	for _, e := range examples {
+	for _, e := range example.ExampleSpecs() {
 		example := e
-		Context(e.name, func() {
+		Context(e.Name, func() {
 			BeforeEach(func() {
-				beforeTestIfaceExample(example.fileName)
+				beforeTestIfaceExample(example.FileName)
 			})
 
 			AfterEach(func() {
-				afterIfaceExample(example.policyName, example.ifaceNames, example.cleanupState)
+				afterIfaceExample(example.PolicyName, example.IfaceNames, example.CleanupState)
 			})
 
 			It("should succeed applying the policy", func() {
-				testIfaceExample(example.policyName)
+				testIfaceExample(example.PolicyName)
 			})
 		})
 	}

--- a/test/e2e/handler/multiple_policies_for_same_node_test.go
+++ b/test/e2e/handler/multiple_policies_for_same_node_test.go
@@ -22,6 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 var _ = Describe("NodeNetworkState", func() {
@@ -36,16 +38,16 @@ var _ = Describe("NodeNetworkState", func() {
 
 		BeforeEach(func() {
 			setDesiredStateWithPolicy(staticIPPolicy, ifaceUpWithStaticIP(firstSecondaryNic, ipAddress, prefixLen))
-			waitForAvailablePolicy(staticIPPolicy)
+			policy.WaitForAvailablePolicy(staticIPPolicy)
 			setDesiredStateWithPolicy(vlanPolicy, ifaceUpWithVlanUp(firstSecondaryNic, vlanID))
-			waitForAvailablePolicy(vlanPolicy)
+			policy.WaitForAvailablePolicy(vlanPolicy)
 		})
 
 		AfterEach(func() {
 			setDesiredStateWithPolicy(staticIPPolicy, ifaceDownIPv4Disabled(firstSecondaryNic))
-			waitForAvailablePolicy(staticIPPolicy)
+			policy.WaitForAvailablePolicy(staticIPPolicy)
 			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(firstSecondaryNic, vlanID))
-			waitForAvailablePolicy(vlanPolicy)
+			policy.WaitForAvailablePolicy(vlanPolicy)
 			deletePolicy(staticIPPolicy)
 			deletePolicy(vlanPolicy)
 			resetDesiredStateForNodes()

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -27,6 +27,7 @@ import (
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
+	policyconditions "github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 func invalidConfig(bridgeName string) nmstate.State {
@@ -54,12 +55,12 @@ var _ = Describe("EnactmentCondition", func() {
 				go func() {
 					defer wg.Done()
 					defer GinkgoRecover()
-					enactmentConditionsStatusEventually(node).
-						Should(matchConditionsFrom(enactmentconditions.SetProgressing), "should reach progressing state at %s", node)
-					enactmentConditionsStatusEventually(node).
-						Should(matchConditionsFrom(enactmentconditions.SetSuccess), "should reach available state at %s", node)
-					enactmentConditionsStatusConsistently(node).
-						Should(matchConditionsFrom(enactmentconditions.SetSuccess), "should keep available state at %s", node)
+					policyconditions.EnactmentConditionsStatusEventually(node).
+						Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetProgressing), "should reach progressing state at %s", node)
+					policyconditions.EnactmentConditionsStatusEventually(node).
+						Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetSuccess), "should reach available state at %s", node)
+					policyconditions.EnactmentConditionsStatusConsistently(node).
+						Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetSuccess), "should keep available state at %s", node)
 				}()
 			}
 			// Run the policy after we set the nnce conditions assert so we
@@ -69,7 +70,7 @@ var _ = Describe("EnactmentCondition", func() {
 			wg.Wait()
 
 			By("Check policy is at available state")
-			waitForAvailableTestPolicy()
+			policyconditions.WaitForAvailableTestPolicy()
 		})
 	})
 
@@ -88,15 +89,15 @@ var _ = Describe("EnactmentCondition", func() {
 		It("should have Failing ConditionType set to true", func() {
 			for _, node := range nodes {
 				Byf("Check %s failing state is reached", node)
-				enactmentConditionsStatusEventually(node).Should(
+				policyconditions.EnactmentConditionsStatusEventually(node).Should(
 					SatisfyAny(
-						matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
-						matchConditionsFrom(enactmentconditions.SetConfigurationAborted),
+						policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure),
+						policyconditions.MatchConditionsFrom(enactmentconditions.SetConfigurationAborted),
 					), "should eventually reach failing or aborted conditions at enactments",
 				)
 			}
 			By("Check policy is at degraded state")
-			waitForDegradedTestPolicy()
+			policyconditions.WaitForDegradedTestPolicy()
 
 			By("Check that the enactment stays in failing state")
 			var wg sync.WaitGroup
@@ -107,10 +108,10 @@ var _ = Describe("EnactmentCondition", func() {
 					defer wg.Done()
 					defer GinkgoRecover()
 					Byf("Check %s failing state is kept", node)
-					enactmentConditionsStatusConsistently(node).Should(
+					policyconditions.EnactmentConditionsStatusConsistently(node).Should(
 						SatisfyAny(
-							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
-							matchConditionsFrom(enactmentconditions.SetConfigurationAborted),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetConfigurationAborted),
 						), "should consistently keep failing or aborted conditions at enactments",
 					)
 				}()
@@ -123,12 +124,12 @@ var _ = Describe("EnactmentCondition", func() {
 				failingConditions := 0
 				abortedConditions := 0
 				for _, node := range nodes {
-					conditionList := enactmentConditionsStatus(node, TestPolicy)
-					success, _ := matchConditionsFrom(enactmentconditions.SetFailedToConfigure).Match(conditionList)
+					conditionList := policyconditions.EnactmentConditionsStatus(node, TestPolicy)
+					success, _ := policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure).Match(conditionList)
 					if success {
 						failingConditions++
 					}
-					success, _ = matchConditionsFrom(enactmentconditions.SetConfigurationAborted).Match(conditionList)
+					success, _ = policyconditions.MatchConditionsFrom(enactmentconditions.SetConfigurationAborted).Match(conditionList)
 					if success {
 						abortedConditions++
 					}
@@ -146,17 +147,17 @@ var _ = Describe("EnactmentCondition", func() {
 					defer wg.Done()
 					defer GinkgoRecover()
 					Byf("Check %s failing state is kept", node)
-					enactmentConditionsStatusEventually(node).Should(
+					policyconditions.EnactmentConditionsStatusEventually(node).Should(
 						SatisfyAny(
-							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
-							matchConditionsFrom(enactmentconditions.SetConfigurationAborted),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetConfigurationAborted),
 						), "should consistently keep failing or aborted conditions at enactments")
 				}()
 			}
 			wg.Wait()
 
 			By("Check policy is at degraded state")
-			waitForDegradedTestPolicy()
+			policyconditions.WaitForDegradedTestPolicy()
 
 			By("Check that the enactments stay in failing or aborted state")
 			wg.Add(len(nodes))
@@ -166,10 +167,10 @@ var _ = Describe("EnactmentCondition", func() {
 					defer wg.Done()
 					defer GinkgoRecover()
 					Byf("Check %s failing state is kept", node)
-					enactmentConditionsStatusConsistently(node).Should(
+					policyconditions.EnactmentConditionsStatusConsistently(node).Should(
 						SatisfyAny(
-							matchConditionsFrom(enactmentconditions.SetFailedToConfigure),
-							matchConditionsFrom(enactmentconditions.SetConfigurationAborted),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure),
+							policyconditions.MatchConditionsFrom(enactmentconditions.SetConfigurationAborted),
 						), "should consistently keep failing or aborted conditions at enactments")
 				}()
 			}
@@ -183,8 +184,8 @@ var _ = Describe("EnactmentCondition", func() {
 			failingEnactmentsCount := func(policy string) int {
 				failingConditions := 0
 				for _, node := range nodes {
-					conditionList := enactmentConditionsStatus(node, TestPolicy)
-					found, _ := matchConditionsFrom(enactmentconditions.SetFailedToConfigure).Match(conditionList)
+					conditionList := policyconditions.EnactmentConditionsStatus(node, TestPolicy)
+					found, _ := policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure).Match(conditionList)
 					if found {
 						failingConditions++
 					}
@@ -199,8 +200,8 @@ var _ = Describe("EnactmentCondition", func() {
 
 			By("Checking the policy is marked as Degraded")
 			Eventually(func() nmstate.ConditionList {
-				return policyConditionsStatus(TestPolicy)
-			}, 2*time.Second, 100*time.Millisecond).Should(containPolicyDegraded(), "policy should be marked as Degraded")
+				return policyconditions.Status(TestPolicy)
+			}, 2*time.Second, 100*time.Millisecond).Should(policyconditions.ContainPolicyDegraded(), "policy should be marked as Degraded")
 		})
 	})
 })

--- a/test/e2e/handler/nnce_desiredstate_test.go
+++ b/test/e2e/handler/nnce_desiredstate_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 var _ = Describe("Enactment DesiredState", func() {
@@ -40,7 +41,7 @@ var _ = Describe("Enactment DesiredState", func() {
 			for _, node := range nodes {
 				enactmentKey := nmstate.EnactmentKey(node, TestPolicy)
 				Byf("Check enactment %s has expected desired state", enactmentKey.Name)
-				nnce := nodeNetworkConfigurationEnactment(enactmentKey)
+				nnce := policy.NodeNetworkConfigurationEnactment(enactmentKey)
 				Expect(nnce.Status.DesiredState).To(MatchYAML(linuxBrUpWithDefaults(bridge1)))
 			}
 		})

--- a/test/e2e/handler/nncp_cleanup_test.go
+++ b/test/e2e/handler/nncp_cleanup_test.go
@@ -27,6 +27,7 @@ import (
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
 
@@ -37,7 +38,7 @@ var _ = Describe("NNCP cleanup", func() {
 		setDesiredStateWithPolicy(bridge1, linuxBrUp(bridge1))
 
 		By("Wait for policy to be ready")
-		waitForAvailablePolicy(bridge1)
+		policy.WaitForAvailablePolicy(bridge1)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/handler/nncp_parallel_test.go
+++ b/test/e2e/handler/nncp_parallel_test.go
@@ -24,13 +24,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	policyconditions "github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func enactmentsInProgress(policy string) int {
 	progressingEnactments := 0
 	for _, node := range nodes {
-		enactment := enactmentConditionsStatus(node, policy)
+		enactment := policyconditions.EnactmentConditionsStatus(node, policy)
 		if cond := enactment.Find(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing); cond != nil {
 			if cond.Status == corev1.ConditionTrue {
 				progressingEnactments++
@@ -60,13 +61,13 @@ var _ = Describe("NNCP with maxUnavailable", func() {
 			Eventually(func() int {
 				return enactmentsInProgress(TestPolicy)
 			}, duration, interval).Should(BeNumerically("==", maxUnavailableNodes()))
-			waitForAvailablePolicy(TestPolicy)
+			policyconditions.WaitForAvailablePolicy(TestPolicy)
 		})
 		It("should never exceed maxUnavailable nodes", func() {
 			Consistently(func() int {
 				return enactmentsInProgress(TestPolicy)
 			}, duration, interval).Should(BeNumerically("<=", maxUnavailableNodes()))
-			waitForAvailablePolicy(TestPolicy)
+			policyconditions.WaitForAvailablePolicy(TestPolicy)
 		})
 	})
 })

--- a/test/e2e/handler/nns_update_timestamp_test.go
+++ b/test/e2e/handler/nns_update_timestamp_test.go
@@ -28,6 +28,7 @@ import (
 
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	nmstatenode "github.com/nmstate/kubernetes-nmstate/pkg/node"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 const expectedDummyName = "dummy0"
@@ -93,11 +94,11 @@ var _ = Describe("[nns] NNS LastSuccessfulUpdateTime", func() {
 			// We want to test all the NNS so we apply policies to control-plane and workers
 			// (use linuxBrUpNoPorts to not affect the nodes secondary interfaces state)
 			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrUpNoPorts(bridge1))
-			waitForAvailableTestPolicy()
+			policy.WaitForAvailableTestPolicy()
 		})
 		AfterEach(func() {
 			setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, linuxBrAbsent(bridge1))
-			waitForAvailableTestPolicy()
+			policy.WaitForAvailableTestPolicy()
 			deletePolicy(TestPolicy)
 		})
 		It("should be immediately updated", func() {

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
@@ -48,13 +49,13 @@ var _ = Describe("NodeSelector", func() {
 			Byf("Set policy %s with not matching node selector", bridge1)
 			// use linuxBrUpNoPorts to not affect the nodes secondary interfaces state
 			setDesiredStateWithPolicyAndNodeSelectorEventually(bridge1, linuxBrUpNoPorts(bridge1), testNodeSelector)
-			waitForAvailablePolicy(bridge1)
+			policy.WaitForAvailablePolicy(bridge1)
 		})
 
 		AfterEach(func() {
 			Byf("Deleteting linux bridge %s at all nodes", bridge1)
 			setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrAbsent(bridge1))
-			waitForAvailablePolicy(bridge1)
+			policy.WaitForAvailablePolicy(bridge1)
 			deletePolicy(bridge1)
 		})
 
@@ -70,7 +71,7 @@ var _ = Describe("NodeSelector", func() {
 				Byf("Remove node selector at policy %s", bridge1)
 				// use linuxBrUpNoPorts to not affect the nodes secondary interfaces state
 				setDesiredStateWithPolicyWithoutNodeSelector(bridge1, linuxBrUpNoPorts(bridge1))
-				waitForAvailablePolicy(bridge1)
+				policy.WaitForAvailablePolicy(bridge1)
 			})
 
 			It("should update all nodes and have Matching enactment state", func() {
@@ -88,7 +89,7 @@ var _ = Describe("NodeSelector", func() {
 				addLabelsToNode(nodes[0], testNodeSelector)
 				//TODO: Remove this when webhook retest policy status when node labels are changed
 				time.Sleep(3 * time.Second)
-				waitForAvailablePolicy(bridge1)
+				policy.WaitForAvailablePolicy(bridge1)
 			})
 			AfterEach(func() {
 				By("Remove test label from node")
@@ -96,7 +97,7 @@ var _ = Describe("NodeSelector", func() {
 			})
 			It("should apply the policy", func() {
 				By("Check that NNCE is created")
-				nodeNetworkConfigurationEnactment(shared.EnactmentKey(nodes[0], bridge1))
+				policy.NodeNetworkConfigurationEnactment(shared.EnactmentKey(nodes[0], bridge1))
 				interfacesNameForNodeEventually(nodes[0]).Should(ContainElement(bridge1))
 			})
 			Context("and remove the label again", func() {
@@ -104,7 +105,7 @@ var _ = Describe("NodeSelector", func() {
 					removeLabelsFromNode(nodes[0], testNodeSelector)
 					//TODO: Remove this when webhook retest policy status when node labels are changed
 					time.Sleep(3 * time.Second)
-					waitForAvailablePolicy(bridge1)
+					policy.WaitForAvailablePolicy(bridge1)
 				})
 				It("should remove the not matching enactment", func() {
 					Expect(numberOfEnactmentsForPolicy(bridge1)).To(Equal(0), "should remove the not matching enactment")

--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 // We cannot change routes at nmstate if the interface is with dhcp true
@@ -126,10 +127,10 @@ var _ = Describe("rollback", func() {
 		})
 		It("should rollback to a good gw configuration", func() {
 			By("Should not be available") // Fail fast
-			policyConditionsStatusConsistently().ShouldNot(containPolicyAvailable())
+			policy.StatusConsistently().ShouldNot(policy.ContainPolicyAvailable())
 
 			By("Wait for reconcile to fail")
-			waitForDegradedTestPolicy()
+			policy.WaitForDegradedTestPolicy()
 			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return dhcpFlag(nodes[0], primaryNic)
@@ -153,10 +154,10 @@ var _ = Describe("rollback", func() {
 		})
 		It("should rollback to previous name servers", func() {
 			By("Should not be available") // Fail fast
-			policyConditionsStatusConsistently().ShouldNot(containPolicyAvailable())
+			policy.StatusConsistently().ShouldNot(policy.ContainPolicyAvailable())
 
 			By("Wait for reconcile to fail")
-			waitForDegradedTestPolicy()
+			policy.WaitForDegradedTestPolicy()
 			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return autoDNS(nodes[0], primaryNic)
@@ -181,10 +182,10 @@ var _ = Describe("rollback", func() {
 		})
 		It("should rollback to previous name servers", func() {
 			By("Should not be available") // Fail fast
-			policyConditionsStatusConsistently().ShouldNot(containPolicyAvailable())
+			policy.StatusConsistently().ShouldNot(policy.ContainPolicyAvailable())
 
 			By("Wait for reconcile to fail")
-			waitForDegradedTestPolicy()
+			policy.WaitForDegradedTestPolicy()
 			Byf("Check that %s is rolled back", primaryNic)
 			Eventually(func() bool {
 				return autoDNS(nodes[0], primaryNic)

--- a/test/e2e/handler/upgrade_test.go
+++ b/test/e2e/handler/upgrade_test.go
@@ -29,6 +29,7 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/api/v1alpha1"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
@@ -54,7 +55,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy upgrade", func() {
 			resetDesiredStateForNodes()
 		})
 		It("should be stored as v1 and end with available state", func() {
-			waitForAvailableTestPolicy()
+			policy.WaitForAvailableTestPolicy()
 		})
 	})
 
@@ -78,7 +79,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy upgrade", func() {
 			resetDesiredStateForNodes()
 		})
 		It("should be stored as v1 and end with available state", func() {
-			waitForAvailableTestPolicy()
+			policy.WaitForAvailableTestPolicy()
 		})
 	})
 })

--- a/test/e2e/handler/user_guide_test.go
+++ b/test/e2e/handler/user_guide_test.go
@@ -21,6 +21,8 @@ package handler
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
 var _ = Describe("[user-guide] Introduction", func() {
@@ -43,9 +45,9 @@ var _ = Describe("[user-guide] Introduction", func() {
 	cleanupConfiguration := func() {
 		deletePolicy("vlan100")
 		setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, interfaceAbsent("eth1.100"))
-		waitForAvailableTestPolicy()
+		policy.WaitForAvailableTestPolicy()
 		setDesiredStateWithPolicyWithoutNodeSelector(TestPolicy, resetPrimaryAndSecondaryNICs())
-		waitForAvailableTestPolicy()
+		policy.WaitForAvailableTestPolicy()
 		deletePolicy(TestPolicy)
 	}
 

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -43,6 +43,7 @@ import (
 	nmstatenode "github.com/nmstate/kubernetes-nmstate/pkg/node"
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/handler/linuxbridge"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	"github.com/nmstate/kubernetes-nmstate/test/environment"
 	"github.com/nmstate/kubernetes-nmstate/test/runner"
@@ -174,7 +175,7 @@ func updateDesiredStateAndWait(desiredState nmstate.State) {
 
 func updateDesiredStateWithCaptureAndWait(desiredState nmstate.State, capture map[string]string) {
 	updateDesiredStateWithCapture(desiredState, capture)
-	waitForAvailableTestPolicy()
+	policy.WaitForAvailableTestPolicy()
 }
 
 func updateDesiredStateAtNode(node string, desiredState nmstate.State) {
@@ -192,7 +193,7 @@ func updateDesiredStateAtNodeAndWait(node string, desiredState nmstate.State) {
 
 func updateDesiredStateWithCaptureAtNodeAndWait(node string, desiredState nmstate.State, capture map[string]string) {
 	updateDesiredStateWithCaptureAtNode(node, desiredState, capture)
-	waitForAvailableTestPolicy()
+	policy.WaitForAvailableTestPolicy()
 }
 
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
@@ -201,7 +202,7 @@ func resetDesiredStateForNodes() {
 	By("Resetting nics state primary up and secondaries down")
 	updateDesiredState(resetPrimaryAndSecondaryNICs())
 	defer deletePolicy(TestPolicy)
-	waitForAvailableTestPolicy()
+	policy.WaitForAvailableTestPolicy()
 }
 
 func nodeNetworkState(key types.NamespacedName) nmstatev1beta1.NodeNetworkState {

--- a/test/e2e/handler/webhook_test.go
+++ b/test/e2e/handler/webhook_test.go
@@ -28,6 +28,7 @@ import (
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 	nncpwebhook "github.com/nmstate/kubernetes-nmstate/pkg/webhook/nodenetworkconfigurationpolicy"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
 
@@ -82,7 +83,7 @@ var _ = Describe("Validation Admission Webhook", func() {
 			updateDesiredState(linuxBrUp(bridge1))
 		})
 		AfterEach(func() {
-			waitForAvailablePolicy(TestPolicy)
+			policy.WaitForAvailablePolicy(TestPolicy)
 			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			resetDesiredStateForNodes()
 		})

--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -19,58 +19,30 @@ package operator
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
-	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
-	"github.com/nmstate/kubernetes-nmstate/test/e2e/deployment"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
 )
 
-type operatorTestData struct {
-	ns                                     string
-	nmstate                                nmstatev1.NMState
-	webhookKey, handlerKey, certManagerKey types.NamespacedName
-}
-
-func newOperatorTestData(ns string) operatorTestData {
-	return operatorTestData{
-		ns: ns,
-		nmstate: nmstatev1.NMState{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "nmstate",
-				Namespace: ns,
-			},
-		},
-		webhookKey:     types.NamespacedName{Namespace: ns, Name: "nmstate-webhook"},
-		handlerKey:     types.NamespacedName{Namespace: ns, Name: "nmstate-handler"},
-		certManagerKey: types.NamespacedName{Namespace: ns, Name: "nmstate-cert-manager"},
-	}
-}
+const manifestsDir = "build/_output/manifests/"
 
 var (
 	nodes            []string
-	defaultOperator  = newOperatorTestData("nmstate")
 	knmstateReporter *knmstatereporter.KubernetesNMStateReporter
+	manifestFiles    = []string{"namespace.yaml", "service_account.yaml", "operator.yaml", "role.yaml", "role_binding.yaml"}
+	defaultOperator  = NewOperatorTestData("nmstate", manifestsDir, manifestFiles)
 )
 
 func TestE2E(t *testing.T) {
@@ -101,7 +73,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	uninstallNMStateAndWaitForDeletion(defaultOperator)
+	UninstallNMStateAndWaitForDeletion(defaultOperator)
 })
 
 var _ = ReportBeforeEach(func(specReport ginkgotypes.SpecReport) {
@@ -111,49 +83,6 @@ var _ = ReportBeforeEach(func(specReport ginkgotypes.SpecReport) {
 var _ = ReportAfterEach(func(specReport ginkgotypes.SpecReport) {
 	knmstateReporter.ReportAfterEach(specReport)
 })
-
-func installNMState(nmstate nmstatev1.NMState) {
-	By(fmt.Sprintf("Creating NMState CR '%s'", nmstate.Name))
-	err := testenv.Client.Create(context.TODO(), &nmstate)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "NMState CR created without error")
-}
-
-func uninstallNMState(nmstate nmstatev1.NMState) {
-	By(fmt.Sprintf("Deleting NMState CR '%s'", nmstate.Name))
-	err := testenv.Client.Delete(context.TODO(), &nmstate, &client.DeleteOptions{})
-	Expect(err).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())), "NMState CR successfully removed")
-	eventuallyIsNotFound(types.NamespacedName{Name: nmstate.Name}, &nmstate, "should delete NMState CR")
-}
-
-func eventuallyIsNotFound(key types.NamespacedName, obj client.Object, msg string) {
-	By(fmt.Sprintf("Wait for %+v deletion", key))
-	EventuallyWithOffset(1, func() error {
-		err := testenv.Client.Get(context.TODO(), key, obj)
-		return err
-	}, 120*time.Second, 1*time.Second).Should(WithTransform(apierrors.IsNotFound, BeTrue()), msg)
-}
-
-func eventuallyIsFound(key types.NamespacedName, obj client.Object, msg string) {
-	By(fmt.Sprintf("Wait for %+v creation", key))
-	EventuallyWithOffset(1, func() error {
-		return testenv.Client.Get(context.TODO(), key, obj)
-	}, 120*time.Second, 1*time.Second).Should(Succeed(), msg)
-}
-
-func uninstallNMStateAndWaitForDeletion(testData operatorTestData) {
-	uninstallNMState(testData.nmstate)
-	eventuallyOperandIsNotFound(testData)
-}
-
-func eventuallyOperandIsReady(testData operatorTestData) {
-	eventuallyOperandIsFound(testData)
-	By("Wait daemonset handler is ready")
-	daemonset.GetEventually(testData.handlerKey).Should(daemonset.BeReady(), "should start handler daemonset")
-	By("Wait deployment webhook is ready")
-	deployment.GetEventually(testData.webhookKey).Should(deployment.BeReady(), "should start webhook deployment")
-	By("Wait deployment cert-manager is ready")
-	deployment.GetEventually(testData.certManagerKey).Should(deployment.BeReady(), "should start cert-manager deployment")
-}
 
 func podsShouldBeDistributedAtNodes(selectedNodes []corev1.Node, listOptions ...client.ListOption) {
 	podList := &corev1.PodList{}
@@ -168,28 +97,6 @@ func podsShouldBeDistributedAtNodes(selectedNodes []corev1.Node, listOptions ...
 	} else {
 		Expect(nodesRunningPod).To(HaveLen(1), "should run pods at the same node")
 	}
-}
-
-func eventuallyOperandIsNotFound(testData operatorTestData) {
-	eventuallyIsNotFound(testData.handlerKey, &appsv1.DaemonSet{}, "should delete handler daemonset")
-	eventuallyIsNotFound(testData.webhookKey, &appsv1.Deployment{}, "should delete webhook deployment")
-	eventuallyIsNotFound(testData.certManagerKey, &appsv1.Deployment{}, "should delete cert-manager deployment")
-	By("Wait for operand pods to terminate")
-	Eventually(func() ([]corev1.Pod, error) {
-		podList := corev1.PodList{}
-		err := testenv.Client.List(
-			context.TODO(),
-			&podList,
-			&client.ListOptions{Namespace: testData.ns, LabelSelector: labels.Set{"app": "kubernetes-nmstate"}.AsSelector()},
-		)
-		return podList.Items, err
-	}, 120*time.Second, time.Second).Should(BeEmpty(), "should terminate all the pods")
-}
-
-func eventuallyOperandIsFound(testData operatorTestData) {
-	eventuallyIsFound(testData.handlerKey, &appsv1.DaemonSet{}, "should create handler daemonset")
-	eventuallyIsFound(testData.webhookKey, &appsv1.Deployment{}, "should create webhook deployment")
-	eventuallyIsFound(testData.certManagerKey, &appsv1.Deployment{}, "should create cert-manager deployment")
 }
 
 func isKubevirtciCluster() bool {

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -29,10 +29,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
@@ -155,11 +157,11 @@ var _ = Describe("NMState operator", func() {
 				"should success creating a clusterrolebinding")
 
 			By("Install NMState for the first time")
-			installNMState(defaultOperator.nmstate)
-			eventuallyOperandIsReady(defaultOperator)
+			InstallNMState(defaultOperator.Nmstate)
+			EventuallyOperandIsReady(defaultOperator)
 		})
 		AfterEach(func() {
-			uninstallNMStateAndWaitForDeletion(defaultOperator)
+			UninstallNMStateAndWaitForDeletion(defaultOperator)
 		})
 		AfterEach(func() {
 			Expect(deleteTestUserCRB(testUserBindingName)).To(Succeed())

--- a/test/e2e/operator/operator.go
+++ b/test/e2e/operator/operator.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/deployment"
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+)
+
+type TestData struct {
+	Ns                                     string
+	Nmstate                                nmstatev1.NMState
+	WebhookKey, HandlerKey, CertManagerKey types.NamespacedName
+	ManifestsDir                           string
+	ManifestFiles                          []string
+}
+
+func NewOperatorTestData(ns string, manifestsDir string, manifestFiles []string) TestData {
+	return TestData{
+		Ns: ns,
+		Nmstate: nmstatev1.NMState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nmstate",
+				Namespace: ns,
+			},
+		},
+		WebhookKey:     types.NamespacedName{Namespace: ns, Name: "nmstate-webhook"},
+		HandlerKey:     types.NamespacedName{Namespace: ns, Name: "nmstate-handler"},
+		CertManagerKey: types.NamespacedName{Namespace: ns, Name: "nmstate-cert-manager"},
+		ManifestsDir:   manifestsDir,
+		ManifestFiles:  manifestFiles,
+	}
+}
+
+func InstallNMState(nmstate nmstatev1.NMState) {
+	By(fmt.Sprintf("Creating NMState CR '%s'", nmstate.Name))
+	err := testenv.Client.Create(context.TODO(), &nmstate)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "NMState CR created without error")
+}
+
+func UninstallNMState(nmstate nmstatev1.NMState) {
+	By(fmt.Sprintf("Deleting NMState CR '%s'", nmstate.Name))
+	err := testenv.Client.Delete(context.TODO(), &nmstate, &client.DeleteOptions{})
+	Expect(err).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())), "NMState CR successfully removed")
+	EventuallyIsNotFound(types.NamespacedName{Name: nmstate.Name}, &nmstate, "should delete NMState CR")
+}
+
+func EventuallyIsNotFound(key types.NamespacedName, obj client.Object, msg string) {
+	By(fmt.Sprintf("Wait for %+v deletion", key))
+	EventuallyWithOffset(1, func() error {
+		err := testenv.Client.Get(context.TODO(), key, obj)
+		return err
+	}, 120*time.Second, 1*time.Second).Should(WithTransform(apierrors.IsNotFound, BeTrue()), msg)
+}
+
+func EventuallyIsFound(key types.NamespacedName, obj client.Object, msg string) {
+	By(fmt.Sprintf("Wait for %+v creation", key))
+	EventuallyWithOffset(1, func() error {
+		return testenv.Client.Get(context.TODO(), key, obj)
+	}, 120*time.Second, 1*time.Second).Should(Succeed(), msg)
+}
+
+func UninstallNMStateAndWaitForDeletion(testData TestData) {
+	UninstallNMState(testData.Nmstate)
+	EventuallyOperandIsNotFound(testData)
+}
+
+func EventuallyOperandIsReady(testData TestData) {
+	EventuallyOperandIsFound(testData)
+	By("Wait daemonset handler is ready")
+	daemonset.GetEventually(testData.HandlerKey).Should(daemonset.BeReady(), "should start handler daemonset")
+	By("Wait deployment webhook is ready")
+	deployment.GetEventually(testData.WebhookKey).Should(deployment.BeReady(), "should start webhook deployment")
+	By("Wait deployment cert-manager is ready")
+	deployment.GetEventually(testData.CertManagerKey).Should(deployment.BeReady(), "should start cert-manager deployment")
+}
+
+func EventuallyOperandIsNotFound(testData TestData) {
+	EventuallyIsNotFound(testData.HandlerKey, &appsv1.DaemonSet{}, "should delete handler daemonset")
+	EventuallyIsNotFound(testData.WebhookKey, &appsv1.Deployment{}, "should delete webhook deployment")
+	EventuallyIsNotFound(testData.CertManagerKey, &appsv1.Deployment{}, "should delete cert-manager deployment")
+	By("Wait for operand pods to terminate")
+	Eventually(func() ([]corev1.Pod, error) {
+		podList := corev1.PodList{}
+		err := testenv.Client.List(
+			context.TODO(),
+			&podList,
+			&client.ListOptions{Namespace: testData.Ns, LabelSelector: labels.Set{"app": "kubernetes-nmstate"}.AsSelector()},
+		)
+		return podList.Items, err
+	}, 120*time.Second, time.Second).Should(BeEmpty(), "should terminate all the pods")
+}
+
+func EventuallyOperandIsFound(testData TestData) {
+	EventuallyIsFound(testData.HandlerKey, &appsv1.DaemonSet{}, "should create handler daemonset")
+	EventuallyIsFound(testData.WebhookKey, &appsv1.Deployment{}, "should create webhook deployment")
+	EventuallyIsFound(testData.CertManagerKey, &appsv1.Deployment{}, "should create cert-manager deployment")
+}
+
+func InstallOperator(operator TestData) {
+	By(fmt.Sprintf("Creating NMState operator with namespace '%s'", operator.Ns))
+	_, err := cmd.Run(
+		"make",
+		false,
+		fmt.Sprintf("OPERATOR_NAMESPACE=%s", operator.Ns),
+		fmt.Sprintf("HANDLER_NAMESPACE=%s", operator.Ns),
+		"IMAGE_REGISTRY=registry:5000",
+		"manifests",
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, manifest := range operator.ManifestFiles {
+		_, err = cmd.Kubectl("apply", "-f", operator.ManifestsDir+manifest)
+		Expect(err).ToNot(HaveOccurred())
+	}
+	deployment.GetEventually(types.NamespacedName{Namespace: operator.Ns, Name: "nmstate-operator"}).Should(deployment.BeReady())
+}
+
+func UninstallOperator(operator TestData) {
+	By(fmt.Sprintf("Deleting namespace '%s'", operator.Ns))
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: operator.Ns,
+		},
+	}
+	Expect(testenv.Client.Delete(context.TODO(), &ns)).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())))
+	EventuallyIsNotFound(types.NamespacedName{Name: operator.Ns}, &ns, "should delete the namespace")
+}

--- a/test/e2e/policy/conditions.go
+++ b/test/e2e/policy/conditions.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package handler
+package policy
 
 import (
 	"context"
@@ -32,18 +32,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
 
-func enactmentsStatusToYaml() string {
-	enactmentsStatus := indexEnactmentStatusByName()
+const (
+	ReadTimeout  = 180 * time.Second
+	ReadInterval = 1 * time.Second
+	TestPolicy   = "test-policy"
+)
+
+func EnactmentsStatusToYaml() string {
+	enactmentsStatus := IndexEnactmentStatusByName()
 	manifest, err := yaml.Marshal(enactmentsStatus)
 	Expect(err).ToNot(HaveOccurred())
 	return string(manifest)
 }
 
-func nodeNetworkConfigurationEnactment(key types.NamespacedName) nmstatev1beta1.NodeNetworkConfigurationEnactment {
+func NodeNetworkConfigurationEnactment(key types.NamespacedName) nmstatev1beta1.NodeNetworkConfigurationEnactment {
 	enactment := nmstatev1beta1.NodeNetworkConfigurationEnactment{}
 	Eventually(func() error {
 		return testenv.Client.Get(context.TODO(), key, &enactment)
@@ -51,7 +58,7 @@ func nodeNetworkConfigurationEnactment(key types.NamespacedName) nmstatev1beta1.
 	return enactment
 }
 
-func indexEnactmentStatusByName() map[string]shared.NodeNetworkConfigurationEnactmentStatus {
+func IndexEnactmentStatusByName() map[string]shared.NodeNetworkConfigurationEnactmentStatus {
 	enactmentList := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
 	Eventually(func() error {
 		return testenv.Client.List(context.TODO(), &enactmentList)
@@ -63,35 +70,35 @@ func indexEnactmentStatusByName() map[string]shared.NodeNetworkConfigurationEnac
 	return enactmentStatusByName
 }
 
-func enactmentConditionsStatus(node, policy string) shared.ConditionList {
-	return nodeNetworkConfigurationEnactment(shared.EnactmentKey(node, policy)).Status.Conditions
+func EnactmentConditionsStatus(node, policy string) shared.ConditionList {
+	return NodeNetworkConfigurationEnactment(shared.EnactmentKey(node, policy)).Status.Conditions
 }
 
-func enactmentConditionsStatusForPolicyEventually(node, policy string) AsyncAssertion {
+func EnactmentConditionsStatusForPolicyEventually(node string, policy string) AsyncAssertion {
 	return Eventually(func() shared.ConditionList {
-		return enactmentConditionsStatus(node, policy)
+		return EnactmentConditionsStatus(node, policy)
 	}, 180*time.Second, 1*time.Second)
 }
 
-func enactmentConditionsStatusForPolicyConsistently(node, policy string) AsyncAssertion {
+func EnactmentConditionsStatusForPolicyConsistently(node, policy string) AsyncAssertion {
 	return Consistently(func() shared.ConditionList {
-		return enactmentConditionsStatus(node, policy)
+		return EnactmentConditionsStatus(node, policy)
 	}, 5*time.Second, 1*time.Second)
 }
 
-func enactmentConditionsStatusEventually(node string) AsyncAssertion {
-	return enactmentConditionsStatusForPolicyEventually(node, TestPolicy)
+func EnactmentConditionsStatusEventually(node string) AsyncAssertion {
+	return EnactmentConditionsStatusForPolicyEventually(node, TestPolicy)
 }
 
-func enactmentConditionsStatusConsistently(node string) AsyncAssertion {
-	return enactmentConditionsStatusForPolicyConsistently(node, TestPolicy)
+func EnactmentConditionsStatusConsistently(node string) AsyncAssertion {
+	return EnactmentConditionsStatusForPolicyConsistently(node, TestPolicy)
 }
 
-// In case a condition does not exist create with Unknown type, this way
+// Status In case a condition does not exist create with Unknown type, this way
 // is easier to just use gomega matchers to check in a homogenous way that
 // condition is not present or unknown.
-func policyConditionsStatus(policyName string) shared.ConditionList {
-	policy := nodeNetworkConfigurationPolicy(policyName)
+func Status(policyName string) shared.ConditionList {
+	policy := NodeNetworkConfigurationPolicy(policyName)
 	conditions := shared.ConditionList{}
 	for _, policyConditionType := range shared.NodeNetworkConfigurationPolicyConditionTypes {
 		condition := policy.Status.Conditions.Find(policyConditionType)
@@ -106,23 +113,32 @@ func policyConditionsStatus(policyName string) shared.ConditionList {
 	return conditions
 }
 
-func policyConditionsStatusForPolicyEventually(policy string) AsyncAssertion {
+func NodeNetworkConfigurationPolicy(policyName string) nmstatev1.NodeNetworkConfigurationPolicy {
+	key := types.NamespacedName{Name: policyName}
+	policy := nmstatev1.NodeNetworkConfigurationPolicy{}
+	EventuallyWithOffset(1, func() error {
+		return testenv.Client.Get(context.TODO(), key, &policy)
+	}, ReadTimeout, ReadInterval).ShouldNot(HaveOccurred())
+	return policy
+}
+
+func StatusForPolicyEventually(policy string) AsyncAssertion {
 	return Eventually(func() shared.ConditionList {
-		return policyConditionsStatus(policy)
+		return Status(policy)
 	}, 480*time.Second, 1*time.Second)
 }
 
-func policyConditionsStatusForPolicyConsistently(policy string) AsyncAssertion {
+func StatusForPolicyConsistently(policy string) AsyncAssertion {
 	return Consistently(func() shared.ConditionList {
-		return policyConditionsStatus(policy)
+		return Status(policy)
 	}, 5*time.Second, 1*time.Second)
 }
 
-func policyConditionsStatusConsistently() AsyncAssertion {
-	return policyConditionsStatusForPolicyConsistently(TestPolicy)
+func StatusConsistently() AsyncAssertion {
+	return StatusForPolicyConsistently(TestPolicy)
 }
 
-func containPolicyAvailable() gomegatypes.GomegaMatcher {
+func ContainPolicyAvailable() gomegatypes.GomegaMatcher {
 	return ContainElement(MatchFields(IgnoreExtras, Fields{
 		"Type":    Equal(shared.NodeNetworkConfigurationPolicyConditionAvailable),
 		"Status":  Equal(corev1.ConditionTrue),
@@ -131,7 +147,7 @@ func containPolicyAvailable() gomegatypes.GomegaMatcher {
 	}))
 }
 
-func containPolicyDegraded() gomegatypes.GomegaMatcher {
+func ContainPolicyDegraded() gomegatypes.GomegaMatcher {
 	return ContainElement(MatchFields(IgnoreExtras, Fields{
 		"Type":    Equal(shared.NodeNetworkConfigurationPolicyConditionDegraded),
 		"Status":  Equal(corev1.ConditionTrue),
@@ -140,32 +156,32 @@ func containPolicyDegraded() gomegatypes.GomegaMatcher {
 	}))
 }
 
-func waitForPolicyTransitionUpdate(policy string) {
+func WaitForPolicyTransitionUpdate(policy string) {
 	now := time.Now()
 	EventuallyWithOffset(1, func() time.Time {
-		availableCondition := policyConditionsStatus(policy).Find(shared.NodeNetworkConfigurationPolicyConditionAvailable)
+		availableCondition := Status(policy).Find(shared.NodeNetworkConfigurationPolicyConditionAvailable)
 		return availableCondition.LastTransitionTime.Time
 	}, 4*time.Minute, 5*time.Second).Should(BeTemporally(">=", now), fmt.Sprintf("Policy %s should have updated transition time", policy))
 }
 
-func waitForAvailableTestPolicy() {
-	waitForAvailablePolicy(TestPolicy)
+func WaitForAvailableTestPolicy() {
+	WaitForAvailablePolicy(TestPolicy)
 }
 
-func waitForDegradedTestPolicy() {
-	waitForDegradedPolicy(TestPolicy)
+func WaitForDegradedTestPolicy() {
+	WaitForDegradedPolicy(TestPolicy)
 }
 
-func waitForAvailablePolicy(policy string) {
-	waitForPolicy(policy, containPolicyAvailable())
+func WaitForAvailablePolicy(policy string) {
+	WaitForPolicy(policy, ContainPolicyAvailable())
 }
 
-func waitForDegradedPolicy(policy string) {
-	waitForPolicy(policy, containPolicyDegraded())
+func WaitForDegradedPolicy(policy string) {
+	WaitForPolicy(policy, ContainPolicyDegraded())
 }
 
-func waitForPolicy(policy string, matcher gomegatypes.GomegaMatcher) {
-	policyConditionsStatusForPolicyEventually(policy).
+func WaitForPolicy(policy string, matcher gomegatypes.GomegaMatcher) {
+	StatusForPolicyEventually(policy).
 		Should(
 			SatisfyAny(containPolicyAvailable(), containPolicyDegraded()),
 			func() string {
@@ -189,7 +205,7 @@ func filterOutMessageAndTimestampFromConditions(conditions shared.ConditionList)
 	return modifiedConditions
 }
 
-func matchConditionsFrom(conditionsSetter func(*shared.ConditionList, string)) gomegatypes.GomegaMatcher {
+func MatchConditionsFrom(conditionsSetter func(*shared.ConditionList, string)) gomegatypes.GomegaMatcher {
 	expectedConditions := shared.ConditionList{}
 	conditionsSetter(&expectedConditions, "")
 	expectedConditions = filterOutMessageAndTimestampFromConditions(expectedConditions)

--- a/test/e2e/policy/conditions.go
+++ b/test/e2e/policy/conditions.go
@@ -183,14 +183,14 @@ func WaitForDegradedPolicy(policy string) {
 func WaitForPolicy(policy string, matcher gomegatypes.GomegaMatcher) {
 	StatusForPolicyEventually(policy).
 		Should(
-			SatisfyAny(containPolicyAvailable(), containPolicyDegraded()),
+			SatisfyAny(ContainPolicyAvailable(), ContainPolicyDegraded()),
 			func() string {
 				return fmt.Sprintf("should reach terminal status at NNCP '%s', \n current enactments statuses:\n%s",
-					policy, enactmentsStatusToYaml())
+					policy, EnactmentsStatusToYaml())
 			},
 		)
-	Expect(policyConditionsStatus(policy)).To(matcher, "should reach expected status at NNCP '%s', \n current enactments statuses:\n%s",
-		policy, enactmentsStatusToYaml())
+	Expect(Status(policy)).To(matcher, "should reach expected status at NNCP '%s', \n current enactments statuses:\n%s",
+		policy, EnactmentsStatusToYaml())
 }
 
 func filterOutMessageAndTimestampFromConditions(conditions shared.ConditionList) shared.ConditionList {

--- a/test/e2e/upgrade/.gitignore
+++ b/test/e2e/upgrade/.gitignore
@@ -1,0 +1,2 @@
+manifests/*
+examples/*

--- a/test/e2e/upgrade/main_test.go
+++ b/test/e2e/upgrade/main_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/operator"
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
+)
+
+const (
+	latestManifestsDir          = "build/_output/manifests/"
+	previousReleaseManifestsDir = "test/e2e/upgrade/manifests/"
+	ReadTimeout                 = 180 * time.Second
+	ReadInterval                = 1 * time.Second
+)
+
+var (
+	nodes            []string
+	knmstateReporter *knmstatereporter.KubernetesNMStateReporter
+)
+
+var (
+	manifestFiles           = []string{"namespace.yaml", "service_account.yaml", "operator.yaml", "role.yaml", "role_binding.yaml"}
+	latestOperator          = operator.NewOperatorTestData("nmstate", latestManifestsDir, manifestFiles)
+	previousReleaseOperator = operator.NewOperatorTestData("nmstate", previousReleaseManifestsDir, manifestFiles)
+)
+
+func TestE2E(t *testing.T) {
+	testenv.TestMain()
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upgrade E2E Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	// Change to root directory some test expect that
+	os.Chdir("../../../")
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	testenv.Start()
+
+	knmstateReporter = knmstatereporter.New("test_logs/e2e/handler", testenv.OperatorNamespace, nodes)
+	knmstateReporter.Cleanup()
+})
+
+var _ = ReportBeforeEach(func(specReport ginkgotypes.SpecReport) {
+	knmstateReporter.ReportBeforeEach(specReport)
+})
+
+var _ = ReportAfterEach(func(specReport ginkgotypes.SpecReport) {
+	knmstateReporter.ReportAfterEach(specReport)
+})
+
+func deletePolicy(name string) {
+	By(fmt.Sprintf("Deleting policy %s", name))
+	policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
+	policy.Name = name
+	err := testenv.Client.Delete(context.TODO(), policy)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	// Wait for policy to be removed
+	EventuallyWithOffset(1, func() bool {
+		err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: name}, &nmstatev1.NodeNetworkConfigurationPolicy{})
+		return apierrors.IsNotFound(err)
+	}, 60*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Policy %s not deleted", name))
+}
+
+func setDesiredStateWithPolicy(
+	name string,
+	desiredState shared.State,
+) error {
+	policy := nmstatev1.NodeNetworkConfigurationPolicy{}
+	policy.Name = name
+	key := types.NamespacedName{Name: name}
+	err := testenv.Client.Get(context.TODO(), key, &policy)
+	policy.Spec.DesiredState = desiredState
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return testenv.Client.Create(context.TODO(), &policy)
+		}
+		return err
+	}
+	err = testenv.Client.Update(context.TODO(), &policy)
+	if err != nil {
+		fmt.Println("Update error: " + err.Error())
+	}
+	return err
+}
+
+func setDesiredStateWithPolicyEventually(
+	name string,
+	desiredState shared.State,
+) {
+	Eventually(func() error {
+		return setDesiredStateWithPolicy(name, desiredState)
+	}, ReadTimeout, ReadInterval).ShouldNot(HaveOccurred(), fmt.Sprintf("Failed updating desired state : %s", desiredState))
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -204,8 +204,8 @@ interfaces:
 
 					By("Waiting for all policies to be re-reconciled")
 					allPoliciesReReconciled := func() error {
-						nncps := nmstatev1.NodeNetworkConfigurationPolicyList{}
-						err := testenv.Client.List(context.TODO(), &nncps)
+						nncps = nmstatev1.NodeNetworkConfigurationPolicyList{}
+						err = testenv.Client.List(context.TODO(), &nncps)
 						if err != nil {
 							return err
 						}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -30,17 +30,10 @@ import (
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	"github.com/nmstate/kubernetes-nmstate/test/doc"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/operator"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 )
-
-type upgradePolicyCase struct {
-	name         string
-	fileName     string
-	policyName   string
-	cleanupState *nmstate.State
-	ifaceNames   []string
-}
 
 var _ = Describe("Upgrade", func() {
 	interfaceAbsent := func(iface string) nmstate.State {
@@ -50,117 +43,32 @@ var _ = Describe("Upgrade", func() {
 `, iface))
 	}
 
-	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
-  config:
-    search: []
-    server: []
-interfaces:
-- name: eth1
-	state: absent
-`)
-
 	kubectlAndCheck := func(command ...string) {
 		out, err := cmd.Kubectl(command...)
 		Expect(err).ShouldNot(HaveOccurred(), out)
 	}
 
-	examples := []upgradePolicyCase{
-		{
-			name:       "Ethernet",
-			fileName:   "ethernet.yaml",
-			policyName: "ethernet",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Linux bridge",
-			fileName:   "linux-bridge.yaml",
-			policyName: "linux-bridge",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "Linux bridge with custom vlan",
-			fileName:   "linux-bridge-vlan.yaml",
-			policyName: "linux-bridge-vlan",
-			ifaceNames: []string{"br1"},
-		},
-		{
-			name:       "OVS bridge with interface",
-			fileName:   "ovs-bridge-iface.yaml",
-			policyName: "ovs-bridge-iface",
-			ifaceNames: []string{"ovs0", "ovs-bridge", "eth1"},
-		},
-		{
-			name:       "Linux bonding",
-			fileName:   "bond.yaml",
-			policyName: "bond",
-			ifaceNames: []string{"bond0"},
-		},
-		{
-			name:       "Linux bonding and VLAN",
-			fileName:   "bond-vlan.yaml",
-			policyName: "bond-vlan",
-			ifaceNames: []string{"bond0.102", "bond0"},
-		},
-		{
-			name:       "VLAN",
-			fileName:   "vlan.yaml",
-			policyName: "vlan",
-			ifaceNames: []string{"eth1.102", "eth1"},
-		},
-		{
-			name:       "DHCP",
-			fileName:   "dhcp.yaml",
-			policyName: "dhcp",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Static IP",
-			fileName:   "static-ip.yaml",
-			policyName: "static-ip",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:       "Route",
-			fileName:   "route.yaml",
-			policyName: "route",
-			ifaceNames: []string{"eth1"},
-		},
-		{
-			name:         "DNS",
-			fileName:     "dns.yaml",
-			policyName:   "dns",
-			ifaceNames:   []string{},
-			cleanupState: &cleanDNSDesiredState,
-		},
-		{
-			name:       "Worker selector",
-			fileName:   "worker-selector.yaml",
-			policyName: "worker-selector",
-			ifaceNames: []string{"eth1"},
-		},
-	}
-
-	createUpgradeCasePolicy := func(example upgradePolicyCase) {
-		By(fmt.Sprintf("Creating policy %s", example.policyName))
-		kubectlAndCheck("apply", "-f", fmt.Sprintf("test/e2e/upgrade/examples/%s", example.fileName))
+	createUpgradeCasePolicy := func(example doc.ExampleSpec) {
+		By(fmt.Sprintf("Creating policy %s", example.PolicyName))
+		kubectlAndCheck("apply", "-f", fmt.Sprintf("test/e2e/upgrade/examples/%s", example.FileName))
 		By("Waiting for policy to be available")
-		kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+		kubectlAndCheck("wait", "nncp", example.PolicyName, "--for", "condition=Available", "--timeout", "3m")
 	}
 
-	createUpgradeCaseCleanupPolicy := func(example upgradePolicyCase) {
-		if example.cleanupState != nil {
-			setDesiredStateWithPolicyEventually(example.policyName, *example.cleanupState)
+	createUpgradeCaseCleanupPolicy := func(example doc.ExampleSpec) {
+		if example.CleanupState != nil {
+			setDesiredStateWithPolicyEventually(example.PolicyName, *example.CleanupState)
 		}
-		if len(example.ifaceNames) > 0 {
-			for _, ifaceName := range example.ifaceNames {
+		if len(example.IfaceNames) > 0 {
+			for _, ifaceName := range example.IfaceNames {
 				setDesiredStateWithPolicyEventually(
-					example.policyName,
+					example.PolicyName,
 					interfaceAbsent(ifaceName),
 				)
 			}
 		}
 
-		kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+		kubectlAndCheck("wait", "nncp", example.PolicyName, "--for", "condition=Available", "--timeout", "3m")
 	}
 
 	BeforeEach(func() {
@@ -170,14 +78,14 @@ interfaces:
 	})
 
 	Context("With examples", func() {
-		for _, e := range examples {
+		for _, e := range doc.ExampleSpecs() {
 			example := e
 
-			Context(example.name, func() {
+			Context(example.Name, func() {
 				It("should succeed applying the policy", func() {
 					//TODO: remove when no longer required
 					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns"} {
-						if policyToSkip == example.policyName {
+						if policyToSkip == example.PolicyName {
 							Skip("Skipping due to malformed example manifest")
 						}
 					}
@@ -225,13 +133,13 @@ interfaces:
 					}, ReadTimeout, ReadInterval).Should(Succeed())
 
 					By("Wait for policy to be Available again")
-					kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+					kubectlAndCheck("wait", "nncp", example.PolicyName, "--for", "condition=Available", "--timeout", "3m")
 
 					By("Apply cleanup policy configuration")
 					createUpgradeCaseCleanupPolicy(example)
 
 					By("Delete policy")
-					deletePolicy(example.policyName)
+					deletePolicy(example.PolicyName)
 				})
 			})
 		}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/operator"
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+)
+
+type upgradePolicyCase struct {
+	name         string
+	fileName     string
+	policyName   string
+	cleanupState *nmstate.State
+	ifaceNames   []string
+}
+
+var _ = Describe("Upgrade", func() {
+	interfaceAbsent := func(iface string) nmstate.State {
+		return nmstate.NewState(fmt.Sprintf(`interfaces:
+- name: %s
+  state: absent
+`, iface))
+	}
+
+	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
+  config:
+    search: []
+    server: []
+interfaces:
+- name: eth1
+	state: absent
+`)
+
+	kubectlAndCheck := func(command ...string) {
+		out, err := cmd.Kubectl(command...)
+		Expect(err).ShouldNot(HaveOccurred(), out)
+	}
+
+	examples := []upgradePolicyCase{
+		{
+			name:       "Ethernet",
+			fileName:   "ethernet.yaml",
+			policyName: "ethernet",
+			ifaceNames: []string{"eth1"},
+		},
+		{
+			name:       "Linux bridge",
+			fileName:   "linux-bridge.yaml",
+			policyName: "linux-bridge",
+			ifaceNames: []string{"br1"},
+		},
+		{
+			name:       "Linux bridge with custom vlan",
+			fileName:   "linux-bridge-vlan.yaml",
+			policyName: "linux-bridge-vlan",
+			ifaceNames: []string{"br1"},
+		},
+		{
+			name:       "OVS bridge with interface",
+			fileName:   "ovs-bridge-iface.yaml",
+			policyName: "ovs-bridge-iface",
+			ifaceNames: []string{"ovs0", "ovs-bridge", "eth1"},
+		},
+		{
+			name:       "Linux bonding",
+			fileName:   "bond.yaml",
+			policyName: "bond",
+			ifaceNames: []string{"bond0"},
+		},
+		{
+			name:       "Linux bonding and VLAN",
+			fileName:   "bond-vlan.yaml",
+			policyName: "bond-vlan",
+			ifaceNames: []string{"bond0.102", "bond0"},
+		},
+		{
+			name:       "VLAN",
+			fileName:   "vlan.yaml",
+			policyName: "vlan",
+			ifaceNames: []string{"eth1.102", "eth1"},
+		},
+		{
+			name:       "DHCP",
+			fileName:   "dhcp.yaml",
+			policyName: "dhcp",
+			ifaceNames: []string{"eth1"},
+		},
+		{
+			name:       "Static IP",
+			fileName:   "static-ip.yaml",
+			policyName: "static-ip",
+			ifaceNames: []string{"eth1"},
+		},
+		{
+			name:       "Route",
+			fileName:   "route.yaml",
+			policyName: "route",
+			ifaceNames: []string{"eth1"},
+		},
+		{
+			name:         "DNS",
+			fileName:     "dns.yaml",
+			policyName:   "dns",
+			ifaceNames:   []string{},
+			cleanupState: &cleanDNSDesiredState,
+		},
+		{
+			name:       "Worker selector",
+			fileName:   "worker-selector.yaml",
+			policyName: "worker-selector",
+			ifaceNames: []string{"eth1"},
+		},
+	}
+
+	createUpgradeCasePolicy := func(example upgradePolicyCase) {
+		By(fmt.Sprintf("Creating policy %s", example.policyName))
+		kubectlAndCheck("apply", "-f", fmt.Sprintf("test/e2e/upgrade/examples/%s", example.fileName))
+		By("Waiting for policy to be available")
+		kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+	}
+
+	createUpgradeCaseCleanupPolicy := func(example upgradePolicyCase) {
+		if example.cleanupState != nil {
+			setDesiredStateWithPolicyEventually(example.policyName, *example.cleanupState)
+		}
+		if len(example.ifaceNames) > 0 {
+			for _, ifaceName := range example.ifaceNames {
+				setDesiredStateWithPolicyEventually(
+					example.policyName,
+					interfaceAbsent(ifaceName),
+				)
+			}
+		}
+
+		kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+	}
+
+	BeforeEach(func() {
+		operator.UninstallOperator(latestOperator)
+		operator.InstallOperator(previousReleaseOperator)
+		operator.EventuallyOperandIsReady(previousReleaseOperator)
+	})
+
+	Context("With examples", func() {
+		for _, e := range examples {
+			example := e
+
+			Context(example.name, func() {
+				It("should succeed applying the policy", func() {
+					//TODO: remove when no longer required
+					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns"} {
+						if policyToSkip == example.policyName {
+							Skip("Skipping due to malformed example manifest")
+						}
+					}
+					createUpgradeCasePolicy(example)
+				})
+				AfterEach(func() {
+					policiesLastHeartbeatTimestamps := map[string]time.Time{}
+
+					nncps := nmstatev1.NodeNetworkConfigurationPolicyList{}
+					err := testenv.Client.List(context.TODO(), &nncps)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Collecting LastHeartbeatTime timestamps of present policies")
+					for _, nncp := range nncps.Items {
+						availableCondition := nncp.Status.Conditions.Find(nmstate.NodeNetworkConfigurationPolicyConditionAvailable)
+						Expect(availableCondition).ToNot(BeNil())
+						policiesLastHeartbeatTimestamps[nncp.Name] = availableCondition.LastHeartbeatTime.Time
+					}
+
+					By("Applying new nmstate operator")
+					operator.UninstallOperator(previousReleaseOperator)
+					operator.InstallOperator(latestOperator)
+					operator.EventuallyOperandIsReady(latestOperator)
+
+					By("Waiting for all policies to be re-reconciled")
+					allPoliciesReReconciled := func() error {
+						nncps := nmstatev1.NodeNetworkConfigurationPolicyList{}
+						err := testenv.Client.List(context.TODO(), &nncps)
+						if err != nil {
+							return err
+						}
+						for _, nncp := range nncps.Items {
+							availableCondition := nncp.Status.Conditions.Find(nmstate.NodeNetworkConfigurationPolicyConditionAvailable)
+							if availableCondition.Status != corev1.ConditionTrue {
+								return fmt.Errorf("policy %s is not Available", nncp.Name)
+							}
+							if !availableCondition.LastHeartbeatTime.Time.After(policiesLastHeartbeatTimestamps[nncp.Name]) {
+								return fmt.Errorf("policy  %s hasn't re-reconciled yet", nncp.Name)
+							}
+						}
+						return nil
+					}
+					Eventually(func() error {
+						return allPoliciesReReconciled()
+					}, ReadTimeout, ReadInterval).Should(Succeed())
+
+					By("Wait for policy to be Available again")
+					kubectlAndCheck("wait", "nncp", example.policyName, "--for", "condition=Available", "--timeout", "3m")
+
+					By("Apply cleanup policy configuration")
+					createUpgradeCaseCleanupPolicy(example)
+
+					By("Delete policy")
+					deletePolicy(example.policyName)
+				})
+			})
+		}
+	})
+})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,7 @@ github.com/google/gofuzz/bytesource
 # github.com/google/licenseclassifier/v2 v2.0.0-alpha.1
 ## explicit; go 1.15
 github.com/google/licenseclassifier/v2
-# github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
+# github.com/google/pprof v0.0.0-20210804190019-f964ff605595
 ## explicit; go 1.14
 github.com/google/pprof/profile
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR proposes introduction of upgrade e2e test suite.
The current state of this proposal adds new suite under `test/e2e/upgrade.
This implies that some common utilities need to be extracted from `test/e2e/handler`. Alternative
would be implementing the upgrade suite under `handler` directly, but since the handler
lane is already runs for a long time, it may be preferable to place these tests to a separate lane.

**Special notes for your reviewer**:
Closes https://github.com/nmstate/kubernetes-nmstate/issues/1011

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
