### PR TITLE
Openshift replace cert manager with openshift cert service

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -182,6 +182,7 @@ spec:
         - name: tls-key-pair
           secret:
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
+{{- if not .IsOpenShift }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -268,6 +269,7 @@ spec:
               value: {{ .SelfSignConfiguration.CertRotateInterval }}
             - name: CERT_OVERLAP_INTERVAL
               value: {{ .SelfSignConfiguration.CertOverlapInterval }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -388,6 +390,8 @@ kind: Service
 metadata:
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}nmstate-webhook
   labels:
     app: kubernetes-nmstate
 spec:
@@ -420,6 +424,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{template "handlerPrefix" .}}nmstate
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app: kubernetes-nmstate
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:
Use cert services at openshift cluster's instead of nmstate-cert-manager

TODO:
- [ ] RBAC cleanup

```release-note
Use cert services at openshift cluster's instead of nmstate-cert-manager
```
