### PR TITLE
test, handler: Do a lazy read of NNCE on error

### DIFF
--- a/test/e2e/handler/conditions.go
+++ b/test/e2e/handler/conditions.go
@@ -168,7 +168,9 @@ func waitForPolicy(policy string, matcher gomegatypes.GomegaMatcher) {
 	policyConditionsStatusForPolicyEventually(policy).
 		Should(
 			matcher,
-			"should reach expected status at NNCP '%s', \n current enactments statuses:\n%s", policy, enactmentsStatusToYaml(),
+			func() string {
+				return fmt.Sprintf("should reach expected status at NNCP '%s', \n current enactments statuses:\n%s", policy, enactmentsStatusToYaml())
+			},
 		)
 }
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Reading the NNCE to create the assert description was done at assert
definition. This change use the gomega lazy functionality to compose
assert descriptions to print NNCEs at the moment the NNCP fails.

**Special notes for your reviewer**:

```release-note
NONE
```
