### PR TITLE
e2e, handler: Check neighbors at lldp test

### DIFF
--- a/test/e2e/handler/lldp_with_nmpolicy_test.go
+++ b/test/e2e/handler/lldp_with_nmpolicy_test.go
@@ -18,16 +18,24 @@ limitations under the License.
 package handler
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("LLDP configuration with nmpolicy", func() {
+	var lldpdPod *corev1.Pod
+
 	lldpEnabledPolicyName := "lldp-enabled"
 	lldpDisabledPolicyName := "lldp-disabled"
 
@@ -42,6 +50,33 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 	interfacesWithLldpEnabledState := nmstate.NewState(`interfaces: "{{ capture.ethernets-lldp.interfaces }}"`)
 
 	BeforeEach(func() {
+		By("Starting lldpd at one node")
+		lldpdPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "lldpd",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:    "lldpd",
+					Image:   "quay.io/fedora/fedora-toolbox",
+					Command: []string{"/bin/bash"},
+					Args:    []string{"-c", "dnf install -y lldpd && lldpd -d"},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.Bool(true),
+					},
+				}},
+				HostNetwork: true,
+			},
+		}
+		Expect(testenv.Client.Create(context.Background(), lldpdPod)).To(Succeed())
+		Eventually(func() (corev1.PodPhase, error) {
+			if err := testenv.Client.Get(context.Background(), client.ObjectKeyFromObject(lldpdPod), lldpdPod); err != nil {
+				return "", err
+			}
+			return lldpdPod.Status.Phase, nil
+		}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Equal(corev1.PodRunning))
+
 		By("Enabling LLDP on up ethernet interfaces")
 		setDesiredStateWithPolicyAndCapture(lldpEnabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("true"))
 		policy.WaitForAvailablePolicy(lldpEnabledPolicyName)
@@ -53,10 +88,13 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 			setDesiredStateWithPolicyAndCapture(lldpDisabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("false"))
 			policy.WaitForAvailablePolicy(lldpDisabledPolicyName)
 			deletePolicy(lldpDisabledPolicyName)
+
+			By("Delete lldpd pod")
+			Expect(testenv.Client.Delete(context.Background(), lldpdPod)).To(Succeed())
 		})
 	})
 
-	It("should enable LLDP on all ethernet interfaces that are up", func() {
+	It("should enable LLDP on all ethernet interfaces that are up and show neighbors", func() {
 		Byf("Check %s has lldp enabled", primaryNic)
 		for _, node := range nodes {
 			Eventually(
@@ -66,5 +104,13 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 				30*time.Second, 1*time.Second,
 			).Should(Equal("true"), fmt.Sprintf("Interface %s should have enabled lldp", primaryNic))
 		}
+
+		Byf("Check %s has neighbors", primaryNic)
+		Eventually(
+			func() string {
+				return lldpNeighbors(lldpdPod.Spec.NodeName, primaryNic)
+			},
+			5*time.Minute, time.Second,
+		).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s should have lldp neighbors", primaryNic))
 	})
 })

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -576,6 +576,10 @@ func nodeInterfacesState(node string, exclude []string) []byte {
 	}
 	return ret
 }
+func lldpNeighbors(node, iface string) string {
+	path := fmt.Sprintf("interfaces.#(name==\"%s\").lldp.neighbors", iface)
+	return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()
+}
 
 func lldpEnabled(node, iface string) string {
 	path := fmt.Sprintf("interfaces.#(name==\"%s\").lldp.enabled", iface)


### PR DESCRIPTION
**What this PR does / why we need it**:
Start lldpd at a node and check that neighbors get reported at nns at the enabled LLDP test.

Closes https://issues.redhat.com/browse/CNV-30149


**Release note**:

```release-note
Check neighbors at e2e handler lldp test.
```
