### PR TITLE
Enable ipv4 and ipv6 on primary nic when resetting

### DIFF
--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -253,6 +253,13 @@ func resetPrimaryAndSecondaryNICs() nmstate.State {
   - name: %s
     type: ethernet
     state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+    ipv6:
+      enabled: true
+      dhcp: true
+      autoconf: true
   - name: %s
     type: ethernet
     state: up


### PR DESCRIPTION
By default NMState disables ipv4 and ipv6 if they are not explicitly set to enabled. This can cause the reset policy to break network connectivity on nodes since the primary interface may lose all of its addresses. To avoid that, set both ipv4 and ipv6 to enabled with DHCP so we will always configure them with an address.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
