### PR TITLE
Use non cached client for operators node actions

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -48,8 +48,9 @@ import (
 // NMStateReconciler reconciles a NMState object
 type NMStateReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	APIClient client.Client
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups="",resources=services;endpoints;persistentvolumeclaims;events;configmaps;secrets;pods,verbs="*"
@@ -262,7 +263,7 @@ func (r *NMStateReconciler) webhookReplicaCount(nodeSelector map[string]string) 
 	)
 
 	nodes := corev1.NodeList{}
-	err := r.Client.List(context.TODO(), &nodes, client.MatchingLabels(nodeSelector))
+	err := r.APIClient.List(context.TODO(), &nodes, client.MatchingLabels(nodeSelector))
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get nodes: %w", err)
 	}

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -97,6 +97,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 		names.ManifestDir = manifestsDir
 		reconciler.Client = cl
+		reconciler.APIClient = cl
 		reconciler.Scheme = s
 		reconciler.Log = ctrl.Log.WithName("controllers").WithName("NMState")
 		os.Setenv("HANDLER_NAMESPACE", handlerNamespace)
@@ -176,6 +177,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			// Create a fake client to mock API calls.
 			cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			reconciler.Client = cl
+			reconciler.APIClient = cl
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
@@ -224,6 +226,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			// Create a fake client to mock API calls.
 			cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			reconciler.Client = cl
+			reconciler.APIClient = cl
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
@@ -259,6 +262,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			// Create a fake client to mock API calls.
 			cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			reconciler.Client = cl
+			reconciler.APIClient = cl
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
@@ -307,6 +311,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			// Create a fake client to mock API calls.
 			cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			reconciler.Client = cl
+			reconciler.APIClient = cl
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
@@ -356,6 +361,7 @@ var _ = Describe("NMState controller reconcile", func() {
 
 			cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
 			reconciler.Client = cl
+			reconciler.APIClient = cl
 
 			var request ctrl.Request
 			request.Name = existingNMStateName


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
On clusters with RBAC enabled we get the following error message in the operator logs:
```
...
E0630 12:31:48.700316       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:250: Failed to watch *v1.Node: unknown (get nodes)
E0630 12:31:51.525805       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:250: Failed to watch *v1.Node: unknown (get nodes)
E0630 12:31:57.862330       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:250: Failed to watch *v1.Node: unknown (get nodes)
E0630 12:32:10.130812       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:250: Failed to watch *v1.Node: unknown (get nodes)
...
```
The operator uses the managers client to `list` and `get` nodes to get the cluster topology (da39a4d738c41b486f52d47b41dce9d2860f537c). This causes the managers client to subscribe to node changes which requires `watch` permissions. This can lead to a bigger cache usage and on clusters having RBAC enabled this causes issues as we didn't give `watch` permissions. 
This PR addresses it and uses a non cached client for the operators actions on node objects so they don't get cached in the managers client.

Comes from https://bugzilla.redhat.com/show_bug.cgi?id=2102682

**Release note**:
```release-note
none
```
