### PR TITLE
test: ability to use kubectl instead of ssh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ export GOPROXY=direct
 export KUBECONFIG ?= $(shell ./cluster/kubeconfig.sh)
 export SSH ?= ./cluster/ssh.sh
 export KUBECTL ?= ./cluster/kubectl.sh
+export USE_KUBECTL_DEBUG_NODE ?= false
 
 KUBECTL ?= ./cluster/kubectl.sh
 OPERATOR_SDK_VERSION ?= 1.21.0


### PR DESCRIPTION
Right now the test framework uses SSH to access nodes in order to run e.g. nmstatectl commands. With this change we add ability to use kubectl debug functionality to run commands directly on the node.

This is useful when running test suite in clusters with no direct SSH access to the nodes, e.g. remote cloud clusters and not a local bare metal setups.

In order to use this feature, make sure the `USE_KUBECTL_DEBUG_NODE` env variable is set when calling Makefile. Also make sure that `KUBECTL` points to the kubectl binary that will be used when making the calls.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
