### PR TITLE
Log setup steps when starting handler

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -124,6 +124,7 @@ func mainHandler() int {
 	if environment.IsHandler() {
 		cacheResourcesOnNodes(&ctrlOptions)
 	}
+	setupLog.Info("Creating manager")
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrlOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -188,6 +189,7 @@ func cacheResourcesOnNodes(ctrlOptions *ctrl.Options) {
 }
 
 func setupHandlerControllers(mgr manager.Manager) error {
+	setupLog.Info("Creating Node controller")
 	if err := (&controllers.NodeReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Node"),
@@ -197,12 +199,14 @@ func setupHandlerControllers(mgr manager.Manager) error {
 		return err
 	}
 
+	setupLog.Info("Creating non cached client")
 	apiClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
 	if err != nil {
 		setupLog.Error(err, "failed creating non cached client")
 		return err
 	}
 
+	setupLog.Info("Creating NodeNetworkConfigurationPolicy controller")
 	if err = (&controllers.NodeNetworkConfigurationPolicyReconciler{
 		Client:    mgr.GetClient(),
 		APIClient: apiClient,
@@ -214,6 +218,7 @@ func setupHandlerControllers(mgr manager.Manager) error {
 		return err
 	}
 
+	setupLog.Info("Creating NodeNetworkConfigurationEnactment controller")
 	if err = (&controllers.NodeNetworkConfigurationEnactmentReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationEnactment"),
@@ -242,6 +247,7 @@ func createHealthyFile() error {
 }
 
 func checkNmstateIsWorking() error {
+	setupLog.Info("Checking availability of nmstatectl")
 	_, err := nmstatectl.Show()
 	if err != nil {
 		setupLog.Error(err, "failed checking nmstatectl health")
@@ -287,6 +293,7 @@ func retrieveCertAndCAIntervals() (certificate.Options, error) {
 }
 
 func setupCertManager(mgr manager.Manager, certManagerOpts certificate.Options) error {
+	setupLog.Info("Creating cert-manager")
 	certManager, err := certificate.NewManager(mgr.GetClient(), &certManagerOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to create cert-manager", "controller", "cert-manager")


### PR DESCRIPTION
We have observed that under specific conditions starting handler may hang indefinitely. In order to help debugging those issues, we are adding some logging to report steps happening when handler starts. Thanks to this, whenever a process hands, we will see which component is not responding.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
