### PR TITLE
OCPBUGS-44596: Mount OVS directory instead of socket file

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -366,7 +366,7 @@ spec:
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
             - name: ovs-socket
-              mountPath: /run/openvswitch/db.sock
+              mountPath: /run/openvswitch
           securityContext:
             privileged: true
           readinessProbe:
@@ -387,7 +387,7 @@ spec:
             path: /var/k8s_nmstate
         - name: ovs-socket
           hostPath:
-            path: /run/openvswitch/db.sock
+            path: /run/openvswitch
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
When mounting the OVS DB socket directly as a file (`/run/openvswitch/db.sock`) instead of mounting the whole directory, handler container loses access to the OVS DB in case of OVS daemon restart on the host. This can only be fixed by restarting the container so that it mounts again the correct file.

To remediate this, we are mounting the whole `/run/openvswitch` directory so that DB connection can be gracefully restored by the handler itself.

Closes: OCPBUGS-44596

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
