### PR TITLE
docs: Pin ruby to 3.1

### DIFF
--- a/automation/check-patch.docs.sh
+++ b/automation/check-patch.docs.sh
@@ -9,7 +9,7 @@ sed -i "s#^url:.*#url: \"$url\"#" docs/_config.yaml
 sed -i "s#^baseurl:.*#baseurl: \"$baseurl\"#" docs/_config.yaml
 
 
-${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby make -C docs install check
+${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby:3.1 make -C docs install check
 
 # Copy the docs to the artifacts
 mkdir -p $ARTIFACTS/gh-pages


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like Jekyll has a pin to a old Liquid version that does not works with ruby 3.2, this change pins to ruby 3.1 so there is no issue.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
