### PR TITLE
Add test exercising lldp configuration with nmpolicy

### DIFF
--- a/docs/examples/lldp.yaml
+++ b/docs/examples/lldp.yaml
@@ -1,0 +1,11 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: lldp-enabled-on-eths
+spec:
+  capture:
+    ethernets: interfaces.type=="ethernet"
+    ethernets-up: capture.ethernets | interfaces.state=="up"
+    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=false
+  desiredState:
+    interfaces: "{{ capture.ethernets-lldp.interfaces }}"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gofrs/flock v0.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
-	github.com/nmstate/nmpolicy v0.3.0
+	github.com/nmstate/nmpolicy v0.5.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20220722144142-ac5cee47c2a0

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nmstate/nmpolicy v0.3.0 h1:mxFDsq6BsWQjPvXa7Yqy2cWyyUgnZpYen6THmiCZ5gE=
-github.com/nmstate/nmpolicy v0.3.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
+github.com/nmstate/nmpolicy v0.5.0 h1:xrioHeIq+oSOzJIaYNK/rWEJb9qWwGYeWOF30/DTvPM=
+github.com/nmstate/nmpolicy v0.5.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/test/e2e/handler/lldp_with_nmpolicy_test.go
+++ b/test/e2e/handler/lldp_with_nmpolicy_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+	"time"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LLDP configuration with nmpolicy", func() {
+	lldpEnabledPolicyName := "lldp-enabled"
+	lldpDisabledPolicyName := "lldp-disabled"
+
+	configureLldpOnEthernetsCapture := func(enabled string) map[string]string {
+		return map[string]string{
+			"ethernets":      `interfaces.type=="ethernet"`,
+			"ethernets-up":   `capture.ethernets | interfaces.state=="up"`,
+			"ethernets-lldp": fmt.Sprintf(`capture.ethernets-up | interfaces.lldp.enabled:=%s`, enabled),
+		}
+	}
+
+	interfacesWithLldpEnabledState := nmstate.NewState(`interfaces: "{{ capture.ethernets-lldp.interfaces }}"`)
+
+	BeforeEach(func() {
+		By("Enabling LLDP on up ethernet interfaces")
+		setDesiredStateWithPolicyAndCapture(lldpEnabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("true"))
+		policy.WaitForAvailablePolicy(lldpEnabledPolicyName)
+
+		DeferCleanup(func() {
+			deletePolicy(lldpEnabledPolicyName)
+
+			By("Disabling LLDP on up ethernet interfaces")
+			setDesiredStateWithPolicyAndCapture(lldpDisabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("false"))
+			policy.WaitForAvailablePolicy(lldpDisabledPolicyName)
+			deletePolicy(lldpDisabledPolicyName)
+		})
+	})
+
+	It("should enable LLDP on all ethernet interfaces that are up", func() {
+		Byf("Check %s has lldp enabled", primaryNic)
+		for _, node := range nodes {
+			Eventually(
+				func() string {
+					return lldpEnabled(node, primaryNic)
+				},
+				30*time.Second, 1*time.Second,
+			).Should(Equal("true"), fmt.Sprintf("Interface %s should have enabled lldp", primaryNic))
+		}
+	})
+})

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -580,6 +580,11 @@ func nodeInterfacesState(node string, exclude []string) []byte {
 	return ret
 }
 
