### PR TITLE
unit,lint: bump timeout to 10m0s

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -3,8 +3,8 @@ golangci_lint_version=v1.42.1
 if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
 fi
-golangci-lint run --timeout 5m0s
+golangci-lint run --timeout 10m0s
 (
 	cd api
-	golangci-lint run --timeout 5m0s --config ../.golangci.yml
+	golangci-lint run --timeout 10m0s --config ../.golangci.yml
 )


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

Unit tests tend to fail on linter timing out.
This PR increases the timeout to 10m0s 


<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
