### PR TITLE
build: Use copr nmstate/nmstate-git for future

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_REPO ?= nmstate
 NAMESPACE ?= nmstate
 
 ifeq ($(NMSTATE_PIN), future)
-HANDLER_EXTRA_PARAMS:= "--build-arg FROM=quay.io/centos/centos:stream9"
+HANDLER_EXTRA_PARAMS:= "--build-arg NMSTATE_SOURCE=git --build-arg FROM=quay.io/centos/centos:stream9"
 endif
 
 HANDLER_IMAGE_NAME ?= kubernetes-nmstate-handler

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,12 +17,14 @@ RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
 ARG FROM=quay.io/centos/centos:stream8
 FROM ${FROM}
 
-COPY --from=build /manager /usr/local/bin/manager
+ARG NMSTATE_SOURCE=distro
 
-RUN dnf install -b -y dnf-plugins-core && \
-    dnf install -b -y -x "*alpha*" -x "*beta*" nmstate && \
+COPY --from=build /manager /usr/local/bin/manager
+COPY --from=build /workdir/build/install-nmstate.${NMSTATE_SOURCE}.sh install-nmstate.sh
+
+RUN ./install-nmstate.sh && \
     dnf install -b -y iproute iputils && \
-    dnf remove -y dnf-plugins-core && \
+    rm ./install-nmstate.sh && \
     dnf clean all
 
 ENTRYPOINT ["manager"]

--- a/build/install-nmstate.distro.sh
+++ b/build/install-nmstate.distro.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+
+dnf install -b -y -x "*alpha*" -x "*beta*" nmstate

--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+dnf install -b -y dnf-plugins-core
+dnf copr enable -y nmstate/nmstate-git
+dnf install -b -y nmstate


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
Using just nmstate from stream9 is not new enough since we are going to
transition soon to stream9 at main, this change uses copr
nmstate/nmstate-git instead wich are RPMs build after a PR is merge at
nmstate base branch.

**Release note**:

```release-note
NONE
```
