### PR TITLE
handler, nncp: Retry on apply error

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -29,6 +29,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -90,6 +91,9 @@ func main() {
 			BindAddress: "0", // disable metrics
 		},
 		HealthProbeBindAddress: ":8081",
+		Cache: cache.Options{
+			Namespaces: []string{os.Getenv("HANDLER_NAMESPACE")},
+		},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrlOptions)

--- a/pkg/nmstatectl/errors.go
+++ b/pkg/nmstatectl/errors.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nmstatectl
+
+import (
+	"errors"
+	"fmt"
+)
+
+// NmstatectlApplyError represents an error that occurs during the nmstatectl apply operation.
+// It wraps the error.
+type NmstatectlApplyError struct {
+	err error // The underlying error
+}
+
+// NewNmstatectlApplyError creates a new NmstatectlApplyError.
+// It accepts an underlying error to wrap and returns an error that implements the NmstatectlApplyError type.
+func NewNmstatectlApplyError(err error) error {
+	return &NmstatectlApplyError{
+		err: err, // The underlying error being wrapped.
+	}
+}
+
+// Error implements the error interface for NmstatectlApplyError.
+// It returns a formatted string representation of the error.
+func (e *NmstatectlApplyError) Error() string {
+	return fmt.Sprintf("nmstatectl apply error: %v", e.err)
+}
+
+// IsNmstatectlApplyError checks if the given error is of type NmstatectlApplyError.
+// It uses errors.As to determine if the error or any wrapped error matches.
+func IsNmstatectlApplyError(err error) bool {
+	var target *NmstatectlApplyError
+	return errors.As(err, &target)
+}

--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -82,7 +82,10 @@ func Set(desiredState nmstate.State, timeout time.Duration) (string, error) {
 		[]string{"apply", "-v", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
 		string(desiredState.Raw),
 	)
-	return setOutput, err
+	if err != nil {
+		return "", NewNmstatectlApplyError(err)
+	}
+	return setOutput, nil
 }
 
 func Commit() (string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```

## Summary by Sourcery

Implement a retry mechanism for applying network configurations via `nmstatectl` to improve resilience against transient errors.

Bug Fixes:
- Retry `nmstatectl apply` calls upon failure to handle transient issues during network state application.
- Treat persistent `nmstatectl apply` failures as terminal errors to halt further reconciliation attempts for the affected resource.
- Introduce `NmstatectlApplyError` to specifically identify `nmstatectl apply` failures for targeted error handling.