### PR TITLE
openshift: Use handler namespace for cleanup

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -118,7 +118,7 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if err := r.cleanupObsoleteResources(ctx, instance.Namespace); err != nil {
+	if err := r.cleanupObsoleteResources(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -358,7 +358,7 @@ func (r *NMStateReconciler) patchOpenshiftConsolePlugin(ctx context.Context) err
 	return nil
 }
 
-func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context, namespace string) error {
+func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error {
 	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
 	if err != nil {
 		return err
@@ -367,7 +367,7 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context, namesp
 	if isOpenShift {
 		err = r.Client.Delete(ctx, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
+				Namespace: os.Getenv("HANDLER_NAMESPACE"),
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
 			},
 		})

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -276,15 +276,6 @@ var _ = Describe("NMState controller reconcile", func() {
 				Expect(deployment.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(k, v))
 			}
 		})
-		It("should add InfraNodeSelector to certmanager deployment", func() {
-			deployment := &appsv1.Deployment{}
-			certManagerKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-cert-manager"}
-			err := cl.Get(context.TODO(), certManagerKey, deployment)
-			Expect(err).ToNot(HaveOccurred())
-			for k, v := range infraNodeSelector {
-				Expect(deployment.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(k, v))
-			}
-		})
 		It("should add InfraNodeSelector to metrics deployment", func() {
 			deployment := &appsv1.Deployment{}
 			metricsKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-metrics"}
@@ -327,13 +318,6 @@ var _ = Describe("NMState controller reconcile", func() {
 		It("should add InfraTolerations to webhook deployment", func() {
 			deployment := &appsv1.Deployment{}
 			err := cl.Get(context.TODO(), webhookKey, deployment)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(allTolerationsPresent(infraTolerations, deployment.Spec.Template.Spec.Tolerations)).To(BeTrue())
-		})
-		It("should add InfraTolerations to cert-manager deployment", func() {
-			deployment := &appsv1.Deployment{}
-			certManagerKey := types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-cert-manager"}
-			err := cl.Get(context.TODO(), certManagerKey, deployment)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(allTolerationsPresent(infraTolerations, deployment.Spec.Template.Spec.Tolerations)).To(BeTrue())
 		})


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
The NMState CR has no namespace at all, to remove the obsolete cert-manager at openshift operator should use the HANDLER_NAMESPACE env var.


**Release note**:
```release-note
Use handler namespace to remove cert-manager at openshift.
```
