### PR TITLE
cluster-sync: Increase rollout timeout

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -18,13 +18,13 @@ function patch_handler_nodeselector() {
 }
 
 function wait_ready_handler() {
-    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} ds nmstate-handler; then
+    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} ds nmstate-handler --timeout=2m; then
         echo "Handler haven't turned ready within the given timeout"
         return 1
     fi
 
     # We have to re-check desired number, sometimes takes some time to be filled in
-    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} deployment nmstate-webhook; then
+    if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} deployment nmstate-webhook --timeout=2m; then
         echo "Webhook haven't turned ready within the given timeout"
         return 1
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to solve rollout timeouts during deploy,
increase the timeout.

**Special notes for your reviewer**:
Saw on both CI and locally

**Release note**:
```release-note
None
```
