### PR TITLE
Revert "container: Use stream9 and ubi9-beta (#1048)"

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM=quay.io/centos/centos:stream9
+ARG FROM=quay.io/centos/centos:stream8
 FROM --platform=linux/amd64 ${FROM} AS build
 
 ARG TARGETARCH
@@ -14,7 +14,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
 
-ARG FROM=quay.io/centos/centos:stream9
+ARG FROM=quay.io/centos/centos:stream8
 FROM ${FROM}
 
 ARG NMSTATE_SOURCE=distro

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 quay.io/centos/centos:stream9 AS build
+FROM --platform=linux/amd64 quay.io/centos/centos:stream8 AS build
 
 ARG TARGETARCH
 
@@ -13,7 +13,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
 
-FROM registry.access.redhat.com/ubi9-beta/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=build /manager /usr/local/bin/manager
 


### PR DESCRIPTION
This reverts commit 5bdd61df4e9cc9d6b0b8a15e080b71367b6760af.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The stream9 nmstate is going to be soon rust only but it's not ready for knmstate, let's go back to stream8 while we fix issues at nmstate rust from https://github.com/nmstate/kubernetes-nmstate/pull/970

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Go back to stream8 while nmstate rust settles
```
