### PR TITLE
[release-0.64] e2e,operator: re-fetch node when removing label

### DIFF
--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -175,6 +175,10 @@ func increaseKubevirtciControlPlane() func() {
 	Expect(err).ToNot(HaveOccurred())
 	return func() {
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err := testenv.Client.Get(context.TODO(), client.ObjectKey{Name: secondNodeName}, node)
+			if err != nil {
+				return err
+			}
 			By(fmt.Sprintf("Configure kubevirtci cluster node %s as non control plane", node.Name))
 			delete(node.Labels, "node-role.kubernetes.io/control-plane")
 			delete(node.Labels, "node-role.kubernetes.io/master")


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
