### PR TITLE
Don't deploy UI Plugin resources if the manifests are missing

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -147,7 +147,8 @@ func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx cont
 	}
 
 	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
-	if err == nil && isOpenShift {
+	_, errUIPluginPathExists := os.Stat(filepath.Join("openshift", "ui-plugin"))
+	if err == nil && isOpenShift && errUIPluginPathExists == nil {
 		if err = r.applyOpenshiftUIPlugin(instance); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed applying UI Plugin")
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
If for whatever reason the UI manifests does not exist in the operator's filesystem, we don't want the operator to deploy UI-related resources, resulting in an error log.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Don't deploy UI Plugin resources if the manifests are missing
```
