### PR TITLE
Allow configuring node placement for nmstate-console-plugin

### DIFF
--- a/api/v1/nmstate_types.go
+++ b/api/v1/nmstate_types.go
@@ -28,7 +28,7 @@ type NMStateSpec struct {
 	// Affinity is an optional affinity selector that will be added to handler DaemonSet manifest.
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// Affinity is an optional affinity selector that will be added to webhook & certmanager Deployment manifests.
+	// InfraAffinity is an optional affinity selector that will be added to webhook, metrics & console-plugin Deployment manifests.
 	// +optional
 	InfraAffinity *corev1.Affinity `json:"infraAffinity,omitempty"`
 	// NodeSelector is an optional selector that will be added to handler DaemonSet manifest
@@ -41,13 +41,14 @@ type NMStateSpec struct {
 	// If Tolerations is specified, the handler daemonset will be also scheduled on nodes with corresponding taints
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// InfraNodeSelector is an optional selector that will be added to webhook & certmanager Deployment manifests
-	// If InfraNodeSelector is specified, the webhook and certmanager will run only on nodes that have each of the indicated
-	// key-value pairs as labels applied to the node.
+	// InfraNodeSelector is an optional selector that will be added to webhook, metrics & console-plugin Deployment manifests
+	// If InfraNodeSelector is specified, the webhook, metrics and the console plugin will run only on nodes that have each
+	// of the indicated key-value pairs as labels applied to the node.
 	// +optional
 	InfraNodeSelector map[string]string `json:"infraNodeSelector,omitempty"`
-	// InfraTolerations is an optional list of tolerations to be added to webhook & certmanager Deployment manifests
-	// If InfraTolerations is specified, the webhook and certmanager will be able to be scheduled on nodes with corresponding taints
+	// InfraTolerations is an optional list of tolerations to be added to webhook, metrics & console-plugin Deployment manifests
+	// If InfraTolerations is specified, the webhook, metrics and the console plugin will be able to be scheduled on nodes with
+	// corresponding taints
 	// +optional
 	InfraTolerations []corev1.Toleration `json:"infraTolerations,omitempty"`
 	// SelfSignConfiguration defines self signed certificate configuration

--- a/bundle/manifests/nmstate.io_nmstates.yaml
+++ b/bundle/manifests/nmstate.io_nmstates.yaml
@@ -803,8 +803,8 @@ spec:
                     type: object
                 type: object
               infraAffinity:
-                description: Affinity is an optional affinity selector that will be
-                  added to webhook & certmanager Deployment manifests.
+                description: InfraAffinity is an optional affinity selector that will
+                  be added to webhook, metrics & console-plugin Deployment manifests.
                 properties:
                   nodeAffinity:
                     description: Describes node affinity scheduling rules for the
@@ -1569,14 +1569,15 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  InfraNodeSelector is an optional selector that will be added to webhook & certmanager Deployment manifests
-                  If InfraNodeSelector is specified, the webhook and certmanager will run only on nodes that have each of the indicated
-                  key-value pairs as labels applied to the node.
+                  InfraNodeSelector is an optional selector that will be added to webhook, metrics & console-plugin Deployment manifests
+                  If InfraNodeSelector is specified, the webhook, metrics and the console plugin will run only on nodes that have each
+                  of the indicated key-value pairs as labels applied to the node.
                 type: object
               infraTolerations:
                 description: |-
-                  InfraTolerations is an optional list of tolerations to be added to webhook & certmanager Deployment manifests
-                  If InfraTolerations is specified, the webhook and certmanager will be able to be scheduled on nodes with corresponding taints
+                  InfraTolerations is an optional list of tolerations to be added to webhook, metrics & console-plugin Deployment manifests
+                  If InfraTolerations is specified, the webhook, metrics and the console plugin will be able to be scheduled on nodes with
+                  corresponding taints
                 items:
                   description: |-
                     The pod this Toleration is attached to tolerates any taint that matches

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -328,10 +328,17 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 
 func (r *NMStateReconciler) applyOpenshiftUIPlugin(instance *nmstatev1.NMState) error {
 	data := render.MakeRenderData()
+	data.Funcs["toYaml"] = nmstaterenderer.ToYaml
 	data.Data["PluginNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "openshift-nmstate")
 	data.Data["PluginName"] = environment.GetEnvVar("PLUGIN_NAME", "nmstate-console-plugin")
 	data.Data["PluginImage"] = environment.GetEnvVar("PLUGIN_IMAGE", "quay.io/nmstate/nmstate-console-plugin:release-1.0.0")
 	data.Data["PluginPort"] = environment.GetEnvVar("PLUGIN_PORT", "9443")
+
+	// if not set in the NMState CR, these entries are nil
+	data.Data["InfraNodeSelector"] = instance.Spec.InfraNodeSelector
+	data.Data["InfraTolerations"] = instance.Spec.InfraTolerations
+	data.Data["InfraAffinity"] = instance.Spec.InfraAffinity
+
 	return r.renderAndApply(instance, data, filepath.Join("openshift", "ui-plugin"), true)
 }
 

--- a/deploy/crds/nmstate.io_nmstates.yaml
+++ b/deploy/crds/nmstate.io_nmstates.yaml
@@ -803,8 +803,8 @@ spec:
                     type: object
                 type: object
               infraAffinity:
-                description: Affinity is an optional affinity selector that will be
-                  added to webhook & certmanager Deployment manifests.
+                description: InfraAffinity is an optional affinity selector that will
+                  be added to webhook, metrics & console-plugin Deployment manifests.
                 properties:
                   nodeAffinity:
                     description: Describes node affinity scheduling rules for the
@@ -1569,14 +1569,15 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  InfraNodeSelector is an optional selector that will be added to webhook & certmanager Deployment manifests
-                  If InfraNodeSelector is specified, the webhook and certmanager will run only on nodes that have each of the indicated
-                  key-value pairs as labels applied to the node.
+                  InfraNodeSelector is an optional selector that will be added to webhook, metrics & console-plugin Deployment manifests
+                  If InfraNodeSelector is specified, the webhook, metrics and the console plugin will run only on nodes that have each
+                  of the indicated key-value pairs as labels applied to the node.
                 type: object
               infraTolerations:
                 description: |-
-                  InfraTolerations is an optional list of tolerations to be added to webhook & certmanager Deployment manifests
-                  If InfraTolerations is specified, the webhook and certmanager will be able to be scheduled on nodes with corresponding taints
+                  InfraTolerations is an optional list of tolerations to be added to webhook, metrics & console-plugin Deployment manifests
+                  If InfraTolerations is specified, the webhook, metrics and the console plugin will be able to be scheduled on nodes with
+                  corresponding taints
                 items:
                   description: |-
                     The pod this Toleration is attached to tolerates any taint that matches

--- a/deploy/openshift/ui-plugin/deployment.yaml
+++ b/deploy/openshift/ui-plugin/deployment.yaml
@@ -19,6 +19,15 @@ spec:
       labels:
         app: {{ .PluginName }}
     spec:
+      {{- if .InfraNodeSelector }}
+      nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .InfraTolerations }}
+      tolerations: {{ toYaml .InfraTolerations | nindent 8 }}
+      {{- end }}
+      {{- if .InfraAffinity }}
+      affinity: {{ toYaml .InfraAffinity | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .PluginName }}
           image: {{ .PluginImage }}


### PR DESCRIPTION
Use the NMState CR fields of `.spec.InfraNodeSelector`, `.spec.InfraTolerations` and `.spec.InfraAffinity` to propagate also to the `nmstate-console-plugin` Deployment. This will allow users to control the placement of the `nmstate-console-plugin` pod, along with the webhook and metrics deployments.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Allow configuring node placement for nmstate-console-plugin through NMState CR.
```
