### PR TITLE
openshift, handler: remove plugin-ovsdb dep

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -9,7 +9,6 @@ RUN \
     microdnf -y update && \
     microdnf -y install \
         nmstate \
-        nmstate-plugin-ovsdb \
         iputils \
         iproute && \
     microdnf clean all


### PR DESCRIPTION
**What this PR does / why we need it**:
With nmstate 2 the nmstate-plugin-ovsdb is no longer needed and also instaling makes the container installing the python binding and and nmstate-libs.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove nmstate-plugin-ovsdb dep at openshift hander
```
