### PR TITLE
test: Wait for terminal NNCP status

### DIFF
--- a/test/e2e/handler/conditions.go
+++ b/test/e2e/handler/conditions.go
@@ -167,11 +167,14 @@ func waitForDegradedPolicy(policy string) {
 func waitForPolicy(policy string, matcher gomegatypes.GomegaMatcher) {
 	policyConditionsStatusForPolicyEventually(policy).
 		Should(
-			matcher,
+			SatisfyAny(containPolicyAvailable(), containPolicyDegraded()),
 			func() string {
-				return fmt.Sprintf("should reach expected status at NNCP '%s', \n current enactments statuses:\n%s", policy, enactmentsStatusToYaml())
+				return fmt.Sprintf("should reach terminal status at NNCP '%s', \n current enactments statuses:\n%s",
+					policy, enactmentsStatusToYaml())
 			},
 		)
+	Expect(policyConditionsStatus(policy)).To(matcher, "should reach expected status at NNCP '%s', \n current enactments statuses:\n%s",
+		policy, enactmentsStatusToYaml())
 }
 
 func filterOutMessageAndTimestampFromConditions(conditions shared.ConditionList) shared.ConditionList {


### PR DESCRIPTION
**What this PR does / why we need it**:
If a NNCP is marked as Degraded the test will continue at eventually.
This change finish the eventually look if a terminal state (Degraded or
Available) is rechead and then check the expected status.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```