### PR TITLE
fix(e2e): Add missing resetDesiredStateForNodes

### DIFF
--- a/test/e2e/handler/nns_ovn.go
+++ b/test/e2e/handler/nns_ovn.go
@@ -62,6 +62,7 @@ var _ = Describe("[nns] NNS OVN bridge mappings", func() {
 				ShouldNot(ContainElement(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
 
 		}
+		resetDesiredStateForNodes()
 	})
 
 	It("are listed", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing resetDesiredStateForNodes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
