### PR TITLE
Bump golangci version to resolve lint failures

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,5 +18,5 @@ jobs:
         env:
           CGO_ENABLED: 0
         with:
-          version: v1.42.1
+          version: v1.45.2
           args: --timeout 3m0s


### PR DESCRIPTION
Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug


**What this PR does / why we need it**:

With golangci 1.42.1, GitHub actions fail to run the linter. I tracked this down to https://github.com/golangci/golangci-lint/issues/893. Assuming the new version fixes it, I'm bumping it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
