### PR TITLE
[release0.52] Install docs on main only

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -39,4 +39,6 @@ publish_docs() {
 }
 
 push_knmstate_containers
-publish_docs
+if [ "$PULL_BASE_REF" == main ]; then
+    publish_docs
+fi


### PR DESCRIPTION
Right now the release branches are also overriding gh-pages so they are
breaking kubernetes-nmtate page and poiting to previous releases, this
change publish the page only for PRs merged at main branch.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
