### PR TITLE
cluster: Skip NM auto-profile for sec interfaces

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -19,6 +19,9 @@ for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); d
         	  ./cluster/cli.sh ssh $node -- sudo nmcli con del $uuid
 	      fi
     done
+    for nic in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do
+        nmcli con modify $nic match.interface-name "!$FIRST_SECONDARY_NIC, !$SECOND_SECONDARY_NIC";
+    done
 done
 
 echo 'Upgrading NetworkManager and enabling and starting up openvswitch'

--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -48,7 +48,7 @@ var (
 type Probe struct {
 	name      string
 	timeout   time.Duration
-	condition func(client.Client) wait.ConditionFunc
+	condition func(client.Client, time.Duration) wait.ConditionFunc
 }
 
 const (
@@ -85,7 +85,7 @@ func yamlToGJson(rawYaml string) (gjson.Result, error) {
 	return gjson.ParseBytes(json), nil
 }
 
-func apiServerCondition(_ client.Client) wait.ConditionFunc {
+func apiServerCondition(_ client.Client, _ time.Duration) wait.ConditionFunc {
 	return checkAPIServerConnectivity
 }
 
@@ -113,7 +113,7 @@ func checkAPIServerConnectivity() (bool, error) {
 	return true, nil
 }
 
-func nodeReadinessCondition(cli client.Client) wait.ConditionFunc {
+func nodeReadinessCondition(cli client.Client, _ time.Duration) wait.ConditionFunc {
 	return func() (bool, error) {
 		return checkNodeReadiness(cli)
 	}
@@ -162,7 +162,7 @@ func defaultGw(currentState gjson.Result) (string, error) {
 	return found.String(), nil
 }
 
-func pingCondition(cli client.Client) wait.ConditionFunc {
+func pingCondition(cli client.Client, timeout time.Duration) wait.ConditionFunc {
 	return func() (bool, error) {
 		return runPing(cli)
 	}
@@ -201,13 +201,13 @@ func ping(target string) (string, error) {
 	return output, nil
 }
 
-func dnsCondition(cli client.Client) wait.ConditionFunc {
+func dnsCondition(cli client.Client, timeout time.Duration) wait.ConditionFunc {
 	return func() (bool, error) {
-		return runDNS(cli)
+		return runDNS(cli, timeout)
 	}
 }
 
-func runDNS(_ client.Client) (bool, error) {
+func runDNS(_ client.Client, timeout time.Duration) (bool, error) {
 	runningServersGJsonPath := "dns-resolver.running.server"
 	errs := []error{}
 
@@ -229,10 +229,13 @@ func runDNS(_ client.Client) (bool, error) {
 				return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
 			},
 		}
-		_, err := r.LookupNS(context.TODO(), "root-servers.net")
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		_, err := r.LookupNS(ctx, "root-servers.net")
 		if err != nil {
+			cancel()
 			errs = append(errs, err)
 		} else {
+			cancel()
 			return true, nil
 		}
 	}
@@ -258,7 +261,7 @@ func Select(cli client.Client) []Probe {
 	}
 
 	for _, p := range externalConnectivityProbes {
-		err := wait.PollImmediate(time.Second, p.timeout, p.condition(cli))
+		err := wait.PollImmediate(time.Second, p.timeout, p.condition(cli, p.timeout))
 		if err == nil {
 			probes = append(probes, p)
 		} else {
@@ -291,7 +294,7 @@ func Run(cli client.Client, probes []Probe) error {
 
 	for _, p := range probes {
 		log.Info(fmt.Sprintf("Running '%s' probe", p.name))
-		err = wait.PollImmediate(time.Second, p.timeout, p.condition(cli))
+		err = wait.PollImmediate(time.Second, p.timeout, p.condition(cli, p.timeout))
 		if err != nil {
 			return errors.Wrapf(
 				err,

--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -67,6 +67,7 @@ interfaces:
   ipv6:
     auto-dns: false
     dhcp: true
+    autoconf: true
     enabled: true
 `, nic))
 }
@@ -89,12 +90,18 @@ interfaces:
   ipv6:
     auto-dns: false
     dhcp: true
+    autoconf: true
     enabled: true
 `, nic))
 }
 
 func discoverNameServers(nic string) nmstate.State {
-	return nmstate.NewState(fmt.Sprintf(`interfaces:
+	return nmstate.NewState(fmt.Sprintf(`
+dns-resolver:
+  config:
+    search: []
+    server: []
+interfaces:
 - name: %s
   type: ethernet
   state: up
@@ -105,6 +112,7 @@ func discoverNameServers(nic string) nmstate.State {
   ipv6:
     auto-dns: true
     dhcp: true
+    autoconf: true
     enabled: true
 `, nic))
 }

--- a/test/e2e/policy/conditions.go
+++ b/test/e2e/policy/conditions.go
@@ -135,6 +135,10 @@ func StatusForPolicyConsistently(policy string) AsyncAssertion {
 	}, 5*time.Second, 1*time.Second)
 }
 
+func StatusEventually() AsyncAssertion {
+	return StatusForPolicyEventually(TestPolicy)
+}
+
 func StatusConsistently() AsyncAssertion {
 	return StatusForPolicyConsistently(TestPolicy)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the eth2 interface comes up without explicitly saying so. This change copy the mechanism at openshift operator to prevent that [1].

[1] https://github.com/openshift/kubernetes-nmstate/blame/master/test/e2e/machineconfigs.yaml#L21


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
