### PR TITLE
cluster: Add sleep before checking rollout

### DIFF
--- a/cluster/sync-operator.sh
+++ b/cluster/sync-operator.sh
@@ -22,7 +22,10 @@ function deploy_operator() {
 }
 
 function wait_ready_operator() {
-    # We have to re-check desired number, sometimes takes some time to be filled in
+    # Wait a little for resources to be created
+    sleep 5
+
+    # Wait for deployment rollout
     if ! $kubectl rollout status -w -n ${OPERATOR_NAMESPACE} deployment nmstate-operator; then
         echo "Operator haven't turned ready within the given timeout"
         return 1

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -18,12 +18,16 @@ function patch_handler_nodeselector() {
 }
 
 function wait_ready_handler() {
+    # Wait a little for resources to be created
+    sleep 5
+
+    # Check daemonset rollout
     if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} ds nmstate-handler --timeout=2m; then
         echo "Handler haven't turned ready within the given timeout"
         return 1
     fi
 
-    # We have to re-check desired number, sometimes takes some time to be filled in
+    # Check deployment rollout
     if ! $kubectl rollout status -w -n ${HANDLER_NAMESPACE} deployment nmstate-webhook --timeout=2m; then
         echo "Webhook haven't turned ready within the given timeout"
         return 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Running rollout sometimes fails if the resources has not being already
created. This change add a little sleep to ensure that, doing an
eventually on creation is not worth it.

```release-note
NONE
```
