### PR TITLE
Use `nmstatectl apply` instead of `nmstatectl set`

### DIFF
--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -78,7 +78,7 @@ func Set(desiredState nmstate.State, timeout time.Duration) (string, error) {
 	defer close(setDoneCh)
 
 	setOutput, err := nmstatectlWithInput(
-		[]string{"set", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
+		[]string{"apply", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
 		string(desiredState.Raw),
 	)
 	return setOutput, err


### PR DESCRIPTION
The `nmstatectl set` is deprecated in order to align with API method
name (`apply`). Should use `nmstatectl apply` instead.