### PR TITLE
handler: Rollback always before Apply

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -166,6 +166,10 @@ func ApplyDesiredState(cli client.Client, desiredState shared.State) (string, er
 	// working fine after apply
 	probes := probe.Select(cli)
 
+	// Rollback before Apply to remove pending checkpoints (for example handler pod restarted
+	// before Commit)
+	nmstatectl.Rollback()
+
 	setOutput, err := nmstatectl.Set(desiredState, DesiredStateConfigurationTimeout)
 	if err != nil {
 		return setOutput, err

--- a/test/cmd/run.go
+++ b/test/cmd/run.go
@@ -38,5 +38,8 @@ func Run(command string, quiet bool, arguments ...string) (string, error) {
 	if !quiet {
 		fmt.Fprintf(GinkgoWriter, "stdout: %.500s...,\nstderr: %s\n", stdout.String(), stderr.String())
 	}
+	if err != nil {
+		return "", fmt.Errorf("%s: %s: %v", stdout.String(), stderr.String(), err)
+	}
 	return stdout.String(), err
 }

--- a/test/e2e/handler/pending_checkpoint_test.go
+++ b/test/e2e/handler/pending_checkpoint_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
+	"github.com/nmstate/kubernetes-nmstate/test/runner"
+)
+
+var _ = Describe("checkpoin", func() {
+	Context("when is not committed from previous operation", func() {
+		BeforeEach(func() {
+			stateAsJSON, err := linuxBrUpNoPorts(bridge1).MarshalJSON()
+			Expect(err).ToNot(HaveOccurred())
+			runner.RunAtHandlerPods("bash", "-c", fmt.Sprintf("echo '%s' | nmstatectl apply --no-commit --timeout 60", string(stateAsJSON)))
+		})
+		Context("and new nncp is configured", func() {
+			BeforeEach(func() {
+				updateDesiredState(linuxBrUpNoPorts(bridge1))
+			})
+			AfterEach(func() {
+				updateDesiredStateAndWait(linuxBrAbsent(bridge1))
+			})
+			It("should remove pending checkpoint and continue", func() {
+				policy.WaitForAvailableTestPolicy()
+			})
+		})
+	})
+})


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug


**What this PR does / why we need it**:
Sometimes a pending checkpoint is lingering around, for example when a handler pod has being restarted before reaching Commit, also looks like the checkpoint feature is not used except for kubernetes-nmstate. This change do Rollback to remove the pending checkpoing before Apply since apply on pending checkpoing fails.

**Special notes for your reviewer**:
Closes https://bugzilla.redhat.com/show_bug.cgi?id=2116562
There is a bug at latest nmstate with a fix that has not reach centos stream 8 yet


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Removing pending checkpoints before apply a state using rollback
```
