### PR TITLE
hack: use full name for qemu container image

### DIFF
--- a/hack/qemu-user-static.sh
+++ b/hack/qemu-user-static.sh
@@ -8,5 +8,5 @@ set -xe
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
 if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
-    ${IMAGE_BUILDER} run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    ${IMAGE_BUILDER} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 fi


### PR DESCRIPTION
This PR changes the image name to include `docker.io` in order to avoid the error with short names when TTY is not available, i.e.

```
+ podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
Error: short-name resolution enforced but cannot prompt without a TTY
```

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
