### PR TITLE
NMT-1521: Add per interface ipv4 forwarding test.

### DIFF
--- a/docs/examples/per-interface-ipv4-forwarding.yaml
+++ b/docs/examples/per-interface-ipv4-forwarding.yaml
@@ -1,0 +1,14 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: per-interface-ipv4-forwarding
+spec:
+  desiredState:
+    interfaces:
+      - name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          dhcp: true
+          enabled: true
+          forwarding: true

--- a/test/doc/examples.go
+++ b/test/doc/examples.go
@@ -54,6 +54,12 @@ interfaces:
 			IfaceNames: []string{"eth1"},
 		},
 		{
+			Name:       "Per interface IPv4 forwarding",
+			FileName:   "per-interface-ipv4-forwarding.yaml",
+			PolicyName: "per-interface-ipv4-forwarding",
+			IfaceNames: []string{"eth1"},
+		},
+		{
 			Name:       "Linux bridge",
 			FileName:   "linux-bridge.yaml",
 			PolicyName: "linux-bridge",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

 /kind enhancement

**What this PR does / why we need it**:
As discussed with @qinqon we're introducing an example test for per interface ipv4 forwarding.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example manifest demonstrating per-interface IPv4 forwarding using a NodeNetworkConfigurationPolicy. The example targets interface eth1, sets it up, enables IPv4 with DHCP, and turns on forwarding.
* **Tests**
  * Expanded example coverage by adding a corresponding test entry for the new per-interface IPv4 forwarding example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->