### PR TITLE
Revert "handler: Temporaly use Gris repo"

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETAR
 ARG FROM=quay.io/centos/centos:stream8
 FROM ${FROM}
 
-ARG NMSTATE_SOURCE=user
+ARG NMSTATE_SOURCE=distro
 
 COPY --from=build /manager /usr/local/bin/manager
 COPY --from=build /workdir/build/install-nmstate.${NMSTATE_SOURCE}.sh install-nmstate.sh

--- a/build/install-nmstate.user.sh
+++ b/build/install-nmstate.user.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -xe
-
-curl "https://people.redhat.com/fge/bz_2158151/nmstate_hotfix.repo" -o /etc/yum.repos.d/nmstate_hotfix.repo
-
-dnf install -b -y -x "*alpha*" -x "*beta*" nmstate


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 007806b31b731e51c942587b9fc79f41fe8ffdc1.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove pin to centos8stream repo fix
```
