### PR TITLE
handler: Install nmstate from proper arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ INDEX_IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO)/kubernetes-nmstate-operator-index:$
 
 SKIP_IMAGE_BUILD ?= false
 
-all: check handler
+all: check handler operator
 
 check: lint vet whitespace-check gofmt-check
 

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -16,7 +16,6 @@ else
     echo "Gimme not installed using existing golang version $(go --version)"
 fi
 
-export ARCHS="amd64 arm64"
 export TMP_PROJECT_PATH=$tmp_dir/kubernetes-nmstate
 export E2E_LOGS=${TMP_PROJECT_PATH}/test_logs/e2e
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}

--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -10,6 +10,7 @@
 main() {
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
+    export ARCHS="amd64 arm64"
     make all
     make UNIT_TEST_ARGS="--output-dir=$ARTIFACTS --no-color --compilers=2" test/unit
 }

--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -12,6 +12,7 @@ image_registry=${IMAGE_REGISTRY:-quay.io}
 image_repo=${IMAGE_REPO:-nmstate}
 
 source automation/check-patch.setup.sh
+export ARCHS="amd64 arm64"
 cd ${TMP_PROJECT_PATH}
 
 push_knmstate_containers() {

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -10,6 +10,7 @@
 git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
 
 source automation/check-patch.setup.sh
+export ARCHS="amd64 arm64"
 cd ${TMP_PROJECT_PATH}
 make \
     IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}  \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
 ARG GO_VERSION=1.18
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/handler
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false go build -o manager ./cmd/handler
 
 FROM quay.io/centos/centos:stream9
 

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,9 +1,9 @@
 ARG GO_VERSION=1.18
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:${GO_VERSION} AS build
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/operator
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false go build -o manager ./cmd/operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/hack/build-push-container.docker.sh
+++ b/hack/build-push-container.docker.sh
@@ -10,6 +10,11 @@ fi
 hack/init-buildx.sh
 
 ARCHS=${ARCHS:-$(go env GOARCH)}
+
+if [ "${ARCHS}" != "$(go env GOARCH)" ]; then
+    hack/qemu-user-static.sh
+fi
+
 PLATFORM=""
 
 for arch in $ARCHS; do

--- a/hack/build-push-container.podman.sh
+++ b/hack/build-push-container.podman.sh
@@ -14,6 +14,10 @@ fi
 
 ARCHS=${ARCHS:-$(go env GOARCH)}
 
+if [ "${ARCHS}" != "$(go env GOARCH)" ]; then
+    hack/qemu-user-static.sh
+fi
+
 buildah rmi ${IMAGE} 2>/dev/null || true
 buildah manifest rm ${IMAGE} 2>/dev/null || true
 buildah manifest create ${IMAGE}

--- a/hack/qemu-user-static.sh
+++ b/hack/qemu-user-static.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -xe
+
+# If qemu-static has already been registered as a runner for foreign
+# binaries, for example by installing qemu-user and qemu-user-binfmt
+# packages on Fedora or by having already run this script earlier,
+# then we shouldn't alter the existing configuration to avoid the
+# risk of possibly breaking it
+if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
+    ${IMAGE_BUILDER} run --rm --privileged multiarch/qemu-user-static --reset -p yes
+fi


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

/kind bug
Closes https://github.com/nmstate/kubernetes-nmstate/issues/1178

**What this PR does / why we need it**:
The handler was installing a amd64 image, this change remove the optimization of forcing the platform at build stage to do crosscompiling so last stage is using the proper architecture, this way the rpm is installed from the proper arch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Propertly build images for non  amd64
```
