### PR TITLE
automation: Dump pods at individual files

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -9,15 +9,13 @@
 
 teardown() {
     ./cluster/kubectl.sh get pod -n nmstate -o wide > $ARTIFACTS/kubernetes-nmstate.pod.list.txt || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.describe.logs || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.describe.logs || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.describe.logs || true
+    for pod in $(./cluster/kubectl.sh get pod -n nmstate -o name); do
+        pod_name=$(echo $pod|sed "s#pod/##")
+        ./cluster/kubectl.sh -n nmstate logs --prefix=true $pod  > $ARTIFACTS/$pod_name.log || true
+        ./cluster/kubectl.sh -n nmstate logs -p --prefix=true $pod  > $ARTIFACTS/$pod_name.previous.log || true
+        ./cluster/kubectl.sh -n nmstate describe $pod  > $ARTIFACTS/$pod_name.describe.log || true
+    done
+    ./cluster/kubectl.sh get events -n nmstate > $ARTIFACTS/nmstate-events.logs || true
     ./cluster/kubectl.sh get events > $ARTIFACTS/cluster-events.logs || true
     make cluster-down
     # Don't fail if there is no logs

--- a/automation/check-patch.e2e-upgrade-k8s.sh
+++ b/automation/check-patch.e2e-upgrade-k8s.sh
@@ -9,16 +9,16 @@
 
 teardown() {
     ./cluster/kubectl.sh get pod -n nmstate -o wide > $ARTIFACTS/kubernetes-nmstate.pod.list.txt || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l app=kubernetes-nmstate > $ARTIFACTS/kubernetes-nmstate.pod.describe.logs || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l app=kubernetes-nmstate-operator > $ARTIFACTS/kubernetes-nmstate-operator.pod.describe.logs || true
-    ./cluster/kubectl.sh logs --tail=1000 -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.logs || true
-    ./cluster/kubectl.sh logs -p --tail=1000 -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.previous.logs || true
-    ./cluster/kubectl.sh describe pods -n nmstate -l component=kubernetes-nmstate-webhook > $ARTIFACTS/kubernetes-nmstate-webhook.pod.describe.logs || true
     ./cluster/kubectl.sh get events > $ARTIFACTS/cluster-events.logs || true
+    for pod in $(./cluster/kubectl.sh get pod -n nmstate -o name); do
+        pod_name=$(echo $pod|sed "s#pod/##")
+        ./cluster/kubectl.sh -n nmstate logs --prefix=true $pod  > $ARTIFACTS/$pod_name.log || true
+        ./cluster/kubectl.sh -n nmstate logs -p --prefix=true $pod  > $ARTIFACTS/$pod_name.previous.log || true
+        ./cluster/kubectl.sh -n nmstate describe $pod  > $ARTIFACTS/$pod_name.describe.log || true
+    done
+    ./cluster/kubectl.sh get events -n nmstate > $ARTIFACTS/nmstate-events.logs || true
+    ./cluster/kubectl.sh get events > $ARTIFACTS/cluster-events.logs || true
+
     make cluster-down
     # Don't fail if there is no logs
     cp -r ${E2E_LOGS}/operator/* ${ARTIFACTS} || true


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

## Summary by Sourcery

Refactor E2E teardown scripts to uniformly dump logs, previous logs, and descriptions for each pod into separate files and add namespace-specific event collection

Enhancements:
- Replace hard-coded label-based log collection with a loop that captures logs, previous logs, and descriptions for each pod individually
- Add explicit capture of events in the nmstate namespace in addition to cluster-wide events