### PR TITLE
OPNET-673: Implement default network policy

### DIFF
--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -20,6 +20,7 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
+COPY deploy/handler/network_policy.yaml /bindata/kubernetes-nmstate/netpol/handler.yaml
 COPY deploy/openshift/ui-plugin/ /bindata/kubernetes-nmstate/openshift/ui-plugin/
 
 USER 1000

--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -13,6 +13,7 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
+COPY deploy/handler/network_policy.yaml /bindata/kubernetes-nmstate/netpol/handler.yaml
 COPY deploy/openshift/ui-plugin/ /bindata/kubernetes-nmstate/openshift/ui-plugin/
 
 ENTRYPOINT ["manager"]

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/nmstate/kubernetes-nmstate-operator:latest
-    createdAt: "2025-05-19T08:33:32Z"
+    createdAt: "2025-05-20T13:25:47Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
@@ -166,6 +166,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
         - apiGroups:
           - operator.openshift.io
           resources:

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -73,6 +73,7 @@ type NMStateReconciler struct {
 // +kubebuilder:rbac:groups="console.openshift.io",resources=consoleplugins,verbs="*"
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;get;watch;update
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=list;get;watch;update;create;patch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs="*"
 
 func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
@@ -145,6 +146,10 @@ func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx cont
 		return errors.Wrap(err, "failed applying RBAC")
 	}
 
+	if err := r.applyNetworkPolicies(instance); err != nil {
+		return errors.Wrap(err, "failed applying network policies")
+	}
+
 	if err := r.applyHandler(instance); err != nil {
 		return errors.Wrap(err, "failed applying Handler")
 	}
@@ -175,6 +180,20 @@ func (r *NMStateReconciler) applyNamespace(instance *nmstatev1.NMState) error {
 	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
 	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
 	return r.renderAndApply(instance, data, "namespace", false)
+}
+
+func (r *NMStateReconciler) applyNetworkPolicies(instance *nmstatev1.NMState) error {
+	data := render.MakeRenderData()
+	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
+	data.Data["PluginNamespace"] = os.Getenv("HANDLER_NAMESPACE")
+
+	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
+	if err != nil {
+		return err
+	}
+	data.Data["IsOpenShift"] = isOpenShift
+
+	return r.renderAndApply(instance, data, "netpol", true)
 }
 
 func (r *NMStateReconciler) applyRBAC(instance *nmstatev1.NMState) error {

--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-api-6443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+{{- if not .IsOpenShift }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cert-manager-egress-api-6443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-cert-manager
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-ingress-8443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-ingress-443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 443
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress-9443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9443
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress-443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 443
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-egress-api-6443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-egress-api-6443
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/deploy/openshift/ui-plugin/network_policy.yaml
+++ b/deploy/openshift/ui-plugin/network_policy.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-plugin-{{ .PluginName }}-ingress
+  namespace: {{ .PluginNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .PluginName }}
+      component: {{ .PluginName }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .PluginPort }}
+  policyTypes:
+    - Ingress

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -65,6 +65,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
   - operator.openshift.io
   resources:
   - consoles


### PR DESCRIPTION
This PR implements a default set of network policies that the operator will deploy. This is supposed to increase security of the cluster so that rogue workload in the operator namespace has limited access to the outside world.

The PR adds a set of policies for the operator container, webhook, metrics and console plugin. It adds a default "deny-all" policy for the whole namespace. As handler pod runs as privileged workload with host-networking, it is not necessary to implement policies there as they would not be applied anyway.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Operator now ships with a default set of network policies to limit the allowed network connectivity
```

## Summary by Sourcery

Implement default network policy enforcement for the operator namespace to restrict connectivity of operator workloads and associated components.

New Features:
- Introduce default deny-all and specific allow network policies for operator, webhook, metrics, console plugin, DNS, and API egress/ingress in the operator namespace.
- Add applyNetworkPolicies method in the reconciler and invoke it during NMState reconcile loop.
- Grant full RBAC permissions for managing networkpolicies in the operator and CSV deployment manifests.

Enhancements:
- Include network policy manifest files in deploy/handler and openshift UI plugin directories and update copyManifests logic to deploy them.
- Update operator CSV to reference networkpolicy RBAC and bump createdAt timestamp.

Deployment:
- Bundle network policy YAMLs in operator manifests for both generic and OpenShift deployments.

Tests:
- Add controller integration test to verify network policies are applied on reconcile.