### PR TITLE
podman: Use full image name

### DIFF
--- a/automation/check-patch.docs.sh
+++ b/automation/check-patch.docs.sh
@@ -9,7 +9,7 @@ sed -i "s#^url:.*#url: \"$url\"#" docs/_config.yaml
 sed -i "s#^baseurl:.*#baseurl: \"$baseurl\"#" docs/_config.yaml
 
 
-${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ ruby make -C docs install check
+${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby make -C docs install check
 
 # Copy the docs to the artifacts
 mkdir -p $ARTIFACTS/gh-pages

--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -25,7 +25,7 @@ push_knmstate_containers() {
 
 publish_docs() {
     # Update gh-pages branch with the generated documentation
-    ${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ ruby make -C /docs install build
+    ${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby make -C /docs install build
     rm -rf /tmp/gh-pages
     git clone --single-branch http://github.com/nmstate/kubernetes-nmstate -b gh-pages /tmp/gh-pages
     rsync -rt --links --cvs-exclude docs/build/kubernetes-nmstate/* /tmp/gh-pages


### PR DESCRIPTION
**What this PR does / why we need it**:
Podman doesn't support short-name as docker does,
hence use full image name.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
