### PR TITLE
operator: Continue on cleanup NotFound errors

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -381,7 +381,7 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
 			},
 		})
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting obsolete cert-manager deployment at openshift: %w", err)
 		}
 
@@ -392,7 +392,7 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-webhook",
 			},
 		})
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting old webhook secret at openshift: %w", err)
 		}
 	}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The operator check if it has to remove old cert-manager stuff for openshift but it fails is they are not found, so it enters an Reconcile infinite loop.

This change just fail if there is an error but is different that NotFound.

**Release note**:
```release-note
operator: Continue on cleanup NotFound errors
```
