### PR TITLE
container: Use stream9 and ubi9-beta

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM=quay.io/centos/centos:stream8
+ARG FROM=quay.io/centos/centos:stream9
 FROM --platform=linux/amd64 ${FROM} AS build
 
 ARG TARGETARCH
@@ -14,7 +14,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
 
-ARG FROM=quay.io/centos/centos:stream8
+ARG FROM=quay.io/centos/centos:stream9
 FROM ${FROM}
 
 ARG NMSTATE_SOURCE=distro

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 quay.io/centos/centos:stream8 AS build
+FROM --platform=linux/amd64 quay.io/centos/centos:stream9 AS build
 
 ARG TARGETARCH
 
@@ -13,7 +13,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9-beta/ubi-minimal
 
 COPY --from=build /manager /usr/local/bin/manager
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes at nmstate are taken more often at centos stream 9. This change
move to stream9 and ubi9-beta the hander and operator so nmstate fixes
reach main sooner.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Move to centos stream 9 and ubi9-beta
```
