### PR TITLE
Add labels for pod security standards

### DIFF
--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -25,4 +25,6 @@ COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
 
+USER 1000
+
 ENTRYPOINT ["manager"]

--- a/deploy/handler/namespace.yaml
+++ b/deploy/handler/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: {{ .HandlerNamespace }}
   labels:
     name: {{ .HandlerNamespace }}
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/operator/namespace.yaml
+++ b/deploy/operator/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: {{ .OperatorNamespace }}
   labels:
     name: {{ .OperatorNamespace }}
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -25,6 +25,10 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: nmstate-operator
           args:
@@ -34,6 +38,11 @@ spec:
           imagePullPolicy: {{ .OperatorPullPolicy }}
           command:
           - manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           resources:
             requests:
               cpu: 60m


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
This PR adds the pod security standard (PSS) labels to the namespace(s).
As the operator itself does not require any privileged permissions, by default the operator namespace will have the restricted PSS. When the handler gets installed, this will "update" to the privileged PSS.
In addition the security context of the operator deployment was adjusted to not run the container as root (I didn't see a need for being root in the operator container) and changed the uid in the dockerfile to `1000`.

**Special notes for your reviewer**:

**Release note**:
```release-note
Add pod security standard labels
```
