### PR TITLE
Respect CR node selector for NMState handler

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -199,11 +199,11 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 	}
 	archAndCRNodeSelector := instance.Spec.NodeSelector
 	if archAndCRNodeSelector == nil {
-		archAndCRNodeSelector = map[string]string{}
+		archAndCRNodeSelector = map[string]string{
+			"kubernetes.io/arch": goruntime.GOARCH,
+			"kubernetes.io/os":   "linux",
+		}
 	}
-	archAndCRNodeSelector["kubernetes.io/arch"] = goruntime.GOARCH
-	archAndCRNodeSelector["kubernetes.io/os"] = "linux"
-
 	handlerTolerations := instance.Spec.Tolerations
 	if handlerTolerations == nil {
 		handlerTolerations = []corev1.Toleration{operatorExistsToleration}

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -183,13 +183,13 @@ var _ = Describe("NMState controller reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 		})
-		It("should add default NodeSelector to handler daemonset", func() {
+		It("should not add default NodeSelector to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
 			handlerKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
 			err := cl.Get(context.TODO(), handlerKey, ds)
 			Expect(err).ToNot(HaveOccurred())
 			for k, v := range defaultHandlerNodeSelector {
-				Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(k, v))
+				Expect(ds.Spec.Template.Spec.NodeSelector).ToNot(HaveKeyWithValue(k, v))
 			}
 		})
 		It("should add NodeSelector to handler daemonset", func() {


### PR DESCRIPTION
Signed-off-by: Mark Spencer Tan <msgtan@gmail.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
fixes #1117 

This PR fixes the handler's node selectors not being overridden properly with the CR's node selectors due to the `"kubernetes.io/arch": goruntime.GOARCH` node selector being added statically. This is problematic for Multi-Architecture clusters since the handler will only deploy on one of the arch types rather than all.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fixed the nmstate handler's node selectors not being overridden properly with the CR's node selectors
```
