### PR TITLE
openshift: Ensure new webhook secret

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -371,8 +371,19 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
 			},
 		})
-		if !apierrors.IsNotFound(err) {
+		if err != nil && apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting obsolete cert-manager deployment at openshift: %w", err)
+		}
+
+		// Remove the non openshift secret
+		err = r.Client.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: os.Getenv("HANDLER_NAMESPACE"),
+				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-webhook",
+			},
+		})
+		if err != nil && apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed deleting old webhook secret at openshift: %w", err)
 		}
 	}
 	return nil

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -181,7 +181,11 @@ spec:
       volumes:
         - name: tls-key-pair
           secret:
+{{- if not .IsOpenShift }}
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
+{{- else }}
+            secretName: {{template "handlerPrefix" .}}openshift-nmstate-webhook
+{{- end }}
 {{- if not .IsOpenShift }}
 ---
 apiVersion: apps/v1
@@ -391,7 +395,7 @@ metadata:
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}nmstate-webhook
+    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}openshift-nmstate-webhook
   labels:
     app: kubernetes-nmstate
 spec:


### PR DESCRIPTION
The non openshift secret is not compatible with openshift generated version, this change a different one so they don't collide and also remove the old one.

```release-note
Use different webhook secret name for openshift.
```
