### PR TITLE
OPNET-627: Implement operator best practices

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -243,7 +243,28 @@ spec:
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: Always
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: healthprobe
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 1
                 name: nmstate-operator
+                ports:
+                - containerPort: 8081
+                  name: healthprobe
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /readyz
+                    port: healthprobe
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 1
                 resources:
                   requests:
                     cpu: 60m

--- a/cluster/sync-operator.sh
+++ b/cluster/sync-operator.sh
@@ -26,7 +26,7 @@ function wait_ready_operator() {
     sleep 5
 
     # Wait for deployment rollout
-    if ! $kubectl rollout status -w -n ${OPERATOR_NAMESPACE} deployment nmstate-operator; then
+    if ! $kubectl rollout status -w -n ${OPERATOR_NAMESPACE} deployment nmstate-operator --timeout=2m; then
         echo "Operator haven't turned ready within the given timeout"
         return 1
     fi

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -131,6 +132,7 @@ func mainHandler() int {
 		Metrics: metricsserver.Options{
 			BindAddress: ":8089", // Explicitly enable metrics
 		},
+		HealthProbeBindAddress: ":8081",
 	}
 
 	if environment.IsHandler() {
@@ -171,6 +173,15 @@ func mainHandler() int {
 		if err = createHealthyFile(); err != nil {
 			return generalExitStatus
 		}
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		return generalExitStatus
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		return generalExitStatus
 	}
 
 	setProfiler()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -30,6 +30,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -88,6 +89,7 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: "0", // disable metrics
 		},
+		HealthProbeBindAddress: ":8081",
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrlOptions)
@@ -99,6 +101,15 @@ func main() {
 	err = setupOperatorController(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to setup controller", "controller", "NMState")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -51,6 +51,33 @@ spec:
             requests:
               cpu: "30m"
               memory: "20Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+          terminationMessagePolicy: FallbackToLogsOnError
+          ports:
+            - containerPort: 8089
+              name: monitoring
+            - containerPort: 8081
+              name: healthprobe
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthprobe
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -86,10 +113,26 @@ spec:
           - containerPort: 8443
             name: metrics
             protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             requests:
-              cpu: 10m
-              memory: 20Mi
+              cpu: "10m"
+              memory: "20Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
           terminationMessagePolicy: FallbackToLogsOnError
 ---
 apiVersion: apps/v1
@@ -141,6 +184,10 @@ spec:
             requests:
               cpu: "30m"
               memory: "20Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -164,6 +211,8 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          - containerPort: 8081
+            name: healthprobe
           readinessProbe:
             httpGet:
               path: /readyz
@@ -174,6 +223,15 @@ spec:
                 value: application/json
             initialDelaySeconds: 10
             periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthprobe
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           volumeMounts:
           - name: tls-key-pair
             readOnly: true
@@ -230,6 +288,10 @@ spec:
             requests:
               cpu: "30m"
               memory: "30Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -325,6 +387,10 @@ spec:
             requests:
               cpu: "100m"
               memory: "100Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -379,6 +445,20 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthprobe
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          ports:
+            - containerPort: 8089
+              name: monitoring
+            - containerPort: 8081
+              name: healthprobe
       volumes:
         - name: dbus-socket
           hostPath:

--- a/deploy/openshift/ui-plugin/deployment.yaml
+++ b/deploy/openshift/ui-plugin/deployment.yaml
@@ -34,11 +34,28 @@ spec:
           ports:
             - containerPort: {{ .PluginPort }}
               protocol: TCP
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: 10m
-              memory: 50Mi
+              cpu: "10m"
+              memory: "50Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"
+          terminationMessagePolicy: FallbackToLogsOnError
+          readinessProbe:
+            tcpSocket:
+              port: {{ .PluginPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .PluginPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           volumeMounts:
             - name: plugin-serving-cert
               readOnly: true

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -57,6 +57,27 @@ spec:
             capabilities:
               drop:
               - ALL
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthprobe
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthprobe
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          ports:
+            - containerPort: 8081
+              name: healthprobe
           resources:
             requests:
               cpu: 60m

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -47,11 +47,11 @@ func main() {
 
 	handlerNamespace := flag.String("handler-namespace", "nmstate", "Namespace for the NMState handler")
 	handlerImage := flag.String("handler-image", "", "Image for the NMState handler")
-	handlerPullPolicy := flag.String("handler-pull-policy", "Always", "Pull policy for the NMState handler image")
+	handlerPullPolicy := flag.String("handler-pull-policy", "IfNotPresent", "Pull policy for the NMState handler image")
 	handlerPrefix := flag.String("handler-prefix", "", "Name prefix for the NMState handler's resources")
 	operatorNamespace := flag.String("operator-namespace", "nmstate-operator", "Namespace for the NMState operator")
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
-	operatorPullPolicy := flag.String("operator-pull-policy", "Always", "Pull policy for the NMState operator image")
+	operatorPullPolicy := flag.String("operator-pull-policy", "IfNotPresent", "Pull policy for the NMState operator image")
 	monitoringNamespace := flag.String("monitoring-namespace", "monitoring", "Namespace for the cluster monitoring")
 	kubeRBACProxyImage := flag.String("kube-rbac-proxy-image", "", "Image for the kube RBAC proxy needed for metrics")
 	inputDir := flag.String("input-dir", "", "Input directory")


### PR DESCRIPTION
This change implements various operator best practices like defining various parameters listed below

- readiness probes for all the running containers
- liveness probes
- resource requests and limits
- terminationMessagePolicy
- image pull policy (IfNotPresent so that loss of image registry does not prevent pods from restarting)

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
