### PR TITLE
e2e: Run skipped OVS tests

### DIFF
--- a/test/e2e/handler/default_ovs_bridged_network_test.go
+++ b/test/e2e/handler/default_ovs_bridged_network_test.go
@@ -92,9 +92,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 			macAddr = macAddress(node, primaryNic)
 		})
 
-		PContext(
-			"and ovs bridge on top of the default interface BZ:[https://bugzilla.redhat.com/show_bug.cgi?id=2011879,"+
-				"https://bugzilla.redhat.com/show_bug.cgi?id=2012420]",
+		Context("and ovs bridge on top of the default interface",
 			func() {
 				BeforeEach(func() {
 					Byf("Creating the %s policy", ovsDefaultNetwork)
@@ -154,8 +152,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 				})
 
 				It("should keep the default IP address after node reboot", func() {
-					err := restartNode(node)
-					Expect(err).ToNot(HaveOccurred())
+					restartNodeWithoutWaiting(node)
 
 					By("Wait for policy re-reconciled after node reboot")
 					waitForPolicyTransitionUpdate(ovsDefaultNetwork)

--- a/test/e2e/handler/nncp_cleanup_test.go
+++ b/test/e2e/handler/nncp_cleanup_test.go
@@ -89,7 +89,7 @@ var _ = Describe("NNCP cleanup", func() {
 				verifyEnactmentRemoved(node, 10*time.Second)
 			}
 
-			waitFotNodeToStart(restartedNode)
+			waitForNodeToStart(restartedNode)
 			verifyEnactmentRemoved(restartedNode, 4*time.Minute)
 		})
 	})

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -266,11 +266,6 @@ func deletePolicy(name string) {
 	}
 }
 
-func restartNode(node string) error {
-	restartNodeWithoutWaiting(node)
-	return waitFotNodeToStart(node)
-}
-
 func restartNodeWithoutWaiting(node string) {
 	Byf("Restarting node %s", node)
 	// Use halt so reboot command does not get stuck also
@@ -279,7 +274,7 @@ func restartNodeWithoutWaiting(node string) {
 	runner.RunAtNode(node, "sudo", "halt", "--reboot")
 }
 
-func waitFotNodeToStart(node string) error {
+func waitForNodeToStart(node string) {
 	Byf("Waiting till node %s is rebooted", node)
 	// It will wait till uptime -p will return up that means that node was currently rebooted and is 0 min up
 	Eventually(func() string {
@@ -289,7 +284,6 @@ func waitFotNodeToStart(node string) error {
 		}
 		return output
 	}, 300*time.Second, 5*time.Second).ShouldNot(Equal("up"), fmt.Sprintf("Node %s failed to start after reboot", node))
-	return nil
 }
 
 func createDummyConnection(nodesToModify []string, dummyName string) []error {


### PR DESCRIPTION
The skipped tests reportedly don't reproduce the issue
described in the linked BZs, let's stop skipping them.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>



**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
