### PR TITLE
Clean up UnavailableNodeCountMap in NNCP Status field after reconcile

### DIFF
--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -20,6 +20,7 @@ package policyconditions
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
The AI review of the NNCP retry PR brought up an issue where at some point the Map that is used to track the unavailable node count per generation in the status field of the NNCP will eventually get bigger and bigger to the point where it will exceed the 1.5MB limit for the status field and cause issues. This PR will clear the the entire map when the NNCP will become available.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
