### PR TITLE
go: Pin to 1.22.12

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -11,8 +11,7 @@ mkdir -p $tmp_dir
 if gimme --help > /dev/null 2>&1; then
 
     go_mod_version=$(grep '^go' go.mod |sed 's/go //')
-    full_version=$(curl -s https://go.dev/dl/?mode=json |jq -r .[].version |grep "$go_mod_version")
-    export GIMME_GO_VERSION=$(echo $full_version |sed 's/go//')
+    export GIMME_GO_VERSION=$(echo $go_mod_version |sed 's/go//')
     echo "Installing go $GIMME_GO_VERSION with gimme"
     eval "$(gimme)"
 else

--- a/build/install-go.sh
+++ b/build/install-go.sh
@@ -6,7 +6,6 @@ os=linux
 go_mod_version=$1
 
 dnf install -y jq
-full_version=$(curl -s https://go.dev/dl/?mode=json |jq -r .[].version |grep "$go_mod_version")
 
 case $(uname -m) in
     x86_64)  arch="amd64";;
@@ -18,6 +17,6 @@ if [ "$arch" == "" ]; then
     exit 1
 fi
 
-tarball_url="https://go.dev/dl/${full_version}.${os}-${arch}.tar.gz"
+tarball_url="https://go.dev/dl/go${version}.${os}-${arch}.tar.gz"
 
 curl --retry 10 -L $tarball_url | tar -C /usr/local -zxf -

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nmstate/kubernetes-nmstate
 
-go 1.22
+go 1.22.12
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
The golang page json version no longer list the 1.22 versions so we cannot discoer the latest full version, this change just pin to latest full version and fix the script to use that.

```release-note
Pin to golang 1.22.12
```
