### PR TITLE
[release-0.64] webhook: Distribute webhook at control-plane nodes (#1012)

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -28,6 +28,13 @@ spec:
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
       tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
       affinity: {{ toYaml .WebhookAffinity | nindent 8 }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            component: kubernetes-nmstate-webhook
       priorityClassName: system-cluster-critical
       containers:
         - name: nmstate-webhook

--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,8 +101,7 @@ var _ = BeforeSuite(func() {
 
 	By("Getting node list from cluster")
 	nodeList := corev1.NodeList{}
-	err := testenv.Client.List(context.TODO(), &nodeList, &client.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(testenv.Client.List(context.TODO(), &nodeList, &client.ListOptions{})).To(Succeed())
 	for _, node := range nodeList.Items {
 		nodes = append(nodes, node.Name)
 	}
@@ -154,6 +154,21 @@ func eventuallyOperandIsReady(testData operatorTestData) {
 	deployment.GetEventually(testData.certManagerKey).Should(deployment.BeReady(), "should start cert-manager deployment")
 }
 
+func podsShouldBeDistributedAtNodes(selectedNodes []corev1.Node, listOptions ...client.ListOption) {
+	podList := &corev1.PodList{}
+	Expect(testenv.Client.List(context.TODO(), podList, listOptions...)).To(Succeed())
+	nodesRunningPod := map[string]bool{}
+	for _, pod := range podList.Items {
+		Expect(pod.Spec.NodeName).To(BeElementOf(namesFromNodes(selectedNodes)), "should run on the selected nodes")
+		nodesRunningPod[pod.Spec.NodeName] = true
+	}
+	if len(selectedNodes) > 1 {
+		Expect(nodesRunningPod).To(HaveLen(len(podList.Items)), "should run pods at different nodes")
+	} else {
+		Expect(nodesRunningPod).To(HaveLen(1), "should run pods at the same node")
+	}
+}
+
 func eventuallyOperandIsNotFound(testData operatorTestData) {
 	eventuallyIsNotFound(testData.handlerKey, &appsv1.DaemonSet{}, "should delete handler daemonset")
 	eventuallyIsNotFound(testData.webhookKey, &appsv1.Deployment{}, "should delete webhook deployment")
@@ -170,4 +185,25 @@ func eventuallyOperandIsFound(testData operatorTestData) {
 	eventuallyIsFound(testData.handlerKey, &appsv1.DaemonSet{}, "should create handler daemonset")
 	eventuallyIsFound(testData.webhookKey, &appsv1.Deployment{}, "should create webhook deployment")
 	eventuallyIsFound(testData.certManagerKey, &appsv1.Deployment{}, "should create cert-manager deployment")
+}
+
+func isKubevirtciCluster() bool {
+	return strings.Contains(os.Getenv("KUBECONFIG"), "kubevirtci")
+}
+
+func controlPlaneNodes() []corev1.Node {
+	nodeList := &corev1.NodeList{}
+	Expect(testenv.Client.List(context.TODO(), nodeList, client.HasLabels{"node-role.kubernetes.io/control-plane"})).To(Succeed())
+	if len(nodeList.Items) == 0 {
+		Expect(testenv.Client.List(context.TODO(), nodeList, client.HasLabels{"node-role.kubernetes.io/master"})).To(Succeed())
+	}
+	return nodeList.Items
+}
+
+func namesFromNodes(nodes []corev1.Node) []string {
+	names := []string{}
+	for _, node := range nodes {
+		names = append(names, node.Name)
+	}
+	return names
 }

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
@@ -37,13 +38,36 @@ import (
 )
 
 var _ = Describe("NMState operator", func() {
+	type controlPlaneTest struct {
+		withMultiNode bool
+	}
+	DescribeTable("for control-plane size",
+		func(tc controlPlaneTest) {
+			if isKubevirtciCluster() && tc.withMultiNode {
+				kubevirtciReset := increaseKubevirtciControlPlane()
+				defer kubevirtciReset()
+			}
+			if tc.withMultiNode && len(controlPlaneNodes()) < 2 {
+				Skip("cluster control-plane size should be > 1")
+			}
+			if !tc.withMultiNode && len(controlPlaneNodes()) > 1 {
+				Skip("cluster control-plane size should be < 2")
+			}
+
+			installNMState(defaultOperator.nmstate)
+			defer uninstallNMStateAndWaitForDeletion(defaultOperator)
+			eventuallyOperandIsReady(defaultOperator)
+
+			By("Check webhook is distributed across control-plane nodes")
+			podsShouldBeDistributedAtNodes(controlPlaneNodes(), client.MatchingLabels{"component": "kubernetes-nmstate-webhook"})
+		},
+		Entry("of a single node shoud deploy webhook replicas at the same node", controlPlaneTest{withMultiNode: false}),
+		Entry("of two nodes should deploy webhook replicas at different nodes", controlPlaneTest{withMultiNode: true}),
+	)
 	Context("when installed for the first time", func() {
 		BeforeEach(func() {
 			By("Install NMState for the first time")
 			installNMState(defaultOperator.nmstate)
-		})
-		It("should deploy a ready operand", func() {
-			eventuallyOperandIsReady(defaultOperator)
 		})
 		AfterEach(func() {
 			uninstallNMStateAndWaitForDeletion(defaultOperator)
@@ -132,4 +156,20 @@ func uninstallOperator(operator operatorTestData) {
 	}
 	Expect(testenv.Client.Delete(context.TODO(), &ns)).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())))
 	eventuallyIsNotFound(types.NamespacedName{Name: operator.ns}, &ns, "should delete the namespace")
+}
+
+func increaseKubevirtciControlPlane() func() {
+	secondNodeName := "node02"
+	node := &corev1.Node{}
+	Expect(testenv.Client.Get(context.TODO(), client.ObjectKey{Name: secondNodeName}, node)).To(Succeed())
+	By(fmt.Sprintf("Configure kubevirtci cluster node %s as control plane", node.Name))
+	node.Labels["node-role.kubernetes.io/control-plane"] = ""
+	node.Labels["node-role.kubernetes.io/master"] = ""
+	Expect(testenv.Client.Update(context.TODO(), node)).To(Succeed())
+	return func() {
+		By(fmt.Sprintf("Configure kubevirtci cluster node %s as non control plane", node.Name))
+		delete(node.Labels, "node-role.kubernetes.io/control-plane")
+		delete(node.Labels, "node-role.kubernetes.io/master")
+		Expect(testenv.Client.Update(context.TODO(), node)).To(Succeed())
+	}
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
At multiple node control-plane webhook was allow to run replicas on the
same node. This change introduces a topologySpreadConstraints directive
at webhook pod to distribute them.

**Special notes for your reviewer**:
(cherry picked from commit 27791eddda8c11c51d34560b446824d56443c0a8)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
0.64 distribute webhook at control-plane nodes
```
