### PR TITLE
test, reset: Remove reset NNCP if it fail

### DIFF
--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -200,8 +200,8 @@ func updateDesiredStateWithCaptureAtNodeAndWait(node string, desiredState nmstat
 func resetDesiredStateForNodes() {
 	By("Resetting nics state primary up and secondaries down")
 	updateDesiredState(resetPrimaryAndSecondaryNICs())
+	defer deletePolicy(TestPolicy)
 	waitForAvailableTestPolicy()
-	deletePolicy(TestPolicy)
 }
 
 func nodeNetworkState(key types.NamespacedName) nmstatev1beta1.NodeNetworkState {


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
If the reset nics NNCP at e2e test fails the NNCP is not deleted so the
next test that try to reset it will apply it but it will take no efect.
This change delete the NNCP with defer so is always deleted.

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
