### PR TITLE
Make lint.sh download and execution compatible with Darwin/arm64

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,14 +1,17 @@
 #!/bin/bash -xe
 architecture=""
 case $(uname -m) in
-    x86_64) architecture="amd64" ;;
-    arm64)    architecture="arm64" ;;
+    x86_64)           architecture="amd64" ;;
+    aarch64|arm64)    architecture="arm64" ;;
+    *)
+                      echo "Unsupported architecture: $(uname -m), must be (x86_64|aarch64|arm64)."
+                      exit 1;
 esac
 
-path_combined="$(uname -s | tr "[:upper:]" "[:lower:]")"-${architecture}
+path_combined="$(uname -s | tr '[:upper:]' '[:lower:]')-${architecture}"
 golangci_lint_version=1.64.7
-golangci_lint_url=https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz
-golangci_cmd=/tmp/golangci-lint-${golangci_lint_version}-${path_combined}/golangci-lint
+golangci_lint_url="https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz"
+golangci_cmd="/tmp/golangci-lint-${golangci_lint_version}-${path_combined}/golangci-lint"
 if [ ! -f "${golangci_cmd}" ]; then
     curl -Lk $golangci_lint_url -o /tmp/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz
     tar -xvzf /tmp/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz -C /tmp

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,10 +1,17 @@
 #!/bin/bash -xe
+architecture=""
+case $(uname -m) in
+    x86_64) architecture="amd64" ;;
+    arm64)    architecture="arm64" ;;
+esac
+
+path_combined="$(uname -s | tr "[:upper:]" "[:lower:]")"-${architecture}
 golangci_lint_version=1.64.7
-golangci_lint_url=https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz
-golangci_cmd=/tmp/golangci-lint-${golangci_lint_version}-linux-amd64/golangci-lint
+golangci_lint_url=https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz
+golangci_cmd=/tmp/golangci-lint-${golangci_lint_version}-${path_combined}/golangci-lint
 if [ ! -f "${golangci_cmd}" ]; then
-    curl -Lk $golangci_lint_url -o /tmp/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz
-    tar -xvzf /tmp/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz -C /tmp
+    curl -Lk $golangci_lint_url -o /tmp/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz
+    tar -xvzf /tmp/golangci-lint-${golangci_lint_version}-${path_combined}.tar.gz -C /tmp
     chmod 755 ${golangci_cmd}
 fi
 ${golangci_cmd} run --timeout 20m0s


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
A previous PR addressed compatibility with Darwin/arm64 machines. In that process the make target `lint` has been forgotten. This PR is adding support to Darwin/arm64 machines for said target.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved platform compatibility for the linting script, allowing it to automatically detect and support different operating systems and architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->