### PR TITLE
linux-bridge: Add test to propertly check vlan

### DIFF
--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -216,6 +216,7 @@ var _ = Describe("NodeNetworkState", func() {
 					resetDesiredStateForNodes()
 				})
 				It("should have the linux bridge at currentState with vlan_filtering 0 and no default vlan range configured", func() {
+					Skip("Pending on https://bugzilla.redhat.com/show_bug.cgi?id=2067058 land centos stream 8")
 					for _, node := range nodes {
 						interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
 						bridgeDescription(node, bridge1).Should(ContainSubstring("vlan_filtering 0"))

--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -204,6 +204,29 @@ var _ = Describe("NodeNetworkState", func() {
 					hasVlans(node, secondSecondaryNic, 2, 4094).Should(Succeed())
 				}
 			})
+			Context("and vlan field reset at ports", func() {
+				BeforeEach(func() {
+					updateDesiredStateAndWait(linuxBrUpWithDisabledVlan(bridge1))
+				})
+				AfterEach(func() {
+					updateDesiredStateAndWait(linuxBrAbsent(bridge1))
+					for _, node := range nodes {
+						interfacesNameForNodeEventually(node).ShouldNot(ContainElement(bridge1))
+					}
+					resetDesiredStateForNodes()
+				})
+				It("should have the linux bridge at currentState with vlan_filtering 0 and no default vlan range configured", func() {
+					for _, node := range nodes {
+						interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
+						bridgeDescription(node, bridge1).Should(ContainSubstring("vlan_filtering 0"))
+
+						getVLANFlagsEventually(node, firstSecondaryNic, 1).
+							Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
+						vlansCardinality(node, firstSecondaryNic).Should(Equal(0))
+					}
+				})
+			})
+
 		})
 		Context("with a active-backup miimon 100 bond interface up", func() {
 			BeforeEach(func() {

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -121,7 +121,9 @@ func linuxBrUpWithDisabledVlan(bridgeName string) nmstate.State {
       port:
         - name: %s
           vlan: {}
-`, bridgeName, firstSecondaryNic))
+        - name: %s
+          vlan: {}
+`, bridgeName, firstSecondaryNic, secondSecondaryNic))
 }
 
 func ovsBrAbsent(bridgeName string) nmstate.State {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The current vlan-filtering test does not create a bridge with it
activated first. This change add a test for it.


**Special notes for your reviewer**:
Depends on:
- https://github.com/nmstate/nmstate/pull/1830

Affected by:
- https://bugzilla.redhat.com/show_bug.cgi?id=2067058

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
