### PR TITLE
probes: Add nmstatectl show verbose output

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -57,6 +57,7 @@ import (
 	controllersmetrics "github.com/nmstate/kubernetes-nmstate/controllers/metrics"
 	"github.com/nmstate/kubernetes-nmstate/pkg/environment"
 	"github.com/nmstate/kubernetes-nmstate/pkg/file"
+	nmstatelog "github.com/nmstate/kubernetes-nmstate/pkg/log"
 	"github.com/nmstate/kubernetes-nmstate/pkg/monitoring"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 	"github.com/nmstate/kubernetes-nmstate/pkg/webhook"
@@ -263,8 +264,8 @@ func createHealthyFile() error {
 
 func checkNmstateIsWorking() error {
 	setupLog.Info("Checking availability of nmstatectl")
-	_, err := nmstatectl.Show()
-	if err != nil {
+	logWriter := nmstatelog.NewWriter(setupLog, 0)
+	if err := nmstatectl.ShowWithArgumentsAndOutputs([]string{"-vvv"}, logWriter, logWriter); err != nil {
 		setupLog.Error(err, "failed checking nmstatectl health")
 		return err
 	}

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -435,8 +435,9 @@ spec:
           livenessProbe:
             exec:
               command:
-              - nmstatectl
-              - show
+              - bash
+              - -c
+              - "nmstatectl show -vvv 2>&1"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+type Writer struct {
+	logger logr.Logger
+	level  int
+}
+
+func NewWriter(logger logr.Logger, level int) *Writer {
+	return &Writer{
+		logger: logger,
+		level:  level,
+	}
+}
+
+func (lw *Writer) Write(p []byte) (n int, err error) {
+	message := strings.TrimSpace(string(p))
+	lw.logger.V(lw.level).Info(message)
+	return len(p), nil
+}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:
Print verbose information at readiness and liveness probe so we can debug problems there with `nmstatectl show` on the system.

**Release note**:
```release-note
probes: Add nmstatectl show verbose output
```

## Summary by Sourcery

Stream verbose nmstatectl show output for readiness and liveness probes by refactoring the command runner to accept custom output writers and updating probe configurations to use verbose flags.

Enhancements:
- Refactor nmstatectl command execution to support custom stdout and stderr writers
- Introduce ShowWithArgumentsAndOutputs helper to run verbose nmstatectl show
- Update health check logic to invoke verbose nmstatectl show and pipe output to stdout/stderr
- Modify liveness probe in operator manifest to run `nmstatectl show -vv` via bash for verbose output