### PR TITLE
webhook: disable HTTP2 to avoid CVE-2023-39325

### DIFF
--- a/pkg/webhook/nodenetworkconfigurationpolicy/server.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/server.go
@@ -18,6 +18,8 @@ limitations under the License.
 package nodenetworkconfigurationpolicy
 
 import (
+	"crypto/tls"
+
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -31,12 +33,19 @@ func Add(mgr manager.Manager) error {
 	// 1.- User changes nncp desiredState so it triggers deleteConditionsHook()
 	// 2.- Since we have deleted the condition the status-mutate webhook is called and
 	//     there we set conditions to Unknown. This final result will be updated.
-	server := &webhook.Server{}
+	server := webhook.Server{
+		// Disable HTTP2 to avoid CVE-2023-39325
+		TLSOpts: []func(config *tls.Config){
+			func(c *tls.Config) {
+				c.NextProtos = []string{"http/1.1"}
+			},
+		},
+	}
 	server.Register("/readyz", healthz.CheckHandler{Checker: healthz.Ping})
 	server.Register("/nodenetworkconfigurationpolicies-mutate", deleteConditionsHook())
 	server.Register("/nodenetworkconfigurationpolicies-status-mutate", setConditionsUnknownHook())
 	server.Register("/nodenetworkconfigurationpolicies-timestamp-mutate", setTimestampAnnotationHook())
 	server.Register("/nodenetworkconfigurationpolicies-update-validate", validatePolicyUpdateHook(mgr.GetClient()))
 	server.Register("/nodenetworkconfigurationpolicies-create-validate", validatePolicyCreateHook(mgr.GetClient()))
-	return mgr.Add(server)
+	return mgr.Add(&server)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:


/kind bug


**What this PR does / why we need it**:

Disable HTTP/2 in the webhook server to avoid CVE-2023-39325

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Disable HTTP/2 in the webhook server to avoid CVE-2023-39325
```
