### PR TITLE
OCPBUGS-57067: Remove arch node selector

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -260,16 +259,6 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		Key:      "",
 		Operator: corev1.TolerationOpExists,
 	}
-	archNodeSelector := map[string]string{
-		"kubernetes.io/arch": goruntime.GOARCH,
-	}
-	archAndCRNodeSelector := instance.Spec.NodeSelector
-	if archAndCRNodeSelector == nil {
-		archAndCRNodeSelector = map[string]string{
-			"kubernetes.io/arch": goruntime.GOARCH,
-			"kubernetes.io/os":   "linux",
-		}
-	}
 	handlerTolerations := instance.Spec.Tolerations
 	if handlerTolerations == nil {
 		handlerTolerations = []corev1.Toleration{operatorExistsToleration}
@@ -279,11 +268,17 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		handlerAffinity = &corev1.Affinity{}
 	}
 
-	archAndCRInfraNodeSelector := instance.Spec.InfraNodeSelector
-	if archAndCRInfraNodeSelector == nil {
-		archAndCRInfraNodeSelector = archNodeSelector
-	} else {
-		archAndCRInfraNodeSelector["kubernetes.io/arch"] = goruntime.GOARCH
+	nodeSelector := instance.Spec.NodeSelector
+	if nodeSelector == nil {
+		nodeSelector = map[string]string{
+			corev1.LabelOSStable: "linux",
+		}
+	}
+	infraNodeSelector := instance.Spec.InfraNodeSelector
+	if infraNodeSelector == nil {
+		infraNodeSelector = map[string]string{
+			corev1.LabelOSStable: "linux",
+		}
 	}
 
 	infraTolerations := instance.Spec.InfraTolerations
@@ -323,7 +318,7 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		}
 	}
 
-	webhookReplicaCountMin, webhookReplicaCountDesired, err := r.webhookReplicaCount(ctx, archAndCRInfraNodeSelector, infraTolerations)
+	webhookReplicaCountMin, webhookReplicaCountDesired, err := r.webhookReplicaCount(ctx, infraNodeSelector, infraTolerations)
 	if err != nil {
 		return fmt.Errorf("could not get min replica count for webhook: %w", err)
 	}
@@ -360,12 +355,12 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
 	data.Data["MonitoringNamespace"] = os.Getenv("MONITORING_NAMESPACE")
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
-	data.Data["InfraNodeSelector"] = archAndCRInfraNodeSelector
+	data.Data["InfraNodeSelector"] = infraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations
 	data.Data["WebhookAffinity"] = infraAffinity
 	data.Data["WebhookReplicas"] = webhookReplicaCountDesired
 	data.Data["WebhookMinReplicas"] = webhookReplicaCountMin
-	data.Data["HandlerNodeSelector"] = archAndCRNodeSelector
+	data.Data["HandlerNodeSelector"] = nodeSelector
 	data.Data["HandlerTolerations"] = handlerTolerations
 	data.Data["HandlerAffinity"] = handlerAffinity
 	data.Data["SelfSignConfiguration"] = selfSignConfiguration

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -96,7 +95,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		cl                         client.Client
 		reconciler                 NMStateReconciler
 		existingNMStateName        = "nmstate"
-		defaultHandlerNodeSelector = map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": goruntime.GOARCH}
+		defaultHandlerNodeSelector = map[string]string{corev1.LabelOSStable: "linux"}
 		customHandlerNodeSelector  = map[string]string{"selector_1": "value_1", "selector_2": "value_2"}
 		handlerTolerations         = []corev1.Toleration{
 			{


### PR DESCRIPTION
This product supports more than a single architecture. Yet, the code is written in a way that it will only deploy pods on the architecture that matches the architecture of the first node where the controller container is running.

As a result, it does not work in multi-arch clusters. If your controller got scheduled in amd64 node, all the containers will only run on amd64 nodes. Similarly if you got scheduled first in arm, it only runs on arm.

This change removes the architecture node selector completely. As a result, we will try scheduling on every node. There may be a side effect that if you have cluster with some exotic nodes they will not run successfully. But if this is the case, NMstate CR has ability to write a custom node selector.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Node selector limiting deployment to a single architecture has been removed. Pods will now try to run on every node in the cluster. In rare cases when this is undesired, custom nodeSelector field in NMstate CR can be set.
```
