### PR TITLE
netpol: use targeted policy for deny-all

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/nmstate/kubernetes-nmstate-operator:latest
-    createdAt: "2025-05-20T13:25:47Z"
+    createdAt: "2025-07-03T14:30:18Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
@@ -248,6 +248,8 @@ spec:
                   value: nmstate
                 - name: MONITORING_NAMESPACE
                   value: monitoring
+                - name: OPERATOR_NAMESPACE
+                  value: nmstate
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -185,6 +185,7 @@ func (r *NMStateReconciler) applyNamespace(instance *nmstatev1.NMState) error {
 func (r *NMStateReconciler) applyNetworkPolicies(instance *nmstatev1.NMState) error {
 	data := render.MakeRenderData()
 	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
+	data.Data["OperatorNamespace"] = os.Getenv("OPERATOR_NAMESPACE")
 	data.Data["PluginNamespace"] = os.Getenv("HANDLER_NAMESPACE")
 
 	isOpenShift, err := cluster.IsOpenShift(r.APIClient)

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -76,6 +76,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		}
 		handlerPrefix       = "handler"
 		handlerNamespace    = "nmstate"
+		operatorNamespace   = "nmstate"
 		handlerKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
 		webhookKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
 		handlerImage        = "quay.io/some_image"
@@ -105,6 +106,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		reconciler.Scheme = s
 		reconciler.Log = ctrl.Log.WithName("controllers").WithName("NMState")
 		os.Setenv("HANDLER_NAMESPACE", handlerNamespace)
+		os.Setenv("OPERATOR_NAMESPACE", operatorNamespace)
 		os.Setenv("RELATED_IMAGE_HANDLER_IMAGE", handlerImage)
 		os.Setenv("HANDLER_IMAGE_PULL_POLICY", imagePullPolicy)
 		os.Setenv("HANDLER_PREFIX", handlerPrefix)

--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-operator-egress-api-6443
-  namespace: {{ .HandlerNamespace }}
+  namespace: {{ .OperatorNamespace }}
 spec:
   podSelector:
     matchLabels:
@@ -139,10 +139,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny
+  name: default-deny-labelled-operator
+  namespace: {{ .OperatorNamespace }}
+spec:
+  podSelector:
+  matchLabels:
+    app: kubernetes-nmstate-operator
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-labelled-operand
   namespace: {{ .HandlerNamespace }}
 spec:
-  podSelector: {}
+  podSelector:
+  matchLabels:
+    app: kubernetes-nmstate
   policyTypes:
     - Ingress
     - Egress

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -107,5 +107,7 @@ spec:
               value: {{ .HandlerNamespace }}
             - name: MONITORING_NAMESPACE
               value: {{ .MonitoringNamespace }}
+            - name: OPERATOR_NAMESPACE
+              value: {{ .OperatorNamespace }}
             - name: KUBE_RBAC_PROXY_IMAGE
               value: {{ .KubeRBACProxyImage }}


### PR DESCRIPTION
This commit changes the deny-all policy from targetting the whole namespace to targetting only labelled workload. This will help with cases when operator runs in a shared namespace and not its own unique.

We require this because with OLM deployment method we do not really forbid users from using a shared namespace.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

## Summary by Sourcery

Scope the deny-all network policies to only the operator and operand workloads by using per-pod label selectors, and introduce the OPERATOR_NAMESPACE parameter across deployment configs, controller logic, and tests to support this change

New Features:
- Scope default-deny network policies to only labelled operator and operand pods rather than entire namespaces

Enhancements:
- Introduce and propagate OPERATOR_NAMESPACE for rendering targeted network policies in the reconciler

Deployment:
- Add OPERATOR_NAMESPACE environment variable to the operator deployment manifest

Tests:
- Set OPERATOR_NAMESPACE environment variable in unit tests to support targeted network policy logic