### PR TITLE
operator: fix handicapped error messages

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -134,23 +134,19 @@ func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx context.Context) error {
 	if err := r.applyCRDs(instance); err != nil {
-		errors.Wrap(err, "failed applying CRDs")
-		return err
+		return errors.Wrap(err, "failed applying CRDs")
 	}
 
 	if err := r.applyNamespace(instance); err != nil {
-		errors.Wrap(err, "failed applying Namespace")
-		return err
+		return errors.Wrap(err, "failed applying Namespace")
 	}
 
 	if err := r.applyRBAC(instance); err != nil {
-		errors.Wrap(err, "failed applying RBAC")
-		return err
+		return errors.Wrap(err, "failed applying RBAC")
 	}
 
 	if err := r.applyHandler(instance); err != nil {
-		errors.Wrap(err, "failed applying Handler")
-		return err
+		return errors.Wrap(err, "failed applying Handler")
 	}
 
 	isOpenShift, err := cluster.IsOpenShift(r.APIClient)


### PR DESCRIPTION
For some reason the current implementation adds context to the error message but forgets to correctly return it. This commit changes this.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

## Summary by Sourcery

Bug Fixes:
- Return wrapped errors instead of the original errors when applying CRDs, namespace, RBAC, and handler manifests in applyManifests.