### PR TITLE
Generate events for NMState Handler failures

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -207,6 +207,7 @@ func setupHandlerControllers(mgr manager.Manager) error {
 		APIClient: apiClient,
 		Log:       ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationPolicy"),
 		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor(fmt.Sprintf("%s.nmstate-handler", environment.NodeName())),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create NodeNetworkConfigurationPolicy controller", "controller", "NMState")
 		return err

--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -128,3 +128,16 @@ rules:
   verbs:
   - use
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-handler-events
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - 'create'

--- a/deploy/handler/role_binding.yaml
+++ b/deploy/handler/role_binding.yaml
@@ -27,3 +27,18 @@ roleRef:
   kind: ClusterRole
   name: {{template "handlerPrefix" .}}nmstate-handler
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-handler-events
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: {{template "handlerPrefix" .}}nmstate-handler
+  namespace: {{ .HandlerNamespace }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{template "handlerPrefix" .}}nmstate-handler-events
+  namespace: default

--- a/docs/user-guide/103-troubleshooting.md
+++ b/docs/user-guide/103-troubleshooting.md
@@ -11,7 +11,8 @@ the operator protect the user from breaking the cluster networking.
 ## Invalid configuration
 
 If any of the following cases render the configuration faulty, the setup will be
-automatically rolled back and Enactment will report the failure.
+automatically rolled back and Enactment will report the failure. In addition,
+an event for the NodeNetworkConfigurationPolicy will be created.
 
 * Configuration fails to be applied on the host (due to missing interfaces, inability to obtain IP, invalid attributes, ...)
 * Connectivity to the default gateway is broken
@@ -108,6 +109,28 @@ the `ERROR` log line:
 
 ```
 Connection activation failed on connection_id eth666: error=nm-manager-error-quark: No suitable device found for this connection
+```
+
+In addition, events are generated in the default namespace:
+```shell
+$ kubectl get events | grep Warning
+6m55s       Warning   ReconcileFailed           nodenetworkconfigurationpolicy/eth666   error reconciling NodeNetworkConfigurationPolicy on node node02 at desired state apply: "",...
+```
+
+And these events are also linked to the NodeNetworkConfigurationPolicy when using `kubectl describe`:
+```shell
+kubectl describe nodenetworkconfigurationpolicies.nmstate.io eth666
+```
+
+```
+# output truncated
+Events:
+  Type     Reason           Age    From                    Message
+  ----     ------           ----   ----                    -------
+  Warning  ReconcileFailed  8m25s  node02.nmstate-handler  error reconciling NodeNetworkConfigurationPolicy on node node02 at desired state apply: "",
+(...)
+NmstateError: InvalidArgument: Ethernet interface eth666 does not exists
+'
 ```
 
 The configuration therefore failed due to absence of NIC `eth666` on the node.


### PR DESCRIPTION
On top of reporting status via nodenetworkconfigurationenactments, also generate events for failures. These events directly show up in the output of `kubectl describe nodenetworkconfigurationpolicies` and thus provide a standardized way for administrators to understand why a reconciliation failed.

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:

Administrators might not know that they can check their node's status with the nodenetworkconfigurationenactments resource. It's also a non-standard way of reporting the failure of a resource.

**Special notes for your reviewer**:

Consider this a suggestion / brainstorming for how issues with reconciling resources are reported to the users. Would it make sense to use events? If so, should they contain the full error message, or refer to the enactment resource?
I personally really didn't know about the enactment resource until I started working on this PR, and I guess it might be the same for other people using kubernetes-nmstate. Reporting reconciliation issues through the enactment resource seems a bit non-standard to me, and the nodenetworkconfigurationpolicy atm only reports:
~~~
Message:                           x/y nodes failed to configure
~~~

With this change, we'd get something like this:
~~~
$ oc describe nodenetworkconfigurationpolicies
Name:         vlan
Namespace:    
Labels:       <none>
Annotations:  nmstate.io/webhook-mutating-timestamp: 1685383832230481361
API Version:  nmstate.io/v1
Kind:         NodeNetworkConfigurationPolicy
Metadata:
  Creation Timestamp:  2023-05-29T18:10:32Z
  Generation:          1
  Managed Fields:
    API Version:  nmstate.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:desiredState:
          .:
          f:interfaces:
    Manager:      kubectl-client-side-apply
    Operation:    Update
    Time:         2023-05-29T18:10:32Z
    API Version:  nmstate.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:conditions:
        f:lastUnavailableNodeCountUpdate:
    Manager:         manager
    Operation:       Update
    Subresource:     status
    Time:            2023-05-29T18:12:39Z
  Resource Version:  19056
  UID:               f0df04cb-773e-4b45-8ff5-8341a6db4dbb
Spec:
  Desired State:
    Interfaces:
      ipv4:
        Dhcp:     true
        Enabled:  true
      Name:       eth3.102
      State:      up
      Type:       vlan
      Vlan:
        Base - Iface:  eth3
        Id:            102
Status:
  Conditions:
    Last Heartbeat Time:               2023-05-29T18:12:39Z
    Last Transition Time:              2023-05-29T18:12:39Z
    Reason:                            FailedToConfigure
    Status:                            False
    Type:                              Available
    Last Heartbeat Time:               2023-05-29T18:12:39Z
    Last Transition Time:              2023-05-29T18:12:39Z
    Message:                           1/1 nodes failed to configure
    Reason:                            FailedToConfigure
    Status:                            True
    Type:                              Degraded
    Last Heartbeat Time:               2023-05-29T18:12:39Z
    Last Transition Time:              2023-05-29T18:12:39Z
    Reason:                            ConfigurationProgressing
    Status:                            False
    Type:                              Progressing
  Last Unavailable Node Count Update:  2023-05-29T18:12:39Z
Events:
  Type     Reason           Age    From                    Message
  ----     ------           ----   ----                    -------
  Warning  ReconcileFailed  2m14s  node02.nmstate-handler  error reconciling NodeNetworkConfigurationPolicy on node node02 at desired state apply: "",
 failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' '' 'Using 'set' is deprecated, use 'apply' instead.
[2023-05-29T18:10:32Z INFO  nmstate::nispor::base_iface] Got unsupported interface type Other("IpTun"): tunl0, ignoring
[2023-05-29T18:10:32Z INFO  nmstate::nispor::show] Got unsupported interface tunl0 type Other("IpTun")
[2023-05-29T18:10:32Z INFO  nmstate::nm::show] Got unsupported interface type ip-tunnel: tunl0, ignoring
[2023-05-29T18:10:32Z INFO  nmstate::query_apply::net_state] Created checkpoint /org/freedesktop/NetworkManager/Checkpoint/8
[2023-05-29T18:10:32Z INFO  nmstate::ifaces::inter_ifaces] Ignoring interface cali48c2ba6b6dd type ethernet
[2023-05-29T18:10:32Z INFO  nmstate::nm::query_apply::profile] Creating connection UUID Some("f86eb1bb-198a-4c31-8a27-064e5b10e987"), ID Some("eth3.102"), type Some("vlan") name Some("eth3.102")
[2023-05-29T18:10:33Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:10:33Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:10:33Z INFO  nmstate::nm::query_apply::profile] Will retry activation 2 seconds
[2023-05-29T18:10:35Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:10:35Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:10:35Z INFO  nmstate::nm::query_apply::profile] Will retry activation 4 seconds
[2023-05-29T18:10:39Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:10:39Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:10:39Z INFO  nmstate::nm::query_apply::profile] Will retry activation 8 seconds
[2023-05-29T18:10:47Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:10:47Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:10:47Z INFO  nmstate::nm::query_apply::profile] Will retry activation 16 seconds
[2023-05-29T18:11:03Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:03Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:03Z INFO  nmstate::nm::query_apply::profile] Will retry activation 32 seconds
[2023-05-29T18:11:35Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:35Z INFO  nmstate::query_apply::net_state] Retrying on: Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:37Z INFO  nmstate::nm::query_apply::profile] Modifying connection UUID Some("f86eb1bb-198a-4c31-8a27-064e5b10e987"), ID Some("eth3.102"), type Some("vlan") name Some("eth3.102")
[2023-05-29T18:11:37Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:37Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:37Z INFO  nmstate::nm::query_apply::profile] Will retry activation 2 seconds
[2023-05-29T18:11:39Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:39Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:39Z INFO  nmstate::nm::query_apply::profile] Will retry activation 4 seconds
[2023-05-29T18:11:43Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:43Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:43Z INFO  nmstate::nm::query_apply::profile] Will retry activation 8 seconds
[2023-05-29T18:11:51Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:11:51Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:11:51Z INFO  nmstate::nm::query_apply::profile] Will retry activation 16 seconds
[2023-05-29T18:12:07Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:12:07Z INFO  nmstate::nm::query_apply::profile] Got activation failure Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
[2023-05-29T18:12:07Z INFO  nmstate::nm::query_apply::profile] Will retry activation 32 seconds
[2023-05-29T18:12:39Z INFO  nmstate::nm::query_apply::profile] Activating connection f86eb1bb-198a-4c31-8a27-064e5b10e987: eth3.102/vlan
[2023-05-29T18:12:39Z INFO  nmstate::query_apply::net_state] Rollbacked to checkpoint /org/freedesktop/NetworkManager/Checkpoint/8
NmstateError: Bug: Manager(UnknownDevice): Failed to find a compatible device for this connection
'
~~~
> Note: I wonder if that's too much text, especially when someone updates a configurationpolicy

~~~
$ oc get events
9m42s       Warning   ReconcileFailed   nodenetworkconfigurationpolicy/vlan   error reconciling NodeNetworkConfigurationPolicy on node node02 at desired state apply: "",...
~~~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
generate events for NMState Handler failures 
```
