### PR TITLE
OPNET-81: Add Ignored status for NNCP when no node is matching the node selector.

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -62,6 +62,7 @@ const (
 	NodeNetworkConfigurationPolicyConditionAvailable   ConditionType = "Available"
 	NodeNetworkConfigurationPolicyConditionDegraded    ConditionType = "Degraded"
 	NodeNetworkConfigurationPolicyConditionProgressing ConditionType = "Progressing"
+	NodeNetworkConfigurationPolicyConditionIgnored     ConditionType = "Ignored"
 )
 
 var NodeNetworkConfigurationPolicyConditionTypes = [...]ConditionType{

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -70,6 +70,12 @@ func SetPolicyProgressing(conditions *nmstate.ConditionList, message string) {
 		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
 		message,
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionIgnored,
+		corev1.ConditionUnknown,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
+	)
 }
 
 func SetPolicySuccess(conditions *nmstate.ConditionList, message string) {
@@ -92,10 +98,22 @@ func SetPolicySuccess(conditions *nmstate.ConditionList, message string) {
 		nmstate.NodeNetworkConfigurationPolicyConditionSuccessfullyConfigured,
 		"",
 	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionIgnored,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationPolicyConditionSuccessfullyConfigured,
+		"",
+	)
 }
 
 func SetPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
 	log.Info("SetPolicyNotMatching")
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionIgnored,
+		corev1.ConditionTrue,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationNoMatchingNode,
+		message,
+	)
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionDegraded,
 		corev1.ConditionFalse,
@@ -104,7 +122,7 @@ func SetPolicyNotMatching(conditions *nmstate.ConditionList, message string) {
 	)
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionAvailable,
-		corev1.ConditionTrue,
+		corev1.ConditionFalse,
 		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationNoMatchingNode,
 		message,
 	)
@@ -132,6 +150,12 @@ func SetPolicyFailedToConfigure(conditions *nmstate.ConditionList, message strin
 	)
 	conditions.Set(
 		nmstate.NodeNetworkConfigurationPolicyConditionProgressing,
+		corev1.ConditionFalse,
+		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
+		"",
+	)
+	conditions.Set(
+		nmstate.NodeNetworkConfigurationPolicyConditionIgnored,
 		corev1.ConditionFalse,
 		nmstate.NodeNetworkConfigurationPolicyConditionConfigurationProgressing,
 		"",

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -62,6 +62,7 @@ const (
 	NodeNetworkConfigurationPolicyConditionAvailable   ConditionType = "Available"
 	NodeNetworkConfigurationPolicyConditionDegraded    ConditionType = "Degraded"
 	NodeNetworkConfigurationPolicyConditionProgressing ConditionType = "Progressing"
+	NodeNetworkConfigurationPolicyConditionIgnored     ConditionType = "Ignored"
 )
 
 var NodeNetworkConfigurationPolicyConditionTypes = [...]ConditionType{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
As per the design proposal in #1348 I have added a `Ignored` status to the NNCP.
This status is being set to ConditionTrue when there is no matching nodes for a given NNCP.
This is supposed to help admins by indicating the lack of nodes in a central point with high visibility.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The NNCP status will indicate status `Ignored` when no node is matching the node selector.
```
