### PR TITLE
makefile: pull policy depending on environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,17 @@ KUBE_RBAC_PROXY_IMAGE ?= $(KUBE_RBAC_PROXY_IMAGE_REGISTRY)/$(KUBE_RBAC_PROXY_FUL
 export HANDLER_NAMESPACE ?= nmstate
 export OPERATOR_NAMESPACE ?= $(HANDLER_NAMESPACE)
 export MONITORING_NAMESPACE ?= monitoring
+export IMAGE_BUILDER ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+
+# "Always" policy must be used only for development, never pushed to the production CSV
+INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+ifdef INTERACTIVE
+HANDLER_PULL_POLICY ?= Always
+OPERATOR_PULL_POLICY ?= Always
+else
 HANDLER_PULL_POLICY ?= IfNotPresent
 OPERATOR_PULL_POLICY ?= IfNotPresent
-export IMAGE_BUILDER ?= $(shell if podman ps >/dev/null 2>&1; then echo podman; elif docker ps >/dev/null 2>&1; then echo docker; fi)
+endif
 
 WHAT ?= ./pkg/... ./controllers/...
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

## Summary by Sourcery

Adjust the Makefile to dynamically choose container pull policy based on interactive environment and streamline image builder detection.

Enhancements:
- Detect and set pull policy to Always in interactive (development) sessions and default to IfNotPresent otherwise.
- Consolidate and relocate IMAGE_BUILDER detection for podman or docker to a single definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment setup for image building and pulling, with smarter detection of available tools and interactive sessions. Image pull policies now adapt automatically based on how the Makefile is run, ensuring more predictable behavior for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->