### PR TITLE
Refact probe timeouts

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -46,9 +46,9 @@ var (
 )
 
 type Probe struct {
-	name    string
-	timeout time.Duration
-	run     func(client.Client, time.Duration) error
+	name      string
+	timeout   time.Duration
+	condition func(client.Client) wait.ConditionFunc
 }
 
 const (
@@ -77,180 +77,187 @@ func currentStateAsGJson() (gjson.Result, error) {
 	return gjson.ParseBytes(currentState), nil
 }
 
-func ping(target string, timeout time.Duration) (string, error) {
-	output := ""
-	return output, wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		cmd := exec.Command("ping", "-c", "1", target)
-		var outputBuffer bytes.Buffer
-		cmd.Stdout = &outputBuffer
-		cmd.Stderr = &outputBuffer
-		err := cmd.Run()
-		output = fmt.Sprintf("cmd output: '%s'", outputBuffer.String())
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	})
+func apiServerCondition(_ client.Client) wait.ConditionFunc {
+	return checkAPIServerConnectivity
 }
 
-// This probes use its own client to bypass cache that
-// why we wrap it to ignore the one it's passed
-func checkAPIServerConnectivity(timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		// Create new custom client to bypass cache [1]
-		// [1] https://github.com/operator-framework/operator-sdk/blob/master/doc/user/client.md#non-default-client
-		currentConfig, err := config.GetConfig()
-		if err != nil {
-			return false, errors.Wrap(err, "getting config")
-		}
-		// Since we are going to retrieve Nodes default schema is good
-		// enough, also align timeout with poll
-		currentConfig.Timeout = timeout
-		cli, err := client.New(currentConfig, client.Options{})
-		if err != nil {
-			log.Error(err, "failed to creating new custom client")
-			return false, nil
-		}
-		err = cli.Get(context.TODO(), types.NamespacedName{Name: metav1.NamespaceDefault}, &corev1.Namespace{})
-		if err != nil {
-			log.Error(err, "failed reaching the apiserver")
-			return false, nil
-		}
-		return true, nil
-	})
-}
+// This probes use its own client to bypass cache
+func checkAPIServerConnectivity() (bool, error) {
+	// Create new custom client to bypass cache [1]
+	// [1] https://github.com/operator-framework/operator-sdk/blob/master/doc/user/client.md#non-default-client
+	currentConfig, err := config.GetConfig()
+	if err != nil {
+		return false, errors.Wrap(err, "getting config")
+	}
 
-func checkNodeReadiness(cli client.Client, timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		nodeName := environment.NodeName()
-		node := corev1.Node{}
-		err := cli.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
-		if err != nil {
-			return false, errors.Wrapf(err, "failed retrieving pod's node %s", nodeName)
-		}
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == corev1.NodeReady &&
-				condition.Status == corev1.ConditionTrue {
-				return true, nil
-			}
-		}
+	// Disable client request timeout
+	currentConfig.Timeout = 0
+	cli, err := client.New(currentConfig, client.Options{})
+	if err != nil {
+		log.Error(err, "failed to creating new custom client")
 		return false, nil
-	})
+	}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: metav1.NamespaceDefault}, &corev1.Namespace{})
+	if err != nil {
+		log.Error(err, "failed reaching the apiserver")
+		return false, nil
+	}
+	return true, nil
+}
+
+func nodeReadinessCondition(cli client.Client) wait.ConditionFunc {
+	return func() (bool, error) {
+		return checkNodeReadiness(cli)
+	}
+}
+
+func checkNodeReadiness(cli client.Client) (bool, error) {
+	nodeName := environment.NodeName()
+	node := corev1.Node{}
+	err := cli.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed retrieving pod's node %s", nodeName)
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady &&
+			condition.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func defaultGw() (string, error) {
-	defaultGw := ""
-	return defaultGw, wait.PollImmediate(time.Second, defaultGwRetrieveTimeout, func() (bool, error) {
-		gjsonCurrentState, err := currentStateAsGJson()
-		if err != nil {
-			return false, errors.Wrap(err, "failed retrieving current state to retrieve default gw")
+	gjsonCurrentState, err := currentStateAsGJson()
+	if err != nil {
+		return "", errors.Wrap(err, "failed retrieving current state to retrieve default gw")
+	}
+	defaultGwGjsonPath := "routes.running.#(destination==\"0.0.0.0/0\").next-hop-address"
+	defaultGw := gjsonCurrentState.Get(defaultGwGjsonPath).String()
+	if defaultGw == "" {
+		msg := "default gw missing"
+		defaultGwLog := log.WithValues("path", defaultGwGjsonPath)
+		defaultGwLogDebug := defaultGwLog.V(1)
+		if defaultGwLogDebug.Enabled() {
+			defaultGwLogDebug.Info(msg, "state", gjsonCurrentState.String())
+		} else {
+			defaultGwLog.Info(msg)
 		}
-		defaultGwGjsonPath := "routes.running.#(destination==\"0.0.0.0/0\").next-hop-address"
-		defaultGw = gjsonCurrentState.
-			Get(defaultGwGjsonPath).String()
-		if defaultGw == "" {
-			msg := "default gw missing"
-			defaultGwLog := log.WithValues("path", defaultGwGjsonPath)
-			defaultGwLogDebug := defaultGwLog.V(1)
-			if defaultGwLogDebug.Enabled() {
-				defaultGwLogDebug.Info(msg, "state", gjsonCurrentState.String())
-			} else {
-				defaultGwLog.Info(msg)
-			}
-			return false, nil
-		}
-
-		return true, nil
-	})
+		return "", fmt.Errorf(msg)
+	}
+	return defaultGw, nil
 }
 
-func runPing(_ client.Client, timeout time.Duration) error {
+func pingCondition(cli client.Client) wait.ConditionFunc {
+	return func() (bool, error) {
+		return runPing(cli)
+	}
+}
+
+func runPing(_ client.Client) (bool, error) {
 	defaultGw, err := defaultGw()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve default gw at runProbes")
+		log.Error(err, "failed to retrieve default gw")
+		return false, nil
 	}
 
-	pingOutput, err := ping(defaultGw, timeout)
+	pingOutput, err := ping(defaultGw)
 	if err != nil {
-		return errors.Wrapf(err, "error pinging default gateway -> output: %s", pingOutput)
+		log.Error(err, fmt.Sprintf("error pinging default gateway -> output: '%s'", pingOutput))
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
-func runDNS(_ client.Client, timeout time.Duration) error {
+func ping(target string) (string, error) {
+	cmd := exec.Command("ping", "-c", "1", target)
+	fmt.Println("\nPinging: " + target + "\n")
+	var outputBuffer bytes.Buffer
+	cmd.Stdout = &outputBuffer
+	cmd.Stderr = &outputBuffer
+	err := cmd.Run()
+	output := fmt.Sprintf("cmd output: '%s'", outputBuffer.String())
+	if err != nil {
+		return "", errors.Wrapf(err, "failed running ping probe: %s", output)
+	}
+	return output, nil
+}
+
+func dnsCondition(cli client.Client) wait.ConditionFunc {
+	return func() (bool, error) {
+		return runDNS(cli)
+	}
+}
+
+func runDNS(_ client.Client) (bool, error) {
 	runningServersGJsonPath := "dns-resolver.running.server"
 	errs := []error{}
-	runningNameServers := []gjson.Result{}
 
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		// Get the name servers at node since the ones at container are not accurate
-		currentStateAsGJson, err := currentStateAsGJson()
+	// Get the name servers at node since the ones at container may not be up to date
+	currentStateAsGJson, err := currentStateAsGJson()
+	if err != nil {
+		return false, errors.Wrap(err, "failed retrieving current state to get name resolving config")
+	}
+	runningNameServers := currentStateAsGJson.Get(runningServersGJsonPath).Array()
+	if len(runningNameServers) == 0 {
+		log.Info(fmt.Sprintf("missing name servers at '%s' on %s", runningServersGJsonPath, currentStateAsGJson.String()))
+		return false, nil
+	}
+	for _, runningNameServer := range runningNameServers {
+		r := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{}
+				return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
+			},
+		}
+		_, err := r.LookupNS(context.TODO(), "root-server.net")
 		if err != nil {
-			return false, errors.Wrap(err, "failed retrieving current state to get name resolving config")
+			errs = append(errs, err)
+		} else {
+			return true, nil
 		}
-		runningNameServers = currentStateAsGJson.Get(runningServersGJsonPath).Array()
-		if len(runningNameServers) == 0 {
-			return false, fmt.Errorf("missing name servers at '%s' on %s", runningServersGJsonPath, currentStateAsGJson.String())
-		}
-		for _, runningNameServer := range runningNameServers {
-			r := &net.Resolver{
-				PreferGo: true,
-				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-					d := net.Dialer{
-						Timeout: timeout,
-					}
-					return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
-				},
-			}
-			_, err := r.LookupNS(context.TODO(), "root-server.net")
-			if err != nil {
-				errs = append(errs, err)
-			} else {
-				return true, nil
-			}
-		}
-		return false, fmt.Errorf("failed checking DNS connectivity: %v", errs)
-	})
+	}
+	log.Error(fmt.Errorf("%v", errs), "failed checking DNS connectivity")
+	return false, nil
 }
 
 // Select will return the external connectivity probes that are working (ping and dns) and
 // the internal connectivity probes
 func Select(cli client.Client) []Probe {
 	probes := []Probe{}
-
-	err := runPing(cli, time.Second)
-	if err == nil {
-		probes = append(probes, Probe{
-			name:    "ping",
-			timeout: defaultGwProbeTimeout,
-			run:     runPing,
-		})
-	} else {
-		log.Info("WARNING not selecting 'ping' probe")
+	externalConnectivityProbes := []Probe{
+		{
+			name:      "ping",
+			timeout:   defaultGwProbeTimeout,
+			condition: pingCondition,
+		},
+		{
+			name:      "dns",
+			timeout:   defaultDNSProbeTimeout,
+			condition: dnsCondition,
+		},
 	}
-	err = runDNS(cli, time.Second)
-	if err == nil {
-		probes = append(probes, Probe{
-			name:    "dns",
-			timeout: defaultDNSProbeTimeout,
-			run:     runDNS,
-		})
-	} else {
-		log.Info("WARNING not selecting 'dns' probe")
+
+	for _, p := range externalConnectivityProbes {
+		err := wait.PollImmediate(time.Second, p.timeout, p.condition(cli))
+		if err == nil {
+			probes = append(probes, p)
+		} else {
+			log.Info(fmt.Sprintf("WARNING not selecting %s probe", p.name))
+		}
 	}
 
 	probes = append(probes,
 		Probe{
-			name:    "api-server",
-			timeout: apiServerProbeTimeout,
-			run: func(_ client.Client, timeout time.Duration) error {
-				return checkAPIServerConnectivity(timeout)
-			},
+			name:      "api-server",
+			timeout:   apiServerProbeTimeout,
+			condition: apiServerCondition,
 		},
 		Probe{
-			name:    "node-readiness",
-			timeout: nodeReadinessProbeTimeout,
-			run:     checkNodeReadiness,
+			name:      "node-readiness",
+			timeout:   nodeReadinessProbeTimeout,
+			condition: nodeReadinessCondition,
 		})
 
 	return probes
@@ -266,7 +273,7 @@ func Run(cli client.Client, probes []Probe) error {
 
 	for _, p := range probes {
 		log.Info(fmt.Sprintf("Running '%s' probe", p.name))
-		err = p.run(cli, p.timeout)
+		err = wait.PollImmediate(time.Second, p.timeout, p.condition(cli))
 		if err != nil {
 			return errors.Wrapf(
 				err,

--- a/test/e2e/handler/error_messages_formatting_test.go
+++ b/test/e2e/handler/error_messages_formatting_test.go
@@ -73,14 +73,15 @@ func createPolicyAndWaitForEnactmentCondition(policy string, desiredState func()
 	waitForNodesReady()
 
 	By("Waiting for enactment to be failing")
-	policyconditions.EnactmentConditionsStatusEventually(
+	policyconditions.EnactmentConditionsStatusForPolicyEventually(
 		nodes[0],
+		policy,
 	).Should(policyconditions.MatchConditionsFrom(enactmentconditions.SetFailedToConfigure))
 }
 
 var _ = Describe("NodeNetworkState", func() {
 	var (
-		defaultPolicy = "test-policy"
+		defaultPolicy = "errors-policy"
 
 		messagesToRemove = []string{
 			"DEBUG    Async action: Create checkpoint started",
@@ -174,7 +175,7 @@ var _ = Describe("NodeNetworkState", func() {
 	Context("with ping fail", func() {
 		var (
 			messagesToKeep = []string{
-				"failed to retrieve default gw at runProbes",
+				"timed out waiting for the condition",
 			}
 		)
 
@@ -185,7 +186,7 @@ var _ = Describe("NodeNetworkState", func() {
 		AfterEach(func() {
 			resetDesiredStateForNodes()
 			By("Remove the policy")
-			deletePolicy("test-policy")
+			deletePolicy(defaultPolicy)
 		})
 
 		It("should discard disarranged parts of the message and keep desired parts of the message", func() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR chages the timeout logic, moving the retry responsibility
out of the probe functions. This simplifies the probe func interface,
as we don't need to pass a timeout parameter, and it's handled by the
caller.

Additionally, some comments seemed unclear. Second commit of this PR attempts to improve those.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
