### PR TITLE
handler: Install plugin-ovsdb

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -9,6 +9,7 @@ RUN \
     microdnf -y update && \
     microdnf -y install \
         nmstate \
+        nmstate-plugin-ovsdb \
         iputils \
         iproute && \
     microdnf clean all

--- a/build/install-nmstate.distro.sh
+++ b/build/install-nmstate.distro.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -xe
 
-dnf install -b -y -x "*alpha*" -x "*beta*" nmstate
+dnf install -b -y -x "*alpha*" -x "*beta*" nmstate nmstate-plugin-ovsdb

--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -2,4 +2,4 @@
 
 dnf install -b -y dnf-plugins-core
 dnf copr enable -y nmstate/nmstate-git
-dnf install -b -y nmstate
+dnf install -b -y nmstate nmstate-plugin-ovsdb


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
When configuring global ovs tables the ovsdb plugin is needed for verification. This change add this to all the handler Dockerfiles.

**Special notes for your reviewer**:

Closes: https://issues.redhat.com/browse/OCPBUGS-1719

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Install ovsdb plugin
```
