### PR TITLE
e2e,handler: use copy-mac-from copy mac from primary iface

### DIFF
--- a/docs/examples/bond.yaml
+++ b/docs/examples/bond.yaml
@@ -8,6 +8,7 @@ spec:
     - name: bond0
       type: bond
       state: up
+      copy-mac-from: eth1
       ipv4:
         dhcp: true
         enabled: true

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
 )
 
-// TODO: When https://bugzilla.redhat.com/show_bug.cgi?id=1906307 is resolved, add firstSecondaryNic to the bond again
 func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
   - name: %s
     type: bond
     state: up
+    copy-mac-from: %s
     ipv4:
       dhcp: true
       enabled: true
@@ -44,7 +44,8 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
         primary: %s
       %s:
         - %s
-`, bondName, fmt.Sprintf(miimonFormat, 140), primaryNic, portFieldName, primaryNic))
+        - %s
+`, bondName, primaryNic, fmt.Sprintf(miimonFormat, 140), primaryNic, portFieldName, primaryNic, firstSecondaryNic))
 }
 
 func bondAbsentWithPrimaryUp(bondName string) nmstate.State {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
With copy-mac-from available, we can create a bond properly from more than just one interface.
This PR uses copy-mac-from to copy mac from primary interface to the bond and adds secondary interface
to the bond.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
