### PR TITLE
Enable caching in builds again

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 
-RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
+RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
 
 ARG FROM=quay.io/centos/centos:stream8
 FROM ${FROM}

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -11,7 +11,7 @@ RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 
-RUN GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
+RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 


### PR DESCRIPTION
Podman v4 seems to be wider available now (e.g. on Fedora, CentOS Stream) so we can enable this option again.

This reverts commit f839932fb9d386e65766f79da31a84a0d5e8f8fe.

Fixes #1031

**Release note:**
```
none
```