### PR TITLE
e2e: don't require empty starting state for bridge mappings

### DIFF
--- a/test/e2e/handler/nns_ovn.go
+++ b/test/e2e/handler/nns_ovn.go
@@ -36,7 +36,8 @@ var _ = Describe("[nns] NNS OVN bridge mappings", func() {
 
 	BeforeEach(func() {
 		for _, node := range nodes {
-			Expect(nodeBridgeMappings(node)).To(BeEmpty())
+			Expect(nodeBridgeMappings(node)).NotTo(
+				ContainElement(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
 		}
 
 		By("provisioning some bridge mappings ...")
@@ -57,7 +58,7 @@ var _ = Describe("[nns] NNS OVN bridge mappings", func() {
 	It("are listed", func() {
 		for _, node := range nodes {
 			Expect(nodeBridgeMappings(node)).To(
-				ConsistOf(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
+				ContainElement(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
 		}
 	})
 })


### PR DESCRIPTION
This commit changes the behaviour of the OVN bridge mapping test so that we do not require the initial state to be empty. Thanks to this we make e2e tests working correctly on machines whre OVN is already used and bridges are deployed.

Without this change the test will pass only if no OVN bridge mappings exist on the node. The assumption is quite strong and not really desired.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
