### PR TITLE
OCPBUGS-36487: Update consoleplugin version

### DIFF
--- a/deploy/openshift/ui-plugin/consoleplugin.yaml
+++ b/deploy/openshift/ui-plugin/consoleplugin.yaml
@@ -1,4 +1,4 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: {{ .PluginName }}
@@ -6,8 +6,10 @@ metadata:
     console.openshift.io/use-i18n: "true"
 spec:
   displayName: 'Console Plugin for NMState'
-  service:
-    name: {{ .PluginName }}
-    namespace: {{ .PluginNamespace }}
-    port: {{ .PluginPort }}
-    basePath: '/'
+  backend:
+    type: Service
+    service:
+      name: {{ .PluginName }}
+      namespace: {{ .PluginNamespace }}
+      port: {{ .PluginPort }}
+      basePath: '/'


### PR DESCRIPTION
due to webhook conversion error

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

Bug

**What this PR does / why we need it**:

Webhook conversion seems to fail on 4.17. So we have to upgrade ConsolePlugin version and use a more updated spec structure


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
