### PR TITLE
rbac: Add missing cluster-reader verbs

### DIFF
--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -23,5 +23,6 @@ COPY deploy/handler/operator.yaml /bindata/kubernetes-nmstate/handler/handler.ya
 COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
+COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
 
 ENTRYPOINT ["manager"]

--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -12,6 +12,7 @@ COPY deploy/handler/operator.yaml /bindata/kubernetes-nmstate/handler/handler.ya
 COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
+COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
 
 ENTRYPOINT ["manager"]
 

--- a/deploy/handler/cluster_role.yaml
+++ b/deploy/handler/cluster_role.yaml
@@ -1,0 +1,19 @@
+{{if .ClusterReaderExists}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nmstate-cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkstates
+  - nodenetworkconfigurationpolicies
+  - nodenetworkconfigurationenactments
+  verbs:
+  - get
+  - list
+  - watch
+{{end}}

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -130,6 +131,54 @@ var _ = Describe("NMState operator", func() {
 			})
 		})
 	})
+	Context("when cluser-reader exists", func() {
+		const (
+			clusterReaderRoleName = "cluster-reader"
+			testUserNamespace     = "default"
+			serviceAccountName    = "test-user"
+			testUserBindingName   = "test-user-binding"
+		)
+
+		var clusterReaderCreated bool
+
+		BeforeEach(func() {
+			err := createClusterReaderCR(clusterReaderRoleName)
+			Expect(err).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsAlreadyExists, BeTrue())))
+			if err == nil {
+				clusterReaderCreated = true
+			}
+
+			Expect(createTestUserSA(testUserNamespace, serviceAccountName)).To(Succeed(),
+				"should success creating a serviceaccount")
+			Expect(createTestUserCRB(testUserBindingName, testUserNamespace, serviceAccountName, clusterReaderRoleName)).To(Succeed(),
+				"should success creating a clusterrolebinding")
+
+			By("Install NMState for the first time")
+			installNMState(defaultOperator.nmstate)
+			eventuallyOperandIsReady(defaultOperator)
+		})
+		AfterEach(func() {
+			uninstallNMStateAndWaitForDeletion(defaultOperator)
+		})
+		AfterEach(func() {
+			Expect(deleteTestUserCRB(testUserBindingName)).To(Succeed())
+		})
+		AfterEach(func() {
+			Expect(deleteTestUserSA(testUserNamespace, serviceAccountName)).To(Succeed())
+		})
+		AfterEach(func() {
+			if clusterReaderCreated {
+				Expect(deleteClusterReaderCR(clusterReaderRoleName)).To(Succeed())
+			}
+		})
+
+		It("should be able to read NMState resources with cluster-reader user", func() {
+			Eventually(func() error {
+				_, err := cmd.Kubectl("get", "nns", fmt.Sprintf("--as=system:serviceaccount:%s:%s", testUserNamespace, serviceAccountName))
+				return err
+			}, 10*time.Second, time.Second).Should(Succeed())
+		})
+	})
 })
 
 func installOperator(operator operatorTestData) {
@@ -191,4 +240,91 @@ func increaseKubevirtciControlPlane() func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 	}
+}
+
+func createClusterReaderCR(clusterReaderRoleName string) error {
+	clusterReader := rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterReaderRoleName,
+		},
+		AggregationRule: &rbacv1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-cluster-reader": "true"},
+				},
+			},
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &clusterReader)
+}
+
+func createTestUserSA(testUserNamespace, serviceAccountName string) error {
+	testUserSA := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testUserNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &testUserSA)
+}
+
+func createTestUserCRB(testUserBindingName, testUserNamespace, serviceAccountName, clusterReaderRoleName string) error {
+	testUserBinding := rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testUserBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Namespace: testUserNamespace,
+				Name:      serviceAccountName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     clusterReaderRoleName,
+			APIGroup: rbacv1.GroupName,
+		},
+	}
+	return testenv.Client.Create(context.TODO(), &testUserBinding)
+}
+
+func deleteClusterReaderCR(clusterReaderRoleName string) error {
+	clusterReader := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterReaderRoleName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &clusterReader)
+}
+
+func deleteTestUserSA(testUserNamespace, serviceAccountName string) error {
+	testUserSA := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testUserNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &testUserSA)
+}
+
+func deleteTestUserCRB(testUserBindingName string) error {
+	testUserBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testUserBindingName,
+		},
+	}
+	return testenv.Client.Delete(context.TODO(), &testUserBinding)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using Openshift, in case cluster-reader
ClusterRole exists,
Users of cluster-readers group should be able to
access k8s nmstate crds, such as nns, nncp and nnce.

Add a ClusterRole that allows it in case
cluster-reader exists.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2022745

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
