### PR TITLE
Remove mount options from build files

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
+RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
 
 ARG FROM=quay.io/centos/centos:stream8
 FROM ${FROM}

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -11,7 +11,7 @@ RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH}  go build -o /manager ./cmd/operator
+RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Removes the `mount` option from `RUN` in the Dockerfiles, as in Podman this is only supported since v4 and v4 is not that popular that much yet.

**Special notes for your reviewer**:
Should be reverted when Podman v4 is out for a little longer (#1031)

**Release note**:
```release-note
none
```
