### PR TITLE
openshift, operator: Add workload annotation

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -197,6 +197,9 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: |
+                  {"effect": "PreferredDuringScheduling"}
               labels:
                 app: kubernetes-nmstate-operator
                 name: kubernetes-nmstate-operator

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -25,6 +25,8 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-metrics
       annotations:
         description: kubernetes-nmstate-metrics dump nmstate metrics
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -135,6 +137,8 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-webhook
       annotations:
         description: kubernetes-nmstate-webhook resets NNCP status
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -248,6 +252,8 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-cert-manager
       annotations:
         description: kubernetes-nmstate-webhook rotate webhook certs
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -340,6 +346,8 @@ spec:
         name: {{template "handlerPrefix" .}}nmstate-handler
       annotations:
         description: kubernetes-nmstate-handler configures and presents node networking, reconciling declerative NNCP and reports with NNS and NNCE
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
     spec:
       # Needed to force vlan filtering config with iproute commands until
       # future nmstate/NM is in place.

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -13,6 +13,9 @@ spec:
       name: kubernetes-nmstate-operator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
       labels:
         app: kubernetes-nmstate-operator
         name: kubernetes-nmstate-operator


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Openshift conformance is complaining with

```
{  fail [github.com/openshift/origin/test/extended/cpu_partitioning/pods.go:141]: Expected
    <[]error | len:1, cap:1>: [
        <*errors.errorString | 0xc007ce7e10>{
            s: "deployment (nmstate-operator) in openshift namespace (openshift-nmstate) must have pod templates annotated with map[target.workload.openshift.io/management:{\"effect\": \"PreferredDuringScheduling\"}]",
        },
    ]
to be empty
Ginkgo exit error 1: exit with code 1}
```

This change add the missing operator for openshift

**Release note**:

```release-note
openshift, operator: Add workload annotation
```

## Summary by Sourcery

Enhancements:
- Add conditional OpenShift-specific annotations to the operator deployment and pod template to comply with OpenShift workload management guidelines