### PR TITLE
Let Ginkgo recover on fail in runAndWait()

### DIFF
--- a/test/reporter/reporter.go
+++ b/test/reporter/reporter.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 )
 
@@ -76,6 +77,7 @@ func runAndWait(funcs ...func()) {
 		// You have to pass f to the goroutine, it's going to change
 		// at the next loop iteration.
 		go func(rf func()) {
+			defer ginkgo.GinkgoRecover()
 			rf()
 			wg.Done()
 		}(f)


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
When there is an error in one of the goroutines in `runAndWait()` (e.g. in `logDeviceStatus` because it can't be ssh'ed to the node), the tests fail with
```
...
  When you, or your assertion library, calls Ginkgo's Fail(),
  Ginkgo panics to prevent subsequent assertions from running.
  Normally Ginkgo rescues this panic so you shouldn't see it.
  However, if you make an assertion in a goroutine, Ginkgo can't capture the
  panic.
  To circumvent this, you should call
  	defer GinkgoRecover()
  at the top of the goroutine that caused this panic.
```
This PR addresses it and adds the ginkgo.GinkgoRecover() to the go routines.

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```
