### PR TITLE
lint: Use binary golangci-lint

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -xe
-golangci_lint_version=v1.55.2
-GOFLAGS=-mod=mod go run github.com/golangci/golangci-lint/cmd/golangci-lint@$golangci_lint_version run --timeout 20m0s
+golangci_lint_version=1.55.2
+golangci_lint_url=https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz
+golangci_cmd=/tmp/golangci-lint-${golangci_lint_version}-linux-amd64/golangci-lint
+if [ ! -f "${golangci_cmd}" ]; then
+    curl -Lk $golangci_lint_url -o /tmp/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz
+    tar -xvzf /tmp/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz -C /tmp
+    chmod 755 ${golangci_cmd}
+fi
+${golangci_cmd} run --timeout 20m0s
 (
 	cd api
-	GOFLAGS=-mod=mod go run github.com/golangci/golangci-lint/cmd/golangci-lint@$golangci_lint_version run --timeout 20m0s --config ../.golangci.yml
+	${golangci_cmd} run --timeout 20m0s --config ../.golangci.yml
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
There are some problems at the current golangci-lint version that can only be fixed bumping to new version that depends on new golang.

This change use directly the linter binary instead of "go run" so we don't have the deps problems.

```release-note
NONE
```
