### PR TITLE
Enable debug logging of nmstate apply

### DIFF
--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -79,7 +79,7 @@ func Set(desiredState nmstate.State, timeout time.Duration) (string, error) {
 	defer close(setDoneCh)
 
 	setOutput, err := nmstatectlWithInput(
-		[]string{"apply", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
+		[]string{"apply", "-v", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
 		string(desiredState.Raw),
 	)
 	return setOutput, err


### PR DESCRIPTION
Enable debug logging of nmstate apply, this could help developer to
debug issue when something broken.

```release-note
Use verbose nmstatectl output on errors.
```
