### PR TITLE
Remove GITHUB_TOKEN from arnested/go-version-action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,8 +9,6 @@ jobs:
         uses: actions/checkout@v2
       - uses: arnested/go-version-action@v1
         id: go-version
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Hi,

I'm the author of [arnested/go-version-action](https://github.com/marketplace/actions/go-version-action).

The action doesn't need a GITHUB_TOKEN anymore (https://github.com/arnested/go-version-action/pull/212).

Instead of getting the Go releases from git tags using GitHub's API (and thus needing the token to avoid being rate limited) it pulls the versions from https://go.dev/dl/?mode=json&include=all.

**Release note**
```release-note
NONE
```