### PR TITLE
e2e, handler: Simplify vlan_filtering 0 check

### DIFF
--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -167,11 +167,10 @@ var _ = Describe("NodeNetworkState", func() {
 			It("should have the linux bridge at currentState with vlan_filtering 0 and no default vlan range configured", func() {
 				for _, node := range nodes {
 					interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
-					bridgeDescription(node, bridge1).Should(ContainSubstring("vlan_filtering 0"))
-
-					getVLANFlagsEventually(node, firstSecondaryNic, 1).
-						Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-					vlansCardinality(node, firstSecondaryNic).Should(Equal(0))
+					bridgeDescription(node, bridge1).Should(SatisfyAll(
+						ContainSubstring("vlan_filtering 0"),
+						ContainSubstring("vlan_default_pvid 1"),
+					))
 				}
 			})
 		})
@@ -216,14 +215,12 @@ var _ = Describe("NodeNetworkState", func() {
 					resetDesiredStateForNodes()
 				})
 				It("should have the linux bridge at currentState with vlan_filtering 0 and no default vlan range configured", func() {
-					Skip("Pending on https://bugzilla.redhat.com/show_bug.cgi?id=2067058 land centos stream 8")
 					for _, node := range nodes {
 						interfacesNameForNodeEventually(node).Should(ContainElement(bridge1))
-						bridgeDescription(node, bridge1).Should(ContainSubstring("vlan_filtering 0"))
-
-						getVLANFlagsEventually(node, firstSecondaryNic, 1).
-							Should(ConsistOf("PVID", Or(Equal("Egress Untagged"), Equal("untagged"))))
-						vlansCardinality(node, firstSecondaryNic).Should(Equal(0))
+						bridgeDescription(node, bridge1).Should(SatisfyAll(
+							ContainSubstring("vlan_filtering 0"),
+							ContainSubstring("vlan_default_pvid 1"),
+						))
 					}
 				})
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like when disabling vlan filtering the bridge vlan show command is not working as expected but the system is correctly working, this change just check tha vlan filtering is 0 at the bridge and that the default pvid is 1, that's more than enough.

```release-note
NONE
```
