### PR TITLE
e2e: Use metrics container when executing commands

### DIFF
--- a/test/runner/pod.go
+++ b/test/runner/pod.go
@@ -84,5 +84,5 @@ func RunAtMetricsPod(arguments ...string) string {
 	metricsPods, err := nmstateMetricsPods()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, metricsPods).ToNot(BeEmpty())
-	return runAtPod(metricsPods[0], arguments...)
+	return runAtPod(metricsPods[0], append([]string{"-c", "nmstate-metrics"}, arguments...)...)
 }


### PR DESCRIPTION
This PR adds explicit `-c nmstate-metrics` to the command invocations that use `kubectl.sh exec [...]`. This should not change the current behaviour as by default we execture them in this container, however it's been noticed that the following stderr is produced

```
stderr: Defaulted container "nmstate-metrics" out of: nmstate-metrics, kube-rbac-proxy
```

so for being explict, we are defining where to execute the command.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
