### PR TITLE
Fix NNCP Progressing condition reason for successful configuration

### DIFF
--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -89,7 +89,7 @@ func SetPolicySuccess(conditions *nmstate.ConditionList, message string) {
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
 		corev1.ConditionFalse,
-		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		nmstate.NodeNetworkConfigurationPolicyConditionSuccessfullyConfigured,
 		"",
 	)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

This PR fixes an inconsistency in NodeNetworkConfigurationPolicy status conditions when a policy is successfully applied. 

Currently, when a NNCP is successfully configured, the condition reasons are inconsistent:
- `Available` condition: `reason: SuccessfullyConfigured` ✅
- `Degraded` condition: `reason: SuccessfullyConfigured` ✅  
- `Progressing` condition: `reason: ConfigurationProgressing` ❌

This creates confusion for users and operators monitoring policy status, as the `Progressing` condition uses a different reason despite the policy being in the same successful state.

The fix changes the `SetPolicySuccess` function in `pkg/policyconditions/conditions.go` to use `SuccessfullyConfigured` as the reason for the `Progressing` condition, making all three conditions consistent when a policy succeeds.

**Special notes for your reviewer**:

- The change is minimal and only affects one line in the `SetPolicySuccess` function
- All existing tests pass, confirming no regression
- The fix only impacts the successful case - failure and progressing scenarios remain unchanged
- This improves consistency and reduces confusion for users monitoring NNCP status

NOTE: This is a cursor generated PR, and reviewed by human.

**Release note**:

```release-note
Fix NodeNetworkConfigurationPolicy Progressing condition to use consistent reason when policy is successfully applied
```

## **Steps to complete the PR:**

1. **Title**: Use the title above
2. **Description**: Paste the formatted description above
3. **Base branch**: Make sure it's targeting `nmstate/kubernetes-nmstate:main`
4. **Reviewers**: Add any relevant reviewers if you know who should review this
5. **Labels**: The `/kind bug` in the description should automatically add the `kind/bug` label

Then click **"Create pull request"** and you're all set! 🚀

The PR will be properly formatted according to the project's template and ready for review.