### PR TITLE
build: Use ubi9 go-toolset to compile golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 PWD = $(shell pwd)
-GO_VERSION = $(shell hack/go-version.sh)
+export GO_VERSION = $(shell hack/go-version.sh)
 
 export IMAGE_REGISTRY ?= quay.io
 IMAGE_REPO ?= nmstate

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,26 +1,16 @@
-ARG FROM=quay.io/centos/centos:stream9
-FROM --platform=linux/amd64 ${FROM} AS build
-
-ARG TARGETARCH
-
-RUN mkdir /workdir
-
-COPY go.mod /workdir
-WORKDIR /workdir
-
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
+ARG GO_VERSION=1.18
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/handler
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/handler
 
-ARG FROM=quay.io/centos/centos:stream9
-FROM ${FROM}
+FROM quay.io/centos/centos:stream9
 
 ARG NMSTATE_SOURCE=distro
 
-COPY --from=build /manager /usr/local/bin/manager
-COPY --from=build /workdir/build/install-nmstate.${NMSTATE_SOURCE}.sh install-nmstate.sh
+COPY --from=build /opt/app-root/src/manager /usr/local/bin/manager
+COPY --from=build /opt/app-root/src/build/install-nmstate.${NMSTATE_SOURCE}.sh install-nmstate.sh
 
 RUN ./install-nmstate.sh && \
     dnf install -b -y iproute iputils && \

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,21 +1,13 @@
-FROM --platform=linux/amd64 quay.io/centos/centos:stream8 AS build
-
-ARG TARGETARCH
-
-RUN mkdir /workdir
-
-COPY go.mod /workdir
-WORKDIR /workdir
-
-RUN dnf install -y golang-$(sed -En 's/^go +(.*+)$/\1/p' go.mod).*
+ARG GO_VERSION=1.18
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux GOARCH=${TARGETARCH} go build -o /manager ./cmd/operator
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/operator
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-COPY --from=build /manager /usr/local/bin/manager
+COPY --from=build /opt/app-root/src/manager /usr/local/bin/manager
 
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/
 COPY deploy/handler/namespace.yaml /bindata/kubernetes-nmstate/namespace/


### PR DESCRIPTION
**What this PR does / why we need it**:
Using a centos container and download a golang compiler takes time and is more demanding for networking. This change use directly the ubi9 golang ready container to build handler and operator.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use ubi9 go-toolset to compile golang.
```
