### PR TITLE
metrics: change port used by metrics server

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -129,7 +129,7 @@ func mainHandler() int {
 	}
 	ctrlOptions := ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: metrics.DefaultBindAddress, // Explicitly enable metrics
+		MetricsBindAddress: ":8089", // Explicitly enable metrics
 	}
 
 	if environment.IsHandler() {

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -73,7 +73,7 @@ spec:
         - args:
           - --logtostderr
           - --secure-listen-address=:8443
-          - --upstream=http://127.0.0.1:8080
+          - --upstream=http://127.0.0.1:8089
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/test/e2e/handler/metrics.go
+++ b/test/e2e/handler/metrics.go
@@ -20,8 +20,6 @@ package handler
 import (
 	"strings"
 
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/runner"
 )
@@ -29,7 +27,7 @@ import (
 func getMetrics(token string) map[string]string {
 	bearer := "Authorization: Bearer " + token
 	return indexMetrics(runner.RunAtMetricsPod("curl", "-s", "-k", "--header",
-		bearer, metrics.DefaultBindAddress, "https://127.0.0.1:8443/metrics"))
+		bearer, ":8089", "https://127.0.0.1:8443/metrics"))
 }
 
 func getPrometheusToken() (string, error) {


### PR DESCRIPTION
Currently metrics server uses port `:8080` what has a high chance of conflicting with other services. In order to decrease a chance of the conflict we are moving to `:8089`.

```release-note
NONE
```
