### PR TITLE
fix(e2e): Don't use static IP if not needed

### DIFF
--- a/test/e2e/handler/simple_bridge_and_bond_test.go
+++ b/test/e2e/handler/simple_bridge_and_bond_test.go
@@ -88,10 +88,8 @@ func bondUpWithEth1AndEth2(bondName string) nmstate.State {
   type: bond
   state: up
   ipv4:
-    address:
-    - ip: 10.10.10.10
-      prefix-length: 24
     enabled: true
+    dhcp: true
   link-aggregation:
     mode: balance-rr
     options:
@@ -108,10 +106,8 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   type: bond
   state: up
   ipv4:
-    address:
-    - ip: 10.10.10.10
-      prefix-length: 24
     enabled: true
+    dhcp: true
   link-aggregation:
     mode: balance-rr
     options:
@@ -123,10 +119,8 @@ func bondUpWithEth1Eth2AndVlan(bondName string) nmstate.State {
   type: vlan
   state: up
   ipv4:
-    address:
-    - ip: 10.102.10.10
-      prefix-length: 24
     enabled: true
+    dhcp: true
   vlan:
     base-iface: %s
     id: 102

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -244,18 +244,6 @@ func interfaceAbsent(iface string) nmstate.State {
 `, iface))
 }
 
-func ifaceIPDisabled(iface string) nmstate.State {
-	return nmstate.NewState(fmt.Sprintf(`interfaces:
-    - name: %s
-      type: ethernet
-      state: up
-      ipv4:
-        enabled: false
-      ipv6:
-        enabled: false
-`, iface))
-}
-
 func vlanUpWithStaticIP(iface, ipAddress string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
     - name: %s


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the static IP address in tests from to avoid IPv4 Duplicate Address Detection (DAD) conflicts in the test environment.

DAD for IPv4 is activated by default at newer NetworkManager.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
