### PR TITLE
openshift, operator: Copy ui-plugin to bindir

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -13,6 +13,7 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
+COPY deploy/openshift/ui-plugin/ /bindata/kubernetes-nmstate/openshift/ui-plugin/
 
 ENTRYPOINT ["manager"]
 

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -147,7 +147,8 @@ func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx cont
 	}
 
 	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
-	_, errUIPluginPathExists := os.Stat(filepath.Join("openshift", "ui-plugin"))
+
+	_, errUIPluginPathExists := os.Stat(filepath.Join(names.ManifestDir, "kubernetes-nmstate", "openshift", "ui-plugin"))
 	if err == nil && isOpenShift && errUIPluginPathExists == nil {
 		if err = r.applyOpenshiftUIPlugin(instance); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed applying UI Plugin")


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

Closes https://issues.redhat.com/browse/OCPBUGS-13096

**What this PR does / why we need it**:
The ui-plugin manifest were copy at the k8s operator Dockerfile but not at the openshift one.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add ui-plugin manifests to the openshift operator
```
