### PR TITLE
e2e,doc: Add LLDP example

### DIFF
--- a/docs/examples/lldp.yaml
+++ b/docs/examples/lldp.yaml
@@ -1,11 +1,11 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: lldp-enabled-on-eths
+  name: enable-lldp-ethernets-up
 spec:
   capture:
     ethernets: interfaces.type=="ethernet"
     ethernets-up: capture.ethernets | interfaces.state=="up"
-    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=false
+    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
   desiredState:
     interfaces: "{{ capture.ethernets-lldp.interfaces }}"

--- a/test/doc/examples.go
+++ b/test/doc/examples.go
@@ -29,14 +29,22 @@ type ExampleSpec struct {
 	CleanupState *nmstate.State
 }
 
+//nolint: funlen
 func ExampleSpecs() []ExampleSpec {
 	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
-    config:
-      search: []
-      server: []
+  config:
+    search: []
+    server: []
 interfaces:
 - name: eth1
   state: absent
+`)
+
+	cleanLLDPDesiredState := nmstate.NewState(`interfaces:
+- name: eth0
+  type: ethernet
+  lldp:
+    enabled: false
 `)
 	return []ExampleSpec{
 		{
@@ -117,6 +125,13 @@ interfaces:
 			PolicyName:   "dns",
 			IfaceNames:   []string{},
 			CleanupState: &cleanDNSDesiredState,
+		},
+		{
+			Name:         "LLDP",
+			FileName:     "lldp.yaml",
+			PolicyName:   "enable-lldp-ethernets-up",
+			IfaceNames:   []string{},
+			CleanupState: &cleanLLDPDesiredState,
 		},
 		{
 			Name:       "Worker selector",

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Upgrade", func() {
 			Context(example.Name, func() {
 				It("should succeed applying the policy", func() {
 					//TODO: remove when no longer required
-					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns"} {
+					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns", "enable-lldp-ethernets-up"} {
 						if policyToSkip == example.PolicyName {
 							Skip("Skipping due to malformed example manifest")
 						}


### PR DESCRIPTION

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
This commit adds example yaml of a policy enabling LLDP on all ethernet interfaces that are at state: up.

The lldp scenario has to be skipped at upgrade lane because older knmstate doesn't feature nmpolicy
version enabling this nmpolicy expression.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add LLDP example policy
```
