### PR TITLE
e2e, handler: Don't put interfaces down

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -11,19 +11,6 @@ if [[ "$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$$ ]]; then \
 		while ! $(KUBECTL) get securitycontextconstraints; do sleep 1; done; \
 fi
 
-for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-    for nic in $FIRST_SECONDARY_NIC $SECOND_SECONDARY_NIC; do
-	      uuid=$(./cluster/cli.sh ssh $node -- nmcli --fields=device,uuid  c show  |grep $nic|awk '{print $2}')
-	      if [ ! -z "$uuid" ]; then
-        	  echo "$node: Flushing nic $nic"
-        	  ./cluster/cli.sh ssh $node -- sudo nmcli con del $uuid
-	      fi
-    done
-    for nic in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do
-        nmcli con modify $nic match.interface-name "!$FIRST_SECONDARY_NIC, !$SECOND_SECONDARY_NIC";
-    done
-done
-
 echo 'Upgrading NetworkManager and enabling and starting up openvswitch'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
     ./cluster/cli.sh ssh ${node} -- sudo dnf upgrade -y NetworkManager

--- a/test/e2e/handler/dns_test.go
+++ b/test/e2e/handler/dns_test.go
@@ -130,7 +130,11 @@ interfaces:
     dhcp: true
 - name: eth1
   type: ethernet
-  state: down
+  state: up
+  ipv4:
+    enabled: false
+  ipv6:
+    enabled: false
 `, dnsTestNicIP, dnsTestNic, dnsTestNic))
 }
 

--- a/test/e2e/handler/multiple_policies_for_same_node_test.go
+++ b/test/e2e/handler/multiple_policies_for_same_node_test.go
@@ -44,7 +44,7 @@ var _ = Describe("NodeNetworkState", func() {
 		})
 
 		AfterEach(func() {
-			setDesiredStateWithPolicy(staticIPPolicy, ifaceDownIPv4Disabled(firstSecondaryNic))
+			setDesiredStateWithPolicy(staticIPPolicy, ifaceIPDisabled(firstSecondaryNic))
 			policy.WaitForAvailablePolicy(staticIPPolicy)
 			setDesiredStateWithPolicy(vlanPolicy, vlanAbsent(firstSecondaryNic, vlanID))
 			policy.WaitForAvailablePolicy(vlanPolicy)

--- a/test/e2e/handler/simple_ovs_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_ovs_bridge_and_bond_test.go
@@ -147,7 +147,7 @@ var _ = Describe("OVS Bridge", func() {
 			BeforeEach(func() {
 				capture := map[string]string{
 					"ethernet-ifaces":  `interfaces.type=="ethernet"`,
-					"secondary-ifaces": `capture.ethernet-ifaces | interfaces.state=="down"`,
+					"secondary-ifaces": `capture.ethernet-ifaces | interfaces.ipv4.enabled==false`,
 				}
 				updateDesiredStateWithCaptureAndWait(
 					ovsBrUpLAGEth1AndEth2(
@@ -256,7 +256,7 @@ var _ = Describe("OVS Bridge", func() {
 				capture := map[string]string{
 					"first-secondary-iface": fmt.Sprintf(`interfaces.name=="%s"`, firstSecondaryNic),
 					"ethernet-ifaces":       `interfaces.type=="ethernet"`,
-					"secondary-ifaces":      `capture.ethernet-ifaces | interfaces.state=="down"`,
+					"secondary-ifaces":      `capture.ethernet-ifaces | interfaces.ipv4.enabled==false`,
 				}
 
 				macAddr = `"{{ capture.first-secondary-iface.interfaces.0.mac-address }}"`

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -222,12 +222,14 @@ func interfaceAbsent(iface string) nmstate.State {
 `, iface))
 }
 
-func ifaceDownIPv4Disabled(iface string) nmstate.State {
+func ifaceIPDisabled(iface string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
     - name: %s
       type: ethernet
-      state: down
+      state: up
       ipv4:
+        enabled: false
+      ipv6:
         enabled: false
 `, iface))
 }
@@ -253,14 +255,14 @@ func resetPrimaryAndSecondaryNICs() nmstate.State {
     state: up
   - name: %s
     type: ethernet
-    state: down
+    state: up
     ipv4:
       enabled: false
     ipv6:
       enabled: false
   - name: %s
+    state: up
     type: ethernet
-    state: down
     ipv4:
       enabled: false
     ipv6:

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -199,7 +199,7 @@ func updateDesiredStateWithCaptureAtNodeAndWait(node string, desiredState nmstat
 // TODO: After we implement policy delete (it will cleanUp desiredState) we have
 //       to remove this
 func resetDesiredStateForNodes() {
-	By("Resetting nics state primary up and secondaries down")
+	By("Resetting nics state primary up and secondaries disable ipv4 and ipv6")
 	updateDesiredState(resetPrimaryAndSecondaryNICs())
 	defer deletePolicy(TestPolicy)
 	policy.WaitForAvailableTestPolicy()


### PR DESCRIPTION
**What this PR does / why we need it**:
By default NetworkManager try to put interfaces up after reboot and users usually don't set interfaces down using nmstate. This change reset the tests doing ipv4/ipv6 enabled false instead of setting them down.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Don't put secondary interfaces down at e2e tests
```
