### PR TITLE
cluster: Use kubectl rollout to deploy

### DIFF
--- a/cluster/sync-common.sh
+++ b/cluster/sync-common.sh
@@ -31,24 +31,6 @@ function isExternal {
     [[ "${KUBEVIRT_PROVIDER}" == external ]]
 }
 
-function isDeploymentOk {
-    $kubectl wait deployment -n $1 -l $2 --for condition=Available --timeout=15s
-}
-
-function isDaemonSetOk {
-    desiredNumberScheduled=$($kubectl get daemonset -n $1 -l $2 -o=jsonpath='{..status.desiredNumberScheduled}')
-
-    numberAvailable=$($kubectl get daemonset -n $1 -l $2 -o=jsonpath='{..status.numberAvailable}')
-
-    # There is no numberAvailable yet, return error so we don't end up with
-    # false possitive after 0==0
-    if [ "$numberAvailable" == "" ]; then
-        return 1
-    fi
-
-    [ "$desiredNumberScheduled" == "$numberAvailable" ]
-}
-
 function isOpenshift {
     $kubectl get co openshift-apiserver
 }

--- a/cluster/sync-operator.sh
+++ b/cluster/sync-operator.sh
@@ -23,14 +23,8 @@ function deploy_operator() {
 
 function wait_ready_operator() {
     # We have to re-check desired number, sometimes takes some time to be filled in
-    if ! eventually isDeploymentOk ${OPERATOR_NAMESPACE} app=kubernetes-nmstate-operator; then
+    if ! $kubectl rollout status -w -n ${OPERATOR_NAMESPACE} deployment nmstate-operator; then
         echo "Operator haven't turned ready within the given timeout"
-        return 1
-    fi
-
-    # Make sure good state is keep for some time
-    if ! consistently isDeploymentOk ${OPERATOR_NAMESPACE} app=kubernetes-nmstate-operator; then
-        echo "Operator is not consistently ready within the given timeout"
         return 1
     fi
 }

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -18,27 +18,14 @@ function patch_handler_nodeselector() {
 }
 
 function wait_ready_handler() {
-    # We have to re-check desired number, sometimes takes some time to be filled in
-    if ! eventually isDaemonSetOk ${HANDLER_NAMESPACE} app=kubernetes-nmstate ; then
+    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} ds nmstate-handler; then
         echo "Handler haven't turned ready within the given timeout"
         return 1
     fi
 
-    # Make sure good state is keep for some time
-    if ! consistently isDaemonSetOk ${HANDLER_NAMESPACE} app=kubernetes-nmstate ; then
-        echo "Handler is not consistently ready within the given timeout"
-        return 1
-    fi
-
     # We have to re-check desired number, sometimes takes some time to be filled in
-    if ! eventually isDeploymentOk ${HANDLER_NAMESPACE} app=kubernetes-nmstate; then
+    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} deployment nmstate-webhook; then
         echo "Webhook haven't turned ready within the given timeout"
-        return 1
-    fi
-
-    # Make sure good state is keep for some time
-    if ! consistently isDeploymentOk ${HANDLER_NAMESPACE} app=kubernetes-nmstate; then
-        echo "Webhook is not consistently ready within the given timeout"
         return 1
     fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The correct way to check for deployment finished is using kubectl
rollout since it's the samething for deployments and daemonsets.

```release-note
NONE
```
