### PR TITLE
go: Disable goproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ endif
 BIN_DIR = $(CURDIR)/build/_output/bin/
 
 export GOFLAGS=-mod=vendor
+export GOPROXY=direct
 
 export KUBECONFIG ?= $(shell ./cluster/kubeconfig.sh)
 export SSH ?= ./cluster/ssh.sh


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Looks like very often the goproxy have some kind of reset by peer, this
disable goproxy and download deps directly from source.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
