### PR TITLE
e2e, operator: Use env var for nmstate

### DIFF
--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -42,7 +42,7 @@ var (
 	nodes            []string
 	knmstateReporter *knmstatereporter.KubernetesNMStateReporter
 	manifestFiles    = []string{"namespace.yaml", "service_account.yaml", "operator.yaml", "role.yaml", "role_binding.yaml"}
-	defaultOperator  = NewOperatorTestData("nmstate", manifestsDir, manifestFiles)
+	defaultOperator  = NewOperatorTestData(os.Getenv("HANDLER_NAMESPACE"), manifestsDir, manifestFiles)
 )
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -20,6 +20,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -107,7 +108,7 @@ var _ = Describe("NMState operator", func() {
 		})
 		Context("and another handler is installed with different namespace", func() {
 			var (
-				altOperator = NewOperatorTestData("nmstate-alt", manifestsDir, manifestFiles)
+				altOperator = NewOperatorTestData(os.Getenv("HANDLER_NAMESPACE")+"-alt", manifestsDir, manifestFiles)
 			)
 			BeforeEach(func() {
 				By("Wait for operand to be ready")


### PR DESCRIPTION
**What this PR does / why we need it**:
Read operator tests namespace from env var.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
