### PR TITLE
e2e: parametrize monitoring namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_FULL_NAME)
 
 export HANDLER_NAMESPACE ?= nmstate
 export OPERATOR_NAMESPACE ?= $(HANDLER_NAMESPACE)
+export MONITORING_NAMESPACE ?= monitoring
 HANDLER_PULL_POLICY ?= Always
 OPERATOR_PULL_POLICY ?= Always
 export IMAGE_BUILDER ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
@@ -178,14 +179,14 @@ test/unit: test/unit/api
 	NODE_NAME=node01 $(GINKGO) --junit-report=junit-pkg-controller-unit-test.xml $(unit_test_args) $(WHAT)
 
 test-e2e-handler:
-	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/handler ...
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) MONITORING_NAMESPACE=$(MONITORING_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/handler ...
 
 test-e2e-operator: manifests
-	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/operator ...
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) MONITORING_NAMESPACE=$(MONITORING_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/operator ...
 
 test-e2e-upgrade: manifests
 	./hack/prepare-e2e-test-upgrade.sh
-	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/upgrade ...
+	KUBECONFIG=$(KUBECONFIG) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) MONITORING_NAMESPACE=$(MONITORING_NAMESPACE) $(GINKGO) $(e2e_test_args) ./test/e2e/upgrade ...
 
 test-e2e: test-e2e-operator test-e2e-handler
 

--- a/test/e2e/handler/metrics.go
+++ b/test/e2e/handler/metrics.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
+	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	"github.com/nmstate/kubernetes-nmstate/test/runner"
 )
 
@@ -32,13 +33,12 @@ func getMetrics(token string) map[string]string {
 
 func getPrometheusToken() (string, error) {
 	const (
-		monitoringNamespace = "monitoring"
-		prometheusPod       = "prometheus-k8s-0"
-		container           = "prometheus"
-		tokenPath           = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101
+		prometheusPod = "prometheus-k8s-0"
+		container     = "prometheus"
+		tokenPath     = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101
 	)
 
-	return cmd.Kubectl("exec", "-n", monitoringNamespace, prometheusPod, "-c", container, "--", "cat", tokenPath)
+	return cmd.Kubectl("exec", "-n", testenv.MonitoringNamespace, prometheusPod, "-c", container, "--", "cat", tokenPath)
 }
 
 func indexMetrics(metrics string) map[string]string {

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -33,15 +33,17 @@ import (
 )
 
 var (
-	cfg               *rest.Config
-	Client            client.Client         // You'll be using this client in your tests.
-	KubeClient        *kubernetes.Clientset // You'll be using this client in your tests.
-	testEnv           *envtest.Environment
-	OperatorNamespace string
+	cfg                 *rest.Config
+	Client              client.Client         // You'll be using this client in your tests.
+	KubeClient          *kubernetes.Clientset // You'll be using this client in your tests.
+	testEnv             *envtest.Environment
+	OperatorNamespace   string
+	MonitoringNamespace string
 )
 
 func TestMain() {
 	OperatorNamespace = environment.GetVarWithDefault("OPERATOR_NAMESPACE", "nmstate")
+	MonitoringNamespace = environment.GetVarWithDefault("MONITORING_NAMESPACE", "monitoring")
 }
 
 func Start() {


### PR DESCRIPTION
This PR adds ability to manually configure monitoring namespace by using `MONITORING_NAMESPACE` env variable passed to Makefile, e.g. when executing

```
make test-e2e-handler
```

With this change we can run e2e tests in OpenShift clusters which use a different name than our hardcoded `monitoring`.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
