### PR TITLE
Set policy status in reconcile if it's Unknown

### DIFF
--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -211,6 +211,10 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(_ context.Context, 
 	defer r.decrementUnavailableNodeCount(instance)
 
 	enactmentConditions.NotifyProgressing()
+	if policyconditions.IsUnknown(&instance.Status.Conditions) {
+		policyconditions.Update(r.Client, r.APIClient, request.NamespacedName)
+	}
+
 	nmstateOutput, err := nmstate.ApplyDesiredState(r.APIClient, enactmentInstance.Status.DesiredState)
 	if err != nil {
 		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy at desired state apply: %s,\n %v", nmstateOutput, err)

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -145,6 +145,14 @@ func IsProgressing(conditions *nmstate.ConditionList) bool {
 	return progressingCondition.Status == corev1.ConditionTrue
 }
 
+func IsUnknown(conditions *nmstate.ConditionList) bool {
+	availableCondition := conditions.Find(nmstate.NodeNetworkConfigurationPolicyConditionAvailable)
+	if availableCondition == nil {
+		return true
+	}
+	return availableCondition.Status == corev1.ConditionUnknown
+}
+
 func Update(cli client.Client, apiReader client.Reader, policyKey types.NamespacedName) error {
 	logger := log.WithValues("policy", policyKey.Name)
 


### PR DESCRIPTION
This change addresses a reported BZ that Policy has Unknown
status when it's already progressing. That is because Reconcile
loop updates policy status only when it's finished.

This doesn't look good, especially on single node cluster, where
policy is never progressing, despite the enactment is progressing.

To limit API hits, the update is only attempted if the policy has
Available condition set to Unknown.

An alternative I thought of is setting this in the mutating webhook, but
downside of that is that in case no node is able to update status after reconciling,
the policy may end up being progressing forever.

The solution in this PR should be safer in this regard, in exchange
for more API requests.

- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2053112


Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Set policy progressing status before first enactment is finished
```
