### PR TITLE
Introduce proper context instead of TODO

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -419,7 +419,7 @@ func lockHandler() (*flock.Flock, error) {
 	setupLog.Info(fmt.Sprintf("Try to take exclusive lock on file: %s", lockFilePath))
 	handlerLock := flock.New(lockFilePath)
 	interval := 5 * time.Second
-	err := wait.PollUntilContextCancel(context.TODO(), interval, true, /*immediate*/
+	err := wait.PollUntilContextCancel(context.Background(), interval, true, /*immediate*/
 		func(context.Context) (done bool, err error) {
 			locked, err := handlerLock.TryLock()
 			if err != nil {

--- a/controllers/handler/node_controller.go
+++ b/controllers/handler/node_controller.go
@@ -45,6 +45,7 @@ import (
 
 // Added for test purposes
 type NmstateUpdater func(
+	ctx context.Context,
 	client client.Client,
 	node *corev1.Node,
 	observedState shared.State,
@@ -81,7 +82,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 	}
 
 	nnsInstance := &nmstatev1beta1.NodeNetworkState{}
-	err = r.Client.Get(context.TODO(), request.NamespacedName, nnsInstance)
+	err = r.Client.Get(ctx, request.NamespacedName, nnsInstance)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, errors.Wrap(err, "Failed to get nnstate")
@@ -98,7 +99,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 
 	// Fetch the Node instance
 	nodeInstance := &corev1.Node{}
-	err = r.Client.Get(context.TODO(), request.NamespacedName, nodeInstance)
+	err = r.Client.Get(ctx, request.NamespacedName, nodeInstance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -109,7 +110,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (c
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-	err = r.nmstateUpdater(r.Client, nodeInstance, currentState, nnsInstance, r.getDependencyVersions())
+	err = r.nmstateUpdater(ctx, r.Client, nodeInstance, currentState, nnsInstance, r.getDependencyVersions())
 	if err != nil {
 		err = errors.Wrap(err, "error at node reconcile creating NodeNetworkState")
 		return ctrl.Result{}, err

--- a/controllers/handler/node_controller_test.go
+++ b/controllers/handler/node_controller_test.go
@@ -131,7 +131,7 @@ routes:
 			By("Set last state")
 			reconciler.lastState = filteredOutObservedState
 
-			reconciler.nmstateUpdater = func(client.Client, *corev1.Node,
+			reconciler.nmstateUpdater = func(context.Context, client.Client, *corev1.Node,
 				shared.State, *nmstatev1beta1.NodeNetworkState, *nmstate.DependencyVersions) error {
 				return fmt.Errorf("we are not suppose to catch this error")
 			}

--- a/controllers/handler/nodenetworkconfigurationenactment_controller.go
+++ b/controllers/handler/nodenetworkconfigurationenactment_controller.go
@@ -54,7 +54,7 @@ func (r *NodeNetworkConfigurationEnactmentReconciler) Reconcile(ctx context.Cont
 
 	// Fetch the NodeNetworkConfigurationEnactment instance
 	enactmentInstance := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, enactmentInstance)
+	err := r.Client.Get(ctx, request.NamespacedName, enactmentInstance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -69,11 +69,11 @@ func (r *NodeNetworkConfigurationEnactmentReconciler) Reconcile(ctx context.Cont
 
 	policyName := enactmentInstance.Labels[shared.EnactmentPolicyLabel]
 	policyInstance := &nmstatev1.NodeNetworkConfigurationPolicy{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: policyName}, policyInstance)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: policyName}, policyInstance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Policy is not found, removing the enactment")
-			err = r.Client.Delete(context.TODO(), enactmentInstance)
+			err = r.Client.Delete(ctx, enactmentInstance)
 			return ctrl.Result{}, err
 		}
 		log.Error(err, "Error retrieving policy")

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -337,7 +337,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				reconciler.Client = cl
 				reconciler.APIClient = cl
 
-				err := reconciler.decrementUnavailableNodeCount(nncp, "gen-1")
+				err := reconciler.decrementUnavailableNodeCount(context.TODO(), nncp, "gen-1")
 
 				Expect(err).To(BeNil())
 
@@ -361,7 +361,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				reconciler.Client = cl
 				reconciler.APIClient = cl
 
-				err := reconciler.decrementUnavailableNodeCount(nncp, "gen-1")
+				err := reconciler.decrementUnavailableNodeCount(context.TODO(), nncp, "gen-1")
 
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring("not found"))
@@ -390,7 +390,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				reconciler.Client = cl
 				reconciler.APIClient = cl
 
-				err := reconciler.decrementUnavailableNodeCount(nncpZeroCount, "gen-1")
+				err := reconciler.decrementUnavailableNodeCount(context.TODO(), nncpZeroCount, "gen-1")
 
 				// Should not return error - this is expected when node already processed
 				Expect(err).To(BeNil())
@@ -409,7 +409,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				reconciler.APIClient = cl
 
 				// Try to decrement a generation key that doesn't exist
-				err := reconciler.decrementUnavailableNodeCount(nncp, "non-existent-gen")
+				err := reconciler.decrementUnavailableNodeCount(context.TODO(), nncp, "non-existent-gen")
 
 				// Should not return error - this is expected when node already processed
 				Expect(err).To(BeNil())

--- a/controllers/metrics/nodenetworkconfigurationenactment_controller.go
+++ b/controllers/metrics/nodenetworkconfigurationenactment_controller.go
@@ -55,7 +55,7 @@ func (r *NodeNetworkConfigurationEnactmentReconciler) Reconcile(ctx context.Cont
 	log.Info("Reconcile")
 
 	enactmentInstance := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, enactmentInstance)
+	err := r.Client.Get(ctx, request.NamespacedName, enactmentInstance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// NNCE has being delete let's clean the old NNCEs map

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -56,7 +56,7 @@ type DependencyVersions struct {
 	HostNmstateVersion    string
 }
 
-func InitializeNodeNetworkState(cli client.Client, node *corev1.Node) (*nmstatev1beta1.NodeNetworkState, error) {
+func InitializeNodeNetworkState(ctx context.Context, cli client.Client, node *corev1.Node) (*nmstatev1beta1.NodeNetworkState, error) {
 	ownerRefList := []metav1.OwnerReference{{Name: node.ObjectMeta.Name, Kind: "Node", APIVersion: "v1", UID: node.UID}}
 
 	nodeNetworkState := nmstatev1beta1.NodeNetworkState{
@@ -68,7 +68,7 @@ func InitializeNodeNetworkState(cli client.Client, node *corev1.Node) (*nmstatev
 		},
 	}
 
-	err := cli.Create(context.TODO(), &nodeNetworkState)
+	err := cli.Create(ctx, &nodeNetworkState)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NodeNetworkState: %v, %+v", err, nodeNetworkState)
 	}
@@ -77,6 +77,7 @@ func InitializeNodeNetworkState(cli client.Client, node *corev1.Node) (*nmstatev
 }
 
 func CreateOrUpdateNodeNetworkState(
+	ctx context.Context,
 	cli client.Client,
 	node *corev1.Node,
 	observedState shared.State,
@@ -85,15 +86,16 @@ func CreateOrUpdateNodeNetworkState(
 ) error {
 	if nns == nil {
 		var err error
-		nns, err = InitializeNodeNetworkState(cli, node)
+		nns, err = InitializeNodeNetworkState(ctx, cli, node)
 		if err != nil {
 			return err
 		}
 	}
-	return UpdateCurrentState(cli, nns, observedState, versions)
+	return UpdateCurrentState(ctx, cli, nns, observedState, versions)
 }
 
 func UpdateCurrentState(
+	ctx context.Context,
 	cli client.Client,
 	nodeNetworkState *nmstatev1beta1.NodeNetworkState,
 	observedState shared.State,
@@ -110,7 +112,7 @@ func UpdateCurrentState(
 	nodeNetworkState.Status.CurrentState = observedState
 	nodeNetworkState.Status.LastSuccessfulUpdateTime = metav1.Time{Time: time.Now()}
 
-	err := cli.Status().Update(context.Background(), nodeNetworkState)
+	err := cli.Status().Update(ctx, nodeNetworkState)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return errors.Wrap(err, "Request object not found, could have been deleted after reconcile request")
@@ -134,7 +136,7 @@ func ExecuteCommand(command string, arguments ...string) (string, error) {
 	return string(bytes.Trim(stdout.Bytes(), "\n")), nil
 }
 
-func rollback(cli client.Client, probes []probe.Probe, cause error) error {
+func rollback(ctx context.Context, cli client.Client, probes []probe.Probe, cause error) error {
 	message := fmt.Sprintf("rolling back desired state configuration: %s", cause)
 	err := nmstatectl.Rollback()
 	if err != nil {
@@ -142,21 +144,21 @@ func rollback(cli client.Client, probes []probe.Probe, cause error) error {
 	}
 
 	// wait for system to settle after rollback
-	probesErr := probe.Run(cli, probes)
+	probesErr := probe.Run(ctx, cli, probes)
 	if probesErr != nil {
 		return errors.Wrap(errors.Wrap(probesErr, "failed running probes after rollback"), message)
 	}
 	return errors.New(message)
 }
 
-func ApplyDesiredState(cli client.Client, desiredState shared.State) (string, error) {
+func ApplyDesiredState(ctx context.Context, cli client.Client, desiredState shared.State) (string, error) {
 	if string(desiredState.Raw) == "" {
 		return "Ignoring empty desired state", nil
 	}
 
 	// Before apply we get the probes that are working fine, they should be
 	// working fine after apply
-	probes := probe.Select(cli)
+	probes := probe.Select(ctx, cli)
 
 	// Rollback before Apply to remove pending checkpoints (for example handler pod restarted
 	// before Commit)
@@ -167,9 +169,9 @@ func ApplyDesiredState(cli client.Client, desiredState shared.State) (string, er
 		return setOutput, err
 	}
 
-	err = probe.Run(cli, probes)
+	err = probe.Run(ctx, cli, probes)
 	if err != nil {
-		return "", rollback(cli, probes, errors.Wrap(err, "failed runnig probes after network changes"))
+		return "", rollback(ctx, cli, probes, errors.Wrap(err, "failed runnig probes after network changes"))
 	}
 
 	commitOutput, err := nmstatectl.Commit()

--- a/pkg/enactment/enactment.go
+++ b/pkg/enactment/enactment.go
@@ -28,10 +28,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CountByPolicy(cli client.Reader, policy *nmstatev1.NodeNetworkConfigurationPolicy) (int, enactmentconditions.ConditionCount, error) {
+func CountByPolicy(
+	ctx context.Context,
+	cli client.Reader,
+	policy *nmstatev1.NodeNetworkConfigurationPolicy,
+) (int, enactmentconditions.ConditionCount, error) {
 	enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
 	policyLabelFilter := client.MatchingLabels{nmstateapi.EnactmentPolicyLabel: policy.GetName()}
-	err := cli.List(context.TODO(), &enactments, policyLabelFilter)
+	err := cli.List(ctx, &enactments, policyLabelFilter)
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "getting enactment list failed")
 	}

--- a/pkg/enactmentstatus/conditions/counter.go
+++ b/pkg/enactmentstatus/conditions/counter.go
@@ -132,6 +132,7 @@ func (c CountByConditionStatus) String() string {
 type LogicalConditionCountFilter map[nmstate.ConditionType]corev1.ConditionStatus
 
 func CountConditionsLogicalAnd(
+	ctx context.Context,
 	cli client.Client,
 	policy *nmstatev1.NodeNetworkConfigurationPolicy,
 	filter LogicalConditionCountFilter) (int, error) {
@@ -139,7 +140,7 @@ func CountConditionsLogicalAnd(
 	enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
 	policyLabelFilter := client.MatchingLabels{nmstate.EnactmentPolicyLabel: policy.Name}
 
-	if err := cli.List(context.TODO(), &enactments, policyLabelFilter); err != nil {
+	if err := cli.List(ctx, &enactments, policyLabelFilter); err != nil {
 		return 0, fmt.Errorf("getting enactments failed: %w", err)
 	}
 

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -43,16 +43,16 @@ func (f MaxUnavailableLimitReachedError) Error() string {
 	return "maximal number of nodes are already processing policy configuration"
 }
 
-func NodesRunningNmstate(cli client.Reader, nodeSelector map[string]string) ([]corev1.Node, error) {
+func NodesRunningNmstate(ctx context.Context, cli client.Reader, nodeSelector map[string]string) ([]corev1.Node, error) {
 	nodes := corev1.NodeList{}
-	err := cli.List(context.TODO(), &nodes, client.MatchingLabels(nodeSelector))
+	err := cli.List(ctx, &nodes, client.MatchingLabels(nodeSelector))
 	if err != nil {
 		return []corev1.Node{}, errors.Wrap(err, "getting nodes failed")
 	}
 
 	pods := corev1.PodList{}
 	byComponent := client.MatchingLabels{"component": "kubernetes-nmstate-handler"}
-	err = cli.List(context.TODO(), &pods, byComponent)
+	err = cli.List(ctx, &pods, byComponent)
 	if err != nil {
 		return []corev1.Node{}, errors.Wrap(err, "getting pods failed")
 	}
@@ -88,8 +88,8 @@ func isReady(node *corev1.Node) bool {
 	return false
 }
 
-func MaxUnavailableNodeCount(cli client.Reader, policy *nmstatev1.NodeNetworkConfigurationPolicy) (int, error) {
-	enactmentsTotal, _, err := enactment.CountByPolicy(cli, policy)
+func MaxUnavailableNodeCount(ctx context.Context, cli client.Reader, policy *nmstatev1.NodeNetworkConfigurationPolicy) (int, error) {
+	enactmentsTotal, _, err := enactment.CountByPolicy(ctx, cli, policy)
 	if err != nil {
 		return MinMaxunavailable, err
 	}

--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -178,13 +178,13 @@ func IsUnknown(conditions *nmstate.ConditionList) bool {
 	return availableCondition.Status == corev1.ConditionUnknown
 }
 
-func Update(cli client.Client, apiReader client.Reader, policyKey types.NamespacedName) error {
+func Update(ctx context.Context, cli client.Client, apiReader client.Reader, policyKey types.NamespacedName) error {
 	logger := log.WithValues("policy", policyKey.Name)
 
-	err := update(cli, apiReader, cli, policyKey)
+	err := update(ctx, cli, apiReader, cli, policyKey)
 	if err != nil {
 		logger.Error(err, "failed to update policy status using cached client. Retrying with non-cached.")
-		err = update(cli, apiReader, apiReader, policyKey)
+		err = update(ctx, cli, apiReader, apiReader, policyKey)
 		if err != nil {
 			logger.Error(err, "failed to update policy status using non-cached client.")
 		}
@@ -193,7 +193,13 @@ func Update(cli client.Client, apiReader client.Reader, policyKey types.Namespac
 }
 
 //nolint:gocritic
-func update(apiWriter client.Client, apiReader client.Reader, policyReader client.Reader, policyKey types.NamespacedName) error {
+func update(
+	ctx context.Context,
+	apiWriter client.Client,
+	apiReader client.Reader,
+	policyReader client.Reader,
+	policyKey types.NamespacedName,
+) error {
 	logger := log.WithValues("policy", policyKey.Name)
 	// On conflict we need to re-retrieve enactments since the
 	// conflict can denote that the calculated policy conditions
@@ -201,20 +207,20 @@ func update(apiWriter client.Client, apiReader client.Reader, policyReader clien
 	// related to certificates until nmstate-webhook pod settles.
 	return retry.OnError(retry.DefaultRetry, allErrors, func() error {
 		policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
-		if err := policyReader.Get(context.TODO(), policyKey, policy); err != nil {
+		if err := policyReader.Get(ctx, policyKey, policy); err != nil {
 			return errors.Wrap(err, "getting policy failed")
 		}
 
 		enactments := nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
 		policyLabelFilter := client.MatchingLabels{nmstate.EnactmentPolicyLabel: policy.Name}
-		if err := apiReader.List(context.TODO(), &enactments, policyLabelFilter); err != nil {
+		if err := apiReader.List(ctx, &enactments, policyLabelFilter); err != nil {
 			return errors.Wrap(err, "getting enactments failed")
 		}
 
 		// Count only nodes that runs nmstate handler and match the policy
 		// nodeSelector, could be that users don't want to run knmstate at control-plane for example
 		// so they don't want to change net config there.
-		nmstateMatchingNodes, err := node.NodesRunningNmstate(apiReader, policy.Spec.NodeSelector)
+		nmstateMatchingNodes, err := node.NodesRunningNmstate(ctx, apiReader, policy.Spec.NodeSelector)
 		if err != nil {
 			return errors.Wrap(err, "getting nodes running kubernets-nmstate pods failed")
 		}
@@ -228,7 +234,7 @@ func update(apiWriter client.Client, apiReader client.Reader, policyReader clien
 
 		setPolicyStatus(policy, &policyStatus)
 
-		if err = apiWriter.Status().Update(context.TODO(), policy); err != nil {
+		if err = apiWriter.Status().Update(ctx, policy); err != nil {
 			if apierrors.IsConflict(err) {
 				logger.Info("conflict updating policy conditions, retrying")
 			} else {
@@ -313,16 +319,16 @@ func calculatePolicyConditionStatus(
 			enactmentsCountByCondition.Aborted()}
 }
 
-func Reset(cli client.Client, policyKey types.NamespacedName) error {
+func Reset(ctx context.Context, cli client.Client, policyKey types.NamespacedName) error {
 	logger := log.WithValues("policy", policyKey.Name)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
-		err := cli.Get(context.TODO(), policyKey, policy)
+		err := cli.Get(ctx, policyKey, policy)
 		if err != nil {
 			return errors.Wrap(err, "getting policy failed")
 		}
 		policy.Status.Conditions = nmstate.ConditionList{}
-		err = cli.Status().Update(context.TODO(), policy)
+		err = cli.Status().Update(ctx, policy)
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				logger.Info("conflict resetting policy conditions, retrying")

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Policy Conditions", func() {
 
 			client := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(updatedPolicy).WithRuntimeObjects(objs...).Build()
 			key := types.NamespacedName{Name: updatedPolicy.Name}
-			err := Update(client, client, key)
+			err := Update(context.TODO(), client, client, key)
 			Expect(err).ToNot(HaveOccurred())
 			err = client.Get(context.TODO(), key, updatedPolicy)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/selectors/labels.go
+++ b/pkg/selectors/labels.go
@@ -34,10 +34,10 @@ func unmatchingLabels(nodeSelector, labels map[string]string) map[string]string 
 	return unmatchingLabels
 }
 
-func (s *Selectors) UnmatchedNodeLabels(nodeName string) (map[string]string, error) {
+func (s *Selectors) UnmatchedNodeLabels(ctx context.Context, nodeName string) (map[string]string, error) {
 	logger := s.logger.WithValues("node", nodeName)
 	node := corev1.Node{}
-	err := s.client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	err := s.client.Get(ctx, types.NamespacedName{Name: nodeName}, &node)
 	if err != nil {
 		logger.Info("Cannot find corev1.Node")
 		return map[string]string{}, err

--- a/pkg/selectors/labels_test.go
+++ b/pkg/selectors/labels_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package selectors
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -63,7 +65,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller selectors", func() {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 			selectorsRequest := NewFromPolicy(fakeClient, &policy)
 
-			unmatchedNodeLabels, err := selectorsRequest.UnmatchedNodeLabels(expectedNode)
+			unmatchedNodeLabels, err := selectorsRequest.UnmatchedNodeLabels(context.TODO(), expectedNode)
 			Expect(err).To(c.MatchResult)
 			Expect(unmatchedNodeLabels).To(Equal(c.UnmatchedNodeLabels))
 

--- a/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
+++ b/pkg/webhook/nodenetworkconfigurationpolicy/handler.go
@@ -79,7 +79,7 @@ func validatePolicyHandler(
 			return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, "failed decoding policy: %s", string(original)))
 		}
 		currentPolicy := nmstatev1.NodeNetworkConfigurationPolicy{}
-		err = cli.Get(context.TODO(), types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}, &currentPolicy)
+		err = cli.Get(ctx, types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}, &currentPolicy)
 		if err != nil && !apierrors.IsNotFound(err) {
 			errMsg := fmt.Sprintf("failed getting policy %s", string(original))
 			log.Error(err, errMsg)

--- a/test/e2e/handler/node_selector_test.go
+++ b/test/e2e/handler/node_selector_test.go
@@ -39,7 +39,7 @@ var _ = Describe("NodeSelector", func() {
 		testNodeSelector            = map[string]string{"testKey": "testValue"}
 		numberOfEnactmentsForPolicy = func(policyName string) int {
 			nncp := nodeNetworkConfigurationPolicy(policyName)
-			numberOfMatchingEnactments, _, err := enactment.CountByPolicy(testenv.Client, &nncp)
+			numberOfMatchingEnactments, _, err := enactment.CountByPolicy(context.Background(), testenv.Client, &nncp)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			return numberOfMatchingEnactments
 		}
@@ -117,7 +117,7 @@ var _ = Describe("NodeSelector", func() {
 
 func addLabelsToNode(nodeName string, labelsToAdd map[string]string) {
 	node := corev1.Node{}
-	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: nodeName}, &node)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to change labels")
 
 	if len(node.Labels) == 0 {
@@ -127,13 +127,13 @@ func addLabelsToNode(nodeName string, labelsToAdd map[string]string) {
 			node.Labels[k] = v
 		}
 	}
-	err = testenv.Client.Update(context.TODO(), &node)
+	err = testenv.Client.Update(context.Background(), &node)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with new labels")
 }
 
 func removeLabelsFromNode(nodeName string, labelsToRemove map[string]string) {
 	node := corev1.Node{}
-	err := testenv.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, &node)
+	err := testenv.Client.Get(context.Background(), types.NamespacedName{Name: nodeName}, &node)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success retrieving node to remove labels")
 
 	if len(node.Labels) == 0 {
@@ -144,6 +144,6 @@ func removeLabelsFromNode(nodeName string, labelsToRemove map[string]string) {
 		delete(node.Labels, k)
 	}
 
-	err = testenv.Client.Update(context.TODO(), &node)
+	err = testenv.Client.Update(context.Background(), &node)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success updating node with label delete")
 }


### PR DESCRIPTION
This PR modifies `context.TODO` and introduces a proper context in multiple places around the codebase.

Where it's intended not to use an context we use `context.Background` as a marker that it's expected.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
