### PR TITLE
controller,nns: remove duplicated controller

### DIFF
--- a/controllers/handler/node_controller.go
+++ b/controllers/handler/node_controller.go
@@ -186,14 +186,6 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	err := ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}).
-		WithEventFilter(onCreationForThisNode).
-		Complete(r)
-	if err != nil {
-		return errors.Wrap(err, "failed to add controller to Node Reconciler listening Node events")
-	}
-
 	// By default all this functors return true so controller watch all events,
 	// but we only want to watch delete/update for current node.
 	onDeleteOrForceUpdateForThisNode := predicate.Funcs{


### PR DESCRIPTION
Recent [PR](https://github.com/nmstate/kubernetes-nmstate/pull/1061) that unified watchers for NNS
failed to remove one of those controller instances.
This PR fixes it and removes it.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
