### PR TITLE
poc: statistics

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -170,6 +170,16 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - nmstate.io
           resources:
           - '*'

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -1,5 +1,7 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.26-centos9'}
 export KUBEVIRTCI_TAG=2303201102-ef46217
+export KUBEVIRT_DEPLOY_PROMETHEUS=true
+export KUBEVIRT_DEPLOY_GRAFANA=true
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -70,6 +70,7 @@ type NMStateReconciler struct {
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list;get
 // +kubebuilder:rbac:groups="console.openshift.io",resources=consoleplugins,verbs="*"
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;get;watch;update
+// +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=list;get;watch;update;create
 
 func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/deploy/handler/cluster_role.yaml
+++ b/deploy/handler/cluster_role.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 - apiGroups:
   - nmstate.io
   resources:

--- a/deploy/handler/namespace.yaml
+++ b/deploy/handler/namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
+    openshift.io/cluster-monitoring: "true"

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -1,4 +1,4 @@
-{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "s-"}}{{end -}}{{end}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -185,6 +185,7 @@ metadata:
   labels:
     app: kubernetes-nmstate
     component: kubernetes-nmstate-handler
+    prometheus.nmstate.io: "true"
 spec:
   selector:
     matchLabels:
@@ -192,13 +193,14 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      maxUnavailable: 10
   template:
     metadata:
       labels:
         app: kubernetes-nmstate
         component: kubernetes-nmstate-handler
         name: {{template "handlerPrefix" .}}nmstate-handler
+        prometheus.nmstate.io: "true"
       annotations:
         description: kubernetes-nmstate-handler configures and presents node networking, reconciling declerative NNCP and reports with NNS and NNCE
     spec:
@@ -215,6 +217,27 @@ spec:
       affinity: {{ toYaml .HandlerAffinity | nindent 8 }}
       priorityClassName: system-node-critical
       containers:
+        - args:
+          - --logtostderr
+          - --secure-listen-address=:8443
+          - --upstream=http://127.0.0.1:8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          ports:
+          - containerPort: 8443
+            name: metrics
+            protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: nmstate-handler
           args:
           - --zap-time-encoding=iso8601
@@ -306,6 +329,24 @@ spec:
   selector:
     name: {{template "handlerPrefix" .}}nmstate-webhook
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-monitor
+  namespace: {{ .HandlerNamespace }}
+  labels:
+    prometheus.nmstate.io: "true"
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    prometheus.nmstate.io: "true"
+  sessionAffinity: None
+  type: ClusterIP
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -389,3 +430,27 @@ spec:
   selector:
     matchLabels:
       name: {{template "handlerPrefix" .}}nmstate-webhook
+---
+apiVersion: monitoring.coreos.com/v1                                            
+kind: ServiceMonitor                                                            
+metadata:                                                                       
+  labels:                                                                       
+    openshift.io/cluster-monitoring: ""
+    prometheus.nmstate.io: "true"
+  name: controller-manager-metrics-monitor                                      
+  namespace: {{ .HandlerNamespace }}
+spec:                                                                           
+  endpoints:                                                                    
+  - scheme: https                                                             
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token      
+    tlsConfig:                                                                
+      insecureSkipVerify: true    
+    relabelings:
+    - action: labeldrop
+      regex: (instance|pod|container|job|namespace|service)
+  namespaceSelector:
+    matchNames:
+      - {{ .HandlerNamespace }}
+  selector:                                                                     
+    matchLabels: 
+      prometheus.nmstate.io: "true"

--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -51,13 +51,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
   - apps
   resourceNames:
   - nmstate-handler
@@ -73,6 +66,23 @@ rules:
   - get
   - create
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-monitor
+  namespace: {{ .HandlerNamespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -118,6 +128,18 @@ rules:
   - configmaps
   verbs:
   - "*"
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 {{- if .IsOpenShift }}
 - apiGroups:
   - security.openshift.io

--- a/deploy/handler/role_binding.yaml
+++ b/deploy/handler/role_binding.yaml
@@ -42,3 +42,17 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: {{template "handlerPrefix" .}}nmstate-handler-events
   namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-monitor
+  namespace: {{ .HandlerNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{template "handlerPrefix" .}}nmstate-monitor
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: {{template "handlerPrefix" .}}monitoring

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -60,6 +60,16 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - nmstate.io
   resources:
   - '*'

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
-	github.com/prometheus/client_golang v1.16.0 // indirect
+	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ApplyTopologyTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "nmstate_apply_topology_total",
+		},
+		[]string{"name"},
+	)
+
+	ApplyFeaturesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "nmstate_apply_features_total",
+		},
+		[]string{"name"},
+	)
+)

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 )
@@ -93,4 +94,25 @@ func Rollback() error {
 		return errors.Wrapf(err, "failed calling nmstatectl rollback")
 	}
 	return nil
+}
+
+type Stats struct {
+	Topology []string `json:"topology"`
+	Features []string `json:"features"`
+}
+
+func Statistic(desiredState nmstate.State) (*Stats, error) {
+	statsOutput, err := nmstatectlWithInput(
+		[]string{"st", "-"},
+		string(desiredState.Raw),
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed calling nmstatectl statistics")
+	}
+	stats := Stats{}
+	err = yaml.Unmarshal([]byte(statsOutput), &stats)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshaling nmstatectl statistics")
+	}
+	return &stats, nil
 }


### PR DESCRIPTION
TODO:
- Just count once per nncp apply (don't know at each node in a cluster)
- Use NNCP status to state if it has already being counted or not, if the NNCP get updated the condition is removed.
- Modify ServiceMonitor to remove pod name and the like
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: my-service-monitor
  namespace: my-namespace
spec:
  selector:
    matchLabels:
      app: my-service
  endpoints:
  - port: metrics
    interval: 30s
    relabelings:
    - sourceLabels: [job]
      action: labeldrop
```

Current counter output example 
```
nmstate_apply_topology_total{container="kube-rbac-proxy", instance="192.168.66.102:8443", job="nmstate-monitor", name="auto_ip4 -> linux-bridge -> ethernet", namespace="nmstate", pod="nmstate-handler-cgnhw", service="nmstate-monitor"}
1
nmstate_apply_topology_total{container="kube-rbac-proxy", instance="192.168.66.102:8443", job="nmstate-monitor", name="ethernet", namespace="nmstate", pod="nmstate-handler-cgnhw", service="nmstate-monitor"}
1
```

Possible query to get top 10 
```
topk(10, sum(nmstate_apply_topology_total) by (name))
```

Looks like we cannot drop "instance"