### PR TITLE
probes: retry to get name server list with 2m timeout

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -176,50 +176,41 @@ func runPing(_ client.Client, timeout time.Duration) error {
 	}
 	return nil
 }
-func lookupRootNS(nameServer string, timeout time.Duration) error {
-	rootNS := "root-server.net"
-	r := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{
-				Timeout: timeout,
-			}
-			return d.DialContext(ctx, network, net.JoinHostPort(nameServer, "53"))
-		},
-	}
-	// We use a closure to create a scope for defer here
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	_, err := r.LookupNS(ctx, rootNS)
-	if err != nil {
-		return errors.Wrapf(err, "failed looking up NS %s using name sever %s", rootNS, nameServer)
-	}
-	return nil
-}
 
-func runDNS(_ client.Client, _ time.Duration) error {
-	currentStateAsGJson, err := currentStateAsGJson()
-	if err != nil {
-		return errors.Wrap(err, "failed retrieving current state to get name resolving config")
-	}
-
-	// Get the name servers at node since the ones at container are not accurate
+func runDNS(_ client.Client, timeout time.Duration) error {
 	runningServersGJsonPath := "dns-resolver.running.server"
-	runningNameServers := currentStateAsGJson.Get(runningServersGJsonPath).Array()
-	if len(runningNameServers) == 0 {
-		return fmt.Errorf("missing name servers at '%s' on %s", runningServersGJsonPath, currentStateAsGJson.String())
-	}
-
 	errs := []error{}
-	for _, runningNameServer := range runningNameServers {
-		err = lookupRootNS(runningNameServer.String(), defaultDNSProbeTimeout)
+	runningNameServers := []gjson.Result{}
+
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		// Get the name servers at node since the ones at container are not accurate
+		currentStateAsGJson, err := currentStateAsGJson()
 		if err != nil {
-			errs = append(errs, err)
-		} else {
-			return nil
+			return false, errors.Wrap(err, "failed retrieving current state to get name resolving config")
 		}
-	}
-	return fmt.Errorf("failed checking DNS connectivity: %v", errs)
+		runningNameServers = currentStateAsGJson.Get(runningServersGJsonPath).Array()
+		if len(runningNameServers) == 0 {
+			return false, fmt.Errorf("missing name servers at '%s' on %s", runningServersGJsonPath, currentStateAsGJson.String())
+		}
+		for _, runningNameServer := range runningNameServers {
+			r := &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					d := net.Dialer{
+						Timeout: timeout,
+					}
+					return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
+				},
+			}
+			_, err := r.LookupNS(context.TODO(), "root-server.net")
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("failed checking DNS connectivity: %v", errs)
+	})
 }
 
 // Select will return the external connectivity probes that are working (ping and dns) and


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2111866

The Bug is about knmstate rolling back due to missing name servers,
we're currently not waiting for name servers to appear.
This PR retries to get non-emty list of name servers from nmstatectl (for up to 2 minutes).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix issue with handler rolling back configuration due to slow update of name servers 
```
