### PR TITLE
deps: Bump nmpolicy to have inequality operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gofrs/flock v0.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
-	github.com/nmstate/nmpolicy v0.5.0
+	github.com/nmstate/nmpolicy v0.6.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20220722144142-ac5cee47c2a0

--- a/go.sum
+++ b/go.sum
@@ -821,8 +821,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nmstate/nmpolicy v0.5.0 h1:xrioHeIq+oSOzJIaYNK/rWEJb9qWwGYeWOF30/DTvPM=
-github.com/nmstate/nmpolicy v0.5.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
+github.com/nmstate/nmpolicy v0.6.0 h1:6qtm0lHjXAFh2fnTy38o7Fssbv8Ya/5/K1WT2YW5jb0=
+github.com/nmstate/nmpolicy v0.6.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/v1alpha1/nodenetworkconfigurationenactment_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/v1alpha1/nodenetworkconfigurationenactment_types.go
@@ -39,6 +39,8 @@ type NodeNetworkConfigurationEnactmentList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nodenetworkconfigurationenactments,shortName=nnce,scope=Cluster
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.status==\"True\")].type",description="Status"
+//nolint:lll
+// +kubebuilder:printcolumn:name="Status Age",type="date",JSONPath=".status.conditions[?(@.status==\"True\")].lastTransitionTime",description="Status Age"
 // +kubebuilder:deprecatedversion
 
 // NodeNetworkConfigurationEnactment is the Schema for the nodenetworkconfigurationenactments API

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/v1beta1/nodenetworkconfigurationenactment_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/v1beta1/nodenetworkconfigurationenactment_types.go
@@ -40,6 +40,8 @@ type NodeNetworkConfigurationEnactmentList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=nodenetworkconfigurationenactments,shortName=nnce,scope=Cluster
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.status==\"True\")].type",description="Status"
+//nolint:lll
+// +kubebuilder:printcolumn:name="Status Age",type="date",JSONPath=".status.conditions[?(@.status==\"True\")].lastTransitionTime",description="Status Age"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.status==\"True\")].reason",description="Reason"
 // +kubebuilder:pruning:PreserveUnknownFields
 // +kubebuilder:storageversion

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
@@ -34,6 +34,7 @@ type Terminal struct {
 type Node struct {
 	Meta
 	EqFilter *TernaryOperator  `json:"eqfilter,omitempty"`
+	NeFilter *TernaryOperator  `json:"nefilter,omitempty"`
 	Replace  *TernaryOperator  `json:"replace,omitempty"`
 	Path     *VariadicOperator `json:"path,omitempty"`
 	Terminal
@@ -42,6 +43,9 @@ type Node struct {
 func (n Node) String() string {
 	if n.EqFilter != nil {
 		return fmt.Sprintf("EqFilter(%s)", *n.EqFilter)
+	}
+	if n.NeFilter != nil {
+		return fmt.Sprintf("NeFilter(%s)", *n.NeFilter)
 	}
 	if n.Replace != nil {
 		return fmt.Sprintf("Replace(%s)", *n.Replace)

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/lexer.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/lexer.go
@@ -102,6 +102,8 @@ func (l *lexer) lexCurrentRune() (*Token, error) {
 		return l.lexEqualAs(REPLACE)
 	} else if l.isEqual() {
 		return l.lexEqualAs(EQFILTER)
+	} else if l.isExclamationMark() {
+		return l.lexEqualAs(NEFILTER)
 	} else if l.isPlus() {
 		return &Token{l.scn.Position(), MERGE, string(l.scn.Rune())}, nil
 	} else if l.isPipe() {

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
@@ -63,6 +63,10 @@ func (l *lexer) isPipe() bool {
 	return l.scn.Rune() == '|'
 }
 
+func (l *lexer) isExclamationMark() bool {
+	return l.scn.Rune() == '!'
+}
+
 func (l *lexer) isDelimiter() bool {
-	return l.isEOF() || l.isSpace() || l.isDot() || l.isEqual() || l.isColon() || l.isPlus() || l.isPipe()
+	return l.isEOF() || l.isSpace() || l.isDot() || l.isEqual() || l.isColon() || l.isPlus() || l.isPipe() || l.isExclamationMark()
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
@@ -31,6 +31,7 @@ const (
 	PIPE     // |
 	REPLACE  // :=
 	EQFILTER // ==
+	NEFILTER // !=
 	MERGE    // +
 	operatorsEnd
 )
@@ -47,6 +48,7 @@ var tokens = []string{
 
 	REPLACE:  "REPLACE",
 	EQFILTER: "EQFILTER",
+	NEFILTER: "NEFILTER",
 	MERGE:    "MERGE",
 }
 

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/errors.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/errors.go
@@ -65,6 +65,13 @@ func wrapWithInvalidEqualityFilterError(err error) *parserError {
 	}
 }
 
+func wrapWithInvalidInequalityFilterError(err error) *parserError {
+	return &parserError{
+		prefix: "invalid inequality filter",
+		inner:  err,
+	}
+}
+
 func wrapWithInvalidReplaceError(err error) *parserError {
 	return &parserError{
 		prefix: "invalid replace",

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/parser.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/parser/parser.go
@@ -78,6 +78,10 @@ func (p *parser) parse() (ast.Node, error) {
 			if err := p.parseEqFilter(); err != nil {
 				return ast.Node{}, err
 			}
+		} else if p.currentToken().Type == lexer.NEFILTER {
+			if err := p.parseNeFilter(); err != nil {
+				return ast.Node{}, err
+			}
 		} else if p.currentToken().Type == lexer.REPLACE {
 			if err := p.parseReplace(); err != nil {
 				return ast.Node{}, err
@@ -222,6 +226,18 @@ func (p *parser) parseEqFilter() error {
 	}
 	if err := p.fillInTernaryOperator(operator.EqFilter); err != nil {
 		return wrapWithInvalidEqualityFilterError(err)
+	}
+	p.lastNode = operator
+	return nil
+}
+
+func (p *parser) parseNeFilter() error {
+	operator := &ast.Node{
+		Meta:     ast.Meta{Position: p.currentToken().Position},
+		NeFilter: &ast.TernaryOperator{},
+	}
+	if err := p.fillInTernaryOperator(operator.NeFilter); err != nil {
+		return wrapWithInvalidInequalityFilterError(err)
 	}
 	p.lastNode = operator
 	return nil

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/errors.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/errors.go
@@ -51,6 +51,10 @@ func wrapWithEqFilterError(err error) error {
 	return fmt.Errorf("eqfilter error: %w", err)
 }
 
+func wrapWithNeFilterError(err error) error {
+	return fmt.Errorf("nefilter error: %w", err)
+}
+
 func replaceError(format string, a ...interface{}) error {
 	return wrapWithReplaceError(fmt.Errorf(format, a...))
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
@@ -114,6 +114,8 @@ func (r *resolver) resolveCaptureEntryName(captureEntryName string) (types.NMSta
 func (r *resolver) resolveCaptureASTEntry() (types.NMState, error) {
 	if r.currentNode.EqFilter != nil {
 		return r.resolveEqFilter()
+	} else if r.currentNode.NeFilter != nil {
+		return r.resolveNeFilter()
 	} else if r.currentNode.Replace != nil {
 		return r.resolveReplace()
 	} else if r.currentNode.Path != nil {
@@ -124,9 +126,18 @@ func (r *resolver) resolveCaptureASTEntry() (types.NMState, error) {
 
 func (r *resolver) resolveEqFilter() (types.NMState, error) {
 	operator := r.currentNode.EqFilter
-	filteredState, err := r.resolveTernaryOperator(operator, filter)
+	filteredState, err := r.resolveTernaryOperator(operator, eqfilter)
 	if err != nil {
 		return nil, wrapWithEqFilterError(err)
+	}
+	return filteredState, nil
+}
+
+func (r *resolver) resolveNeFilter() (types.NMState, error) {
+	operator := r.currentNode.NeFilter
+	filteredState, err := r.resolveTernaryOperator(operator, nefilter)
+	if err != nil {
+		return nil, wrapWithNeFilterError(err)
 	}
 	return filteredState, nil
 }
@@ -141,7 +152,7 @@ func (r *resolver) resolveReplace() (types.NMState, error) {
 }
 
 func (r *resolver) resolvePathFilter() (types.NMState, error) {
-	return filter(r.currentState, *r.currentNode.Path, nil)
+	return eqfilter(r.currentState, *r.currentNode.Path, nil)
 }
 
 func (r *resolver) resolveTernaryOperator(operator *ast.TernaryOperator,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
-# github.com/nmstate/nmpolicy v0.5.0
+# github.com/nmstate/nmpolicy v0.6.0
 ## explicit; go 1.17
 github.com/nmstate/nmpolicy/nmpolicy
 github.com/nmstate/nmpolicy/nmpolicy/internal


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:
Latest nmpolicy v0.6.0 implements != operator needed for some scenarios where we want to check interfaces that are not part of a specific "controller".

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Learn inequality "!=" operator at capture
```
