### PR TITLE
automation: Store NMState CR on artifacts

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -8,6 +8,7 @@
 # automation/check-patch.e2e-k8s.sh
 
 teardown() {
+    ./cluster/kubectl.sh get nmstate -A -o yaml > $ARTIFACTS/nmstate.yaml || true
     ./cluster/kubectl.sh get pod -n nmstate -o wide > $ARTIFACTS/kubernetes-nmstate.pod.list.txt || true
     for pod in $(./cluster/kubectl.sh get pod -n nmstate -o name); do
         pod_name=$(echo $pod|sed "s#pod/##")


### PR DESCRIPTION
**What this PR does / why we need it**:
Store the NMState CR on the CI artifacts to check status

**Release note**:

```release-note
NONE
```
