### PR TITLE
Mount /etc/systemd/network in handler pod for interface alt-names

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -428,6 +428,8 @@ spec:
               mountPath: /var/k8s_nmstate
             - name: ovs-socket
               mountPath: /run/openvswitch
+            - name: systemd-network
+              mountPath: /etc/systemd/network
           securityContext:
             privileged: true
           readinessProbe:
@@ -460,6 +462,10 @@ spec:
         - name: ovs-socket
           hostPath:
             path: /run/openvswitch
+        - name: systemd-network
+          hostPath:
+            path: /etc/systemd/network
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:
Add volume mount for /etc/systemd/network to allow the nmstate handler pod to write systemd .link files for interface alternative names persistence. Without this mount, alternative names would only be configured after the handler pod starts following a node reboot, rather than during early boot.

This change supports the interface alternative name feature introduced in nmstate 2.2.51, which uses systemd .link files for persistence instead of NetworkManager.

References:
- https://github.com/nmstate/nmstate/pull/2979
- https://nmstate.io/features/alt-name.html
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The handler pod now mounts /etc/systemd/network to enable persistence of interface alternative names via systemd .link files. This ensures alternative names are available during early boot, not just after the handler pod starts following a node reboot. This enhancement supports the interface alternative name feature (https://nmstate.io/features/alt-name.html) introduced in nmstate 2.2.51.
```
