### PR TITLE
build: Install nmstate from c9s

### DIFF
--- a/build/install-nmstate.distro.sh
+++ b/build/install-nmstate.distro.sh
@@ -1,7 +1,3 @@
 #!/bin/bash -xe
 
-#dnf install -b -y -x "*alpha*" -x "*beta*" nmstate
-
-dnf install -b -y dnf-plugins-core
-dnf copr enable -y packit/nmstate-nmstate-2280
-dnf install -b -y nmstate
+dnf install -b -y -x "*alpha*" -x "*beta*" nmstate


### PR DESCRIPTION
**What this PR does / why we need it**:
Main branch was consuming nmstate from copr [#2280](https://github.com/nmstate/nmstate/pull/2280) to fix a bug. this change revert that to consume the delivered version at latest centos 9 stream.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
