### PR TITLE
e2e,examples: fix e2e examples

### DIFF
--- a/docs/examples/dns-cleanup.yaml
+++ b/docs/examples/dns-cleanup.yaml
@@ -1,0 +1,13 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: dns-cleanup
+spec:
+  desiredState:
+    dns-resolver:
+      config:
+        search: []
+        server: []
+    interfaces:
+    - name: eth1
+      state: absent

--- a/docs/examples/dns.yaml
+++ b/docs/examples/dns.yaml
@@ -12,3 +12,15 @@ spec:
         server:
         - 8.8.8.8
         - 2001:4860:4860::8888
+    interfaces:
+    - name: eth1
+      type: ethernet
+      state: up
+      ipv4:
+        auto-dns: false
+        dhcp: true
+        enabled: true
+      ipv6:
+        auto-dns: false
+        dhcp: true
+        enabled: true

--- a/docs/examples/linux-bridge-vlan.yaml
+++ b/docs/examples/linux-bridge-vlan.yaml
@@ -18,12 +18,12 @@ spec:
               enabled: false
           port:
             - name: eth1
-            vlan:
-              mode: trunk
-              trunk-tags:
-                - id: 101
-                - id-range:
-                    max: 500
-                    min: 200
-              tag: 100
-              enable-native: true
+              vlan:
+                mode: trunk
+                trunk-tags:
+                  - id: 101
+                  - id-range:
+                      max: 500
+                      min: 200
+                tag: 100
+                enable-native: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, examples test only the very last example yaml, which is
'worker selector'. The reason is Ginkgo's multistep flow, which
1. collects all the container nodes (Context, Describe, When) and stores
the runtime blocks (the actual test functions passed to It specs) for
later execution.
2. executes those blocks

This means that in our case, the containers have correct names,
generated during the loop, but the functions all hold reference
to the last example, so all specs work with worker-selector.yaml.

Fixing this by storing to a local variable.

This change also includes fixes to the examples, that are not working
properly. The DNS test in particular requires proper cleanup.
This change adds cleanupState field to the exampleSpec to perform custom
cleanup at AfterEach stage.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Special notes for your reviewer**:
We may add a separate example for cleaning the DNS setting, but we still need to clean the DNS configuration in the AfterEach, otherwise we hit issues with the outer-most AfterEach, that attempts to restore interfaces - because we can't remove the interface if DNS configuration is bound to it (it currently requires specific interface, either dynamic with auto-dns: false of static with static gateway), so the cleanupState is still required.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
