### PR TITLE
handler: Propertly filter unmanaged veth

### DIFF
--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -104,8 +104,7 @@ func filterOutInterfaces(ifacesState []interfaceState) []interfaceState {
 }
 
 func isVeth(ifaceData map[string]interface{}) bool {
-	_, ok := ifaceData["veth"]
-	return ok
+	return ifaceData["type"] == "veth"
 }
 
 func isUnmanaged(ifaceData map[string]interface{}) bool {

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -136,7 +136,7 @@ routes:
 			state = nmstate.NewState(`interfaces:
 - name: vethab6030bd
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 routes:
@@ -151,7 +151,7 @@ routes:
 			filteredState = nmstate.NewState(`interfaces:
 - name: vethab6030bd
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 routes:
@@ -177,7 +177,7 @@ routes:
 			state = nmstate.NewState(`interfaces:
 - name: vethab6030bd
   state: ignore
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 routes:
@@ -211,22 +211,22 @@ routes:
   type: ethernet
 - name: veth101
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 - name: veth102
   state: ignore
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 - name: vethjyuftrgv
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 - name: vethvasziovs
   state: ignore
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 routes:
@@ -264,12 +264,12 @@ routes:
   type: ethernet
 - name: veth101
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 - name: vethjyuftrgv
   state: down
-  type: ethernet
+  type: veth
   veth:
     peer: eth2
 routes:
@@ -334,47 +334,47 @@ dns-resolver:
   - name: eth0
     type: ethernet
   - name: '0'
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: '1101010'
-    type: ethernet
+    type: veth
     state: ignore
     veth:
       peer: eth2
   - name: '0.0'
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: '1.0'
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: '0xfe'
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: '60.e+02'
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: 10e+02
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: 70e+02
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore
   - name: 94475496822e234
-    type: ethernet
+    type: veth
     veth:
       peer: eth2
     state: ignore


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The number of veth interfaces not managed by NetworkManager at a k8s cluster is massive since they are all the network interfaces of containers running at the node and it pollute the NodeNetworkState without much use, to fix that there is a code that ignore those. At some envs the "veth" parth is not present since the peer is at different namespace so the detection logic was failing. This change goes back to use "type == veth" now that the veth type is no longer "ethernet".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix fitering out unmanaged veths
```
