### PR TITLE
build: Add centos 9 stream bug workaround

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,8 @@ RUN mkdir /workdir
 COPY go.mod /workdir
 WORKDIR /workdir
 
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 
@@ -22,7 +23,8 @@ ARG NMSTATE_SOURCE=distro
 COPY --from=build /manager /usr/local/bin/manager
 COPY --from=build /workdir/build/install-nmstate.${NMSTATE_SOURCE}.sh install-nmstate.sh
 
-RUN ./install-nmstate.sh && \
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    ./install-nmstate.sh && \
     dnf install -b -y NetworkManager iproute iputils && \
     rm ./install-nmstate.sh && \
     dnf clean all

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -7,7 +7,8 @@ RUN mkdir /workdir
 COPY go.mod /workdir
 WORKDIR /workdir
 
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
 
 COPY . .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently there is a bug at centos 9 stream that prevent installing packages from a container, this change add a workaround for it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
