### PR TITLE
e2e: ignore calico tunl0 interface

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -52,7 +52,7 @@ var (
 	portFieldName        string
 	miimonFormat         string
 	nodesInterfacesState = make(map[string][]byte)
-	interfacesToIgnore   = []string{"flannel.1", "dummy0"}
+	interfacesToIgnore   = []string{"flannel.1", "dummy0", "tunl0"}
 	knmstateReporter     *knmstatereporter.KubernetesNMStateReporter
 )
 


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

The `tunl0` interface is a calico IPIP tunnel interface, we should ignore it when
checking node state.

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Should fix https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/nmstate_kubernetes-nmstate/1072/pull-kubernetes-nmstate-e2e-handler-k8s/1519907330412515328
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
