### PR TITLE
Store operator e2e test artifacts in correct directory

### DIFF
--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 		nodes = append(nodes, node.Name)
 	}
 
-	knmstateReporter = knmstatereporter.New("test_logs/e2e/handler", testenv.OperatorNamespace, nodes)
+	knmstateReporter = knmstatereporter.New("test_logs/e2e/operator", testenv.OperatorNamespace, nodes)
 	knmstateReporter.Cleanup()
 })
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
 /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Stores the artifacts of the operator e2e tests in the correct directory to align with https://github.com/nmstate/kubernetes-nmstate/blob/19528fce42424b9e25a690b02a7b9f15718b2473/hack/run-e2e-test-operator.sh#L3

**Release note**:
```release-note
none
```
