### PR TITLE
api: add ovn bridge mappings to node network state

### DIFF
--- a/pkg/state/ovn_bridge_mappings_test.go
+++ b/pkg/state/ovn_bridge_mappings_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+var _ = Describe("OVN bridge mappings", func() {
+	var (
+		state, filteredState nmstate.State
+	)
+
+	When("the OVN subtree is omitted", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+`)
+
+			filteredState = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+`)
+		})
+
+		It("the OVN bridge mappings are not shown on the node network state", func() {
+			returnedState, err := filterOut(state)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+
+	When("an empty OVN subtree is configured", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn: {}
+`)
+
+			filteredState = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn: {}
+`)
+		})
+
+		It("the OVN subtree is reported, but mappings are not shown", func() {
+			returnedState, err := filterOut(state)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+
+	When("mappings are provisioned", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn:
+  bridge-mappings:
+  - localnet: datanet
+    bridge: ovs1
+    state: present
+`)
+			filteredState = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn:
+  bridge-mappings:
+  - localnet: datanet
+    bridge: ovs1
+    state: present
+`)
+		})
+
+		It("the OVN bridge mappings are listed in the node network state", func() {
+			returnedState, err := filterOut(state)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+
+	When("an empty list of mappings is provisioned", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn:
+  bridge-mappings: []
+`)
+			filteredState = nmstate.NewState(`
+interfaces: []
+routes:
+  config: []
+  running: []
+ovn: {}
+`)
+		})
+
+		It("the OVN subtree (without mappings) is shown", func() {
+			returnedState, err := filterOut(state)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
+})

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -28,6 +28,7 @@ type rootState struct {
 	Interfaces  []interfaceState `json:"interfaces"             yaml:"interfaces"`
 	Routes      *routes          `json:"routes,omitempty"       yaml:"routes,omitempty"`
 	DNSResolver *dnsResolver     `json:"dns-resolver,omitempty" yaml:"dns-resolver,omitempty"`
+	Ovn         *bridgeMappings  `json:"ovn,omitempty"          yaml:"ovn,omitempty"`
 }
 
 type routes struct {
@@ -101,4 +102,14 @@ func (r *routeState) UnmarshalJSON(b []byte) error {
 	r.Data["next-hop-interface"] = fields.NextHopInterface
 	r.routeFields = fields
 	return nil
+}
+
+type bridgeMappings struct {
+	PhysicalNetworkMappings []PhysicalNetworks `json:"bridge-mappings,omitempty" yaml:"bridge-mappings,omitempty"`
+}
+
+type PhysicalNetworks struct {
+	Name   string `json:"localnet" yaml:"localnet"`
+	Bridge string `json:"bridge" yaml:"bridge"`
+	State  string `json:"state,omitempty" yaml:"state,omitempty"`
 }

--- a/test/e2e/handler/nns_ovn.go
+++ b/test/e2e/handler/nns_ovn.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nmstate/kubernetes-nmstate/pkg/state"
+	policyconditions "github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
+)
+
+var _ = Describe("[nns] NNS OVN bridge mappings", func() {
+	const (
+		bridgeName  = "ovsbr1"
+		networkName = "net1"
+	)
+
+	BeforeEach(func() {
+		for _, node := range nodes {
+			Expect(nodeBridgeMappings(node)).To(BeEmpty())
+		}
+
+		By("provisioning some bridge mappings ...")
+		updateDesiredState(bridgeMappings(networkName, bridgeName))
+
+		By("Check policy is at available state")
+		policyconditions.WaitForAvailableTestPolicy()
+
+		DeferCleanup(func() {
+			By("resetting the bridge mappings ...")
+			updateDesiredState(cleanBridgeMappings(networkName))
+
+			By("Check policy is at available state")
+			policyconditions.WaitForAvailableTestPolicy()
+		})
+	})
+
+	It("are listed", func() {
+		for _, node := range nodes {
+			Expect(nodeBridgeMappings(node)).To(
+				ConsistOf(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
+		}
+	})
+})
+
+func nodeBridgeMappings(nodeName string) ([]state.PhysicalNetworks, error) {
+	var physicalNetworks []state.PhysicalNetworks
+	mappingsData := ovnBridgeMappings(nodeName)
+	if err := json.Unmarshal([]byte(mappingsData), &physicalNetworks); err != nil {
+		return nil, fmt.Errorf("failed to unmarshall bridge mappings for node %q: %w", nodeName, err)
+	}
+	return physicalNetworks, nil
+}

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -331,3 +331,22 @@ func matchingBond(expectedBond map[string]interface{}) types.GomegaMatcher {
 		)),
 	)
 }
+
+func bridgeMappings(networkName string, bridgeName string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`
+ovn:
+  bridge-mappings:
+  - localnet: %s
+    bridge: %s
+    state: present
+`, networkName, bridgeName))
+}
+
+func cleanBridgeMappings(networkName string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`
+ovn:
+  bridge-mappings:
+  - localnet: %s
+    state: absent
+`, networkName))
+}

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -675,3 +675,11 @@ func dnsResolverForNode(node, path string) []string {
 	}
 	return arr
 }
+
+func ovnBridgeMappings(node string) string {
+	result := gjson.ParseBytes(currentStateJSON(node)).Get("ovn.bridge-mappings")
+	if result.String() == "" {
+		return "null"
+	}
+	return result.String()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
This PR exposes the node's ovn bridge mappings (already provided on `nmstatectl show`) via the NNS object.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Display OVN bridge mappings on the NodeNetworkState object
```
