### PR TITLE
test: use IPv6 link-local DNS server

### DIFF
--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -77,10 +77,10 @@ func setBadNameServers(nic string) nmstate.State {
   config:
     search: []
     server:
-      - 192.168.100.3
-      - 192.168.100.4
+      - "fe80::deef:1%%%[1]s"
+      - "fe80::deef:2%%%[1]s"
 interfaces:
-- name: %s
+- name: %[1]s
   type: ethernet
   state: up
   ipv4:


### PR DESCRIPTION
This PR changes the test scenario for configuring an incorrect DNS server. Instead of using a fixed `192.x.x.x` name server we are now using an IPv6 link-local address `fe80::deef:1` parametrized with a NIC name.

The reason for this change is the bug in NetworkManager that prevents rollbacks of incorrect DNS servers applied globally, i.e. not on a specific NIC. As this test explicitly tests the rollback functionality, we want it to explicitly configure a specific NIC and not a global configuration.

By using IPv6 link-local address we are ensure the configuration is applied to the NIC specified, what fulfills the requitement of our test.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
