### PR TITLE
Use correct domain root-servers.net for DNS probes

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -210,7 +210,7 @@ func runDNS(_ client.Client) (bool, error) {
 				return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
 			},
 		}
-		_, err := r.LookupNS(context.TODO(), "root-server.net")
+		_, err := r.LookupNS(context.TODO(), "root-servers.net")
 		if err != nil {
 			errs = append(errs, err)
 		} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

Closes https://github.com/nmstate/kubernetes-nmstate/issues/1164

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
NONE

```release-note
NONE
```

----------------

Fix for https://issues.redhat.com/browse/OCPBUGS-11272

At time of this writing (both in OpenShift QE and from my laptop) we can see that root-server.net returns nothing:
~~~
[akaris@linux test]$ cat main.go
// You can edit this code!
// Click here and start typing.
package main

import (
"fmt"
"net"
)

func main() {
for _, i := range []string{"[www.google.com](http://www.google.com/)", "a.root-servers.net", "root-servers.net", "root-server.net"} {
ns, err := net.LookupNS(i)
fmt.Println(i, "ns", ns, "err", err)
}
}
[akaris@linux test]$ go run .
[www.google.com](http://www.google.com/) ns [] err lookup www.google.com on 127.0.0.53:53: no such host
a.root-servers.net ns [] err lookup a.root-servers.net on 127.0.0.53:53: no such host
root-servers.net ns [0xc000180200 0xc000180210 0xc000180230 0xc000180240 0xc000180250 0xc000180260 0xc000180270 0xc000180280 0xc000180290 0xc0001802a0 0xc0001802b0 0xc0001802c0 0xc0001802d0] err
root-server.net ns [] err lookup root-server.net on 127.0.0.53:53: no such host
[akaris@linux test]$
~~~

The correct domain is root-servers.net (plural) anyway: https://www.iana.org/domains/root/servers
