### PR TITLE
operator: Add placeholder for kube-rbac-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ OPERATOR_IMAGE_TAG ?= latest
 OPERATOR_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_FULL_NAME)
 
+KUBE_RBAC_PROXY_IMAGE ?= quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+
 export HANDLER_NAMESPACE ?= nmstate
 export OPERATOR_NAMESPACE ?= $(HANDLER_NAMESPACE)
 export MONITORING_NAMESPACE ?= monitoring
@@ -156,7 +158,7 @@ check-bundle: bundle
 generate: gen-k8s gen-crds gen-rbac
 
 manifests:
-	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
+	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -kube-rbac-proxy-image=$(KUBE_RBAC_PROXY_IMAGE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: SKIP_PUSH=true
 handler: push-handler

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -256,6 +256,8 @@ spec:
                   value: Always
                 - name: HANDLER_NAMESPACE
                   value: nmstate
+                - name: KUBE_RBAC_PROXY_IMAGE
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: Always
                 name: nmstate-operator

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -299,6 +299,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 	data.Data["HandlerImage"] = os.Getenv("RELATED_IMAGE_HANDLER_IMAGE")
 	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
 	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
+	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["InfraNodeSelector"] = archAndCRInfraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations
 	data.Data["WebhookAffinity"] = infraAffinity

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -73,13 +73,14 @@ var _ = Describe("NMState controller reconcile", func() {
 				UID:  "12345",
 			},
 		}
-		handlerPrefix    = "handler"
-		handlerNamespace = "nmstate"
-		handlerKey       = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
-		webhookKey       = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
-		handlerImage     = "quay.io/some_image"
-		imagePullPolicy  = "Always"
-		manifestsDir     = ""
+		handlerPrefix      = "handler"
+		handlerNamespace   = "nmstate"
+		handlerKey         = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
+		webhookKey         = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
+		handlerImage       = "quay.io/some_image"
+		kubeRBACProxyImage = "quay.io/some_kube_rbac_proxy_image"
+		imagePullPolicy    = "Always"
+		manifestsDir       = ""
 	)
 	BeforeEach(func() {
 		var err error
@@ -105,6 +106,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		os.Setenv("RELATED_IMAGE_HANDLER_IMAGE", handlerImage)
 		os.Setenv("HANDLER_IMAGE_PULL_POLICY", imagePullPolicy)
 		os.Setenv("HANDLER_PREFIX", handlerPrefix)
+		os.Setenv("KUBE_RBAC_PROXY_IMAGE", kubeRBACProxyImage)
 	})
 	AfterEach(func() {
 		err := os.RemoveAll(manifestsDir)

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -79,7 +79,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+          image: {{ .KubeRBACProxyImage }}
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -78,3 +78,5 @@ spec:
               value: {{ .HandlerPullPolicy }}
             - name: HANDLER_NAMESPACE
               value: {{ .HandlerNamespace }}
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: {{ .KubeRBACProxyImage }}

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -41,6 +41,7 @@ func main() {
 		OperatorNamespace  string
 		OperatorImage      string
 		OperatorPullPolicy string
+		KubeRBACProxyImage string
 	}
 
 	handlerNamespace := flag.String("handler-namespace", "nmstate", "Namespace for the NMState handler")
@@ -50,6 +51,7 @@ func main() {
 	operatorNamespace := flag.String("operator-namespace", "nmstate-operator", "Namespace for the NMState operator")
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
 	operatorPullPolicy := flag.String("operator-pull-policy", "Always", "Pull policy for the NMState operator image")
+	kubeRBACProxyImage := flag.String("kube-rbac-proxy-image", "", "Image for the kube RBAC proxy needed for metrics")
 	inputDir := flag.String("input-dir", "", "Input directory")
 	outputDir := flag.String("output-dir", "", "Output directory")
 	flag.Parse()
@@ -62,6 +64,7 @@ func main() {
 		OperatorNamespace:  *operatorNamespace,
 		OperatorImage:      *operatorImage,
 		OperatorPullPolicy: *operatorPullPolicy,
+		KubeRBACProxyImage: *kubeRBACProxyImage,
 	}
 
 	// Clean up output dir so we don't have old files.


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
At some deployments the kube-rbac-proxy is different from the one at quay.io, this change add a new environment variable at operator deployment to configure that image.

Fixes https://issues.redhat.com/browse/OCPBUGS-33866

**Special notes for your reviewer**:

**Release note**:

```release-note
Add a environment variable at operator to configure kube-rbac-proxy
```
