### PR TITLE
Use kubernetes.io/arch instead of beta.kubernetes.io/arch

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -171,14 +171,14 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 		Operator: corev1.TolerationOpExists,
 	}
 	archOnMasterNodeSelector := map[string]string{
-		"beta.kubernetes.io/arch":        goruntime.GOARCH,
+		"kubernetes.io/arch":             goruntime.GOARCH,
 		"node-role.kubernetes.io/master": "",
 	}
 	archAndCRNodeSelector := instance.Spec.NodeSelector
 	if archAndCRNodeSelector == nil {
 		archAndCRNodeSelector = map[string]string{}
 	}
-	archAndCRNodeSelector["beta.kubernetes.io/arch"] = goruntime.GOARCH
+	archAndCRNodeSelector["kubernetes.io/arch"] = goruntime.GOARCH
 	archAndCRNodeSelector["kubernetes.io/os"] = "linux"
 
 	handlerTolerations := instance.Spec.Tolerations
@@ -198,7 +198,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 	if archAndCRInfraNodeSelector == nil {
 		archAndCRInfraNodeSelector = archOnMasterNodeSelector
 	} else {
-		archAndCRInfraNodeSelector["beta.kubernetes.io/arch"] = goruntime.GOARCH
+		archAndCRInfraNodeSelector["kubernetes.io/arch"] = goruntime.GOARCH
 	}
 
 	infraTolerations := instance.Spec.InfraTolerations

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		cl                         client.Client
 		reconciler                 NMStateReconciler
 		existingNMStateName        = "nmstate"
-		defaultHandlerNodeSelector = map[string]string{"kubernetes.io/os": "linux", "beta.kubernetes.io/arch": goruntime.GOARCH}
+		defaultHandlerNodeSelector = map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": goruntime.GOARCH}
 		customHandlerNodeSelector  = map[string]string{"selector_1": "value_1", "selector_2": "value_2"}
 		handlerTolerations         = []corev1.Toleration{
 			{


### PR DESCRIPTION
The label beta.kubernetes.io/arch is deprecated and will be removed.
Let's use kubernetes.io/arch label instead.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