+func lldpEnabled(node, iface string) string {
+	path := fmt.Sprintf("interfaces.#(name==\"%s\").lldp.enabled", iface)
+	return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()
+}
+
 func ipv4Address(node, iface string) string {
 	path := fmt.Sprintf("interfaces.#(name==\"%s\").ipv4.address.0.ip", iface)
 	return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
@@ -28,6 +28,7 @@ type Terminal struct {
 	Str      *string `json:"string,omitempty"`
 	Identity *string `json:"identity,omitempty"`
 	Number   *int    `json:"number,omitempty"`
+	Boolean  *bool   `json:"boolean,omitempty"`
 }
 
 type Node struct {
@@ -60,6 +61,9 @@ func (t Terminal) String() string {
 	}
 	if t.Number != nil {
 		return fmt.Sprintf("Number=%d", *t.Number)
+	}
+	if t.Boolean != nil {
+		return fmt.Sprintf("Boolean=%t", *t.Boolean)
 	}
 	return ""
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
@@ -62,3 +62,7 @@ func (l *lexer) isPlus() bool {
 func (l *lexer) isPipe() bool {
 	return l.scn.Rune() == '|'
 }
+
+func (l *lexer) isDelimiter() bool {
+	return l.isEOF() || l.isSpace() || l.isDot() || l.isEqual() || l.isColon() || l.isPlus() || l.isPipe()
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
@@ -23,6 +23,7 @@ const (
 	IDENTITY
 	NUMBER
 	STRING
+	BOOLEAN
 
 	DOT // .
 
@@ -32,9 +33,6 @@ const (
 	EQFILTER // ==
 	MERGE    // +
 	operatorsEnd
-
-	TRUE  // true
-	FALSE // false
 )
 
 var tokens = []string{
@@ -42,6 +40,7 @@ var tokens = []string{
 	IDENTITY: "IDENTITY",
 	NUMBER:   "NUMBER",
 	STRING:   "STRING",
+	BOOLEAN:  "BOOLEAN",
 
 	DOT:  "DOT",
 	PIPE: "PIPE",
@@ -49,9 +48,6 @@ var tokens = []string{
 	REPLACE:  "REPLACE",
 	EQFILTER: "EQFILTER",
 	MERGE:    "MERGE",
-
-	TRUE:  "TRUE",
-	FALSE: "FALSE",
 }
 
 func (t TokenType) String() string {
@@ -66,4 +62,12 @@ type Token struct {
 	Position int
 	Type     TokenType
 	Literal  string
+}
+
+func (t *Token) IsTrue() bool {
+	return t.Literal == "true"
+}
+
+func (t *Token) IsFalse() bool {
+	return t.Literal == "false"
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/replace.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/replace.go
@@ -61,7 +61,7 @@ func (r replaceOpVisitor) visitMap(p path, mapToVisit map[string]interface{}) (i
 	}
 	interfaceToVisit, ok := mapToVisit[*p.currentStep.Identity]
 	if !ok {
-		return nil, nil
+		interfaceToVisit = map[string]interface{}{}
 	}
 
 	visitResult, err := visitState(p.nextStep(), interfaceToVisit, &r)

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
@@ -159,7 +159,7 @@ func (r *resolver) resolveTernaryOperator(operator *ast.TernaryOperator,
 		return nil, err
 	}
 	r.currentNode = &(*operator)[2]
-	value, err := r.resolveStringOrCaptureEntryPath()
+	value, err := r.resolveTerminalOrCapturePath()
 	if err != nil {
 		return nil, err
 	}
@@ -193,11 +193,13 @@ func (r *resolver) resolveInputSource() (types.NMState, error) {
 	return nil, fmt.Errorf("invalid input source (%s), only current state or capture reference is supported", *r.currentNode)
 }
 
-func (r *resolver) resolveStringOrCaptureEntryPath() (interface{}, error) {
+func (r *resolver) resolveTerminalOrCapturePath() (interface{}, error) {
 	if r.currentNode.Str != nil {
 		return *r.currentNode.Str, nil
 	} else if r.currentNode.Path != nil {
 		return r.resolveCaptureEntryPath()
+	} else if r.currentNode.Boolean != nil {
+		return *r.currentNode.Boolean, nil
 	} else {
 		return nil, fmt.Errorf("not supported value. Only string or capture entry path are supported")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
-# github.com/nmstate/nmpolicy v0.3.0
+# github.com/nmstate/nmpolicy v0.5.0
 ## explicit; go 1.17
 github.com/nmstate/nmpolicy/nmpolicy
 github.com/nmstate/nmpolicy/nmpolicy/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR bumps nmpolicy dependency to allow configuration of boolean values.
In the second commit, this feature is used in an e2e test that configures lldp with nmpolicy capture.
In the third commit, an example of enabling lldp on all ethernet interfaces that are up is added.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bump nmpolicy to v0.5.0
```
