### PR TITLE
publish: Pin to ruby 3.1

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -25,7 +25,7 @@ push_knmstate_containers() {
 
 publish_docs() {
     # Update gh-pages branch with the generated documentation
-    ${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby make -C /docs install build
+    ${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ docker.io/library/ruby:3.1 make -C /docs install build
     rm -rf /tmp/gh-pages
     git clone --single-branch http://github.com/nmstate/kubernetes-nmstate -b gh-pages /tmp/gh-pages
     rsync -rt --links --cvs-exclude docs/build/kubernetes-nmstate/* /tmp/gh-pages


### PR DESCRIPTION
**What this PR does / why we need it**:
Publish has to follow the changes at https://github.com/nmstate/kubernetes-nmstate/pull/1135

```release-note
NONE
```
