### PR TITLE
feat(gh): Add Actions workflows for OperatorHub publishing

### DIFF
--- a/.github/workflows/publish-operatorhub-on-release.yml
+++ b/.github/workflows/publish-operatorhub-on-release.yml
@@ -1,0 +1,281 @@
+name: Publish to OperatorHub on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v0.88.0)'
+        required: true
+        type: string
+
+env:
+  OPERATOR_NAME: kubernetes-nmstate-operator
+  IMAGE_REGISTRY: quay.io
+  IMAGE_REPO: nmstate
+  HANDLER_IMAGE_NAME: kubernetes-nmstate-handler
+  OPERATOR_IMAGE_NAME: kubernetes-nmstate-operator
+
+jobs:
+  publish-to-community-operators:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ github.event.inputs.tag }}"
+          fi
+
+          # Remove 'v' prefix if present
+          VERSION="${TAG#v}"
+
+          # Validate semver format
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in semver format (e.g., 0.88.0)"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout kubernetes-nmstate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Generate bundle
+        run: |
+          make bundle VERSION=${{ steps.version.outputs.version }} \
+            HANDLER_IMAGE_TAG=${{ steps.version.outputs.tag }} \
+            OPERATOR_IMAGE_TAG=${{ steps.version.outputs.tag }} \
+            HANDLER_PULL_POLICY=IfNotPresent \
+            OPERATOR_PULL_POLICY=IfNotPresent
+
+      - name: Validate bundle
+        run: |
+          # Verify bundle was generated correctly
+          if [ ! -f "bundle/manifests/${{ env.OPERATOR_NAME }}.clusterserviceversion.yaml" ]; then
+            echo "Error: CSV file not found"
+            exit 1
+          fi
+
+          # Check that images reference the correct version
+          if ! grep -q "${{ steps.version.outputs.tag }}" "bundle/manifests/${{ env.OPERATOR_NAME }}.clusterserviceversion.yaml"; then
+            echo "Warning: CSV may not reference the correct image tag"
+          fi
+
+      - name: Checkout community-operators
+        uses: actions/checkout@v4
+        with:
+          repository: k8s-operatorhub/community-operators
+          path: community-operators
+          token: ${{ secrets.OPERATORHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.name "kubernetes-nmstate-bot"
+          git config --global user.email "nmstate-bot@users.noreply.github.com"
+
+      - name: Create operator version directory
+        run: |
+          OPERATOR_DIR="community-operators/operators/${{ env.OPERATOR_NAME }}/${{ steps.version.outputs.version }}"
+          mkdir -p "$OPERATOR_DIR"
+
+          # Copy bundle manifests and metadata
+          cp -r bundle/manifests "$OPERATOR_DIR/"
+          cp -r bundle/metadata "$OPERATOR_DIR/"
+
+          # Copy bundle.Dockerfile if it exists
+          if [ -f "bundle.Dockerfile" ]; then
+            cp bundle.Dockerfile "$OPERATOR_DIR/"
+          fi
+
+      - name: Create and push PR branch
+        working-directory: community-operators
+        run: |
+          BRANCH_NAME="kubernetes-nmstate-${{ steps.version.outputs.version }}"
+          git checkout -b "$BRANCH_NAME"
+          git add operators/${{ env.OPERATOR_NAME }}/${{ steps.version.outputs.version }}
+          git commit -m "operator ${{ env.OPERATOR_NAME }} (${{ steps.version.outputs.version }})"
+          git push origin "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Create Pull Request to community-operators
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OPERATORHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: 'k8s-operatorhub',
+              repo: 'community-operators',
+              title: 'operator ${{ env.OPERATOR_NAME }} (${{ steps.version.outputs.version }})',
+              head: '${{ env.BRANCH_NAME }}',
+              base: 'main',
+              body: `## kubernetes-nmstate-operator version ${{ steps.version.outputs.version }}
+
+            This PR adds version ${{ steps.version.outputs.version }} of the kubernetes-nmstate-operator to OperatorHub.
+
+            **Release**: ${{ github.event.release.html_url || 'Manual trigger' }}
+
+            ### Images
+            - Handler: \`${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.HANDLER_IMAGE_NAME }}:${{ steps.version.outputs.tag }}\`
+            - Operator: \`${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ steps.version.outputs.tag }}\`
+
+            ### Checklist
+            - [x] Bundle manifests generated and validated
+            - [x] Image tags updated to ${{ steps.version.outputs.tag }}
+            - [x] Pull policy set to IfNotPresent
+            - [x] Automatically generated from release ${{ steps.version.outputs.tag }}
+
+            /kind operator
+            /area provider/kubernetes`
+            });
+
+            core.info(\`Community operators PR created: \${pr.html_url}\`);
+            return { pr_url: pr.html_url, pr_number: pr.number };
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-bundle-${{ steps.version.outputs.version }}
+          path: |
+            bundle/
+            bundle.Dockerfile
+          retention-days: 90
+
+      - name: Create job summary
+        run: |
+          echo "## OperatorHub Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully published to community-operators" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Tag**: ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Handler Image**: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.HANDLER_IMAGE_NAME }}:${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Operator Image**: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The bundle has been uploaded as an artifact and is available for 90 days." >> $GITHUB_STEP_SUMMARY
+
+  publish-to-community-operators-prod:
+    runs-on: ubuntu-latest
+    needs: publish-to-community-operators
+    # Only run for production releases (not pre-releases)
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in semver format"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout kubernetes-nmstate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Generate bundle
+        run: |
+          make bundle VERSION=${{ steps.version.outputs.version }} \
+            HANDLER_IMAGE_TAG=${{ steps.version.outputs.tag }} \
+            OPERATOR_IMAGE_TAG=${{ steps.version.outputs.tag }} \
+            HANDLER_PULL_POLICY=IfNotPresent \
+            OPERATOR_PULL_POLICY=IfNotPresent
+
+      - name: Checkout community-operators-prod
+        uses: actions/checkout@v4
+        with:
+          repository: redhat-openshift-ecosystem/community-operators-prod
+          path: community-operators-prod
+          token: ${{ secrets.OPERATORHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.name "kubernetes-nmstate-bot"
+          git config --global user.email "nmstate-bot@users.noreply.github.com"
+
+      - name: Create operator version directory
+        run: |
+          OPERATOR_DIR="community-operators-prod/operators/${{ env.OPERATOR_NAME }}/${{ steps.version.outputs.version }}"
+          mkdir -p "$OPERATOR_DIR"
+
+          cp -r bundle/manifests "$OPERATOR_DIR/"
+          cp -r bundle/metadata "$OPERATOR_DIR/"
+
+          if [ -f "bundle.Dockerfile" ]; then
+            cp bundle.Dockerfile "$OPERATOR_DIR/"
+          fi
+
+      - name: Create and push PR branch
+        working-directory: community-operators-prod
+        run: |
+          BRANCH_NAME="kubernetes-nmstate-${{ steps.version.outputs.version }}"
+          git checkout -b "$BRANCH_NAME"
+          git add operators/${{ env.OPERATOR_NAME }}/${{ steps.version.outputs.version }}
+          git commit -m "operator ${{ env.OPERATOR_NAME }} (${{ steps.version.outputs.version }})"
+          git push origin "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Create Pull Request to community-operators-prod
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OPERATORHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: 'redhat-openshift-ecosystem',
+              repo: 'community-operators-prod',
+              title: 'operator ${{ env.OPERATOR_NAME }} (${{ steps.version.outputs.version }})',
+              head: '${{ env.BRANCH_NAME }}',
+              base: 'main',
+              body: `## kubernetes-nmstate-operator version ${{ steps.version.outputs.version }}
+
+            This PR adds version ${{ steps.version.outputs.version }} of the kubernetes-nmstate-operator to OpenShift OperatorHub (production).
+
+            **Release**: ${{ github.event.release.html_url }}
+
+            ### Images
+            - Handler: \`${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.HANDLER_IMAGE_NAME }}:${{ steps.version.outputs.tag }}\`
+            - Operator: \`${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ steps.version.outputs.tag }}\`
+
+            ### Checklist
+            - [x] Bundle manifests generated and validated
+            - [x] Image tags updated to ${{ steps.version.outputs.tag }}
+            - [x] Production release (not pre-release)
+            - [x] Automatically generated from release ${{ steps.version.outputs.tag }}
+
+            /kind operator`
+            });
+
+            core.info(\`Community operators prod PR created: \${pr.html_url}\`);
+
+      - name: Update job summary
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully published to community-operators-prod (OpenShift)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-operatorhub.yml
+++ b/.github/workflows/publish-operatorhub.yml
@@ -1,0 +1,188 @@
+name: Publish to OperatorHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Operator version to publish (e.g., 0.88.0)'
+        required: true
+        type: string
+      operator_hub_repo:
+        description: 'Target OperatorHub repository'
+        required: true
+        type: choice
+        default: 'community-operators'
+        options:
+          - community-operators
+          - community-operators-prod
+      create_pr:
+        description: 'Create PR to OperatorHub (disable for testing)'
+        required: true
+        type: boolean
+        default: true
+
+env:
+  OPERATOR_NAME: kubernetes-nmstate-operator
+  IMAGE_REGISTRY: quay.io
+  IMAGE_REPO: nmstate
+  HANDLER_IMAGE_NAME: kubernetes-nmstate-handler
+  OPERATOR_IMAGE_NAME: kubernetes-nmstate-operator
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kubernetes-nmstate
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in semver format (e.g., 0.88.0)"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set image tags
+        run: |
+          echo "HANDLER_IMAGE_TAG=v${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE_TAG=v${{ env.VERSION }}" >> $GITHUB_ENV
+
+      - name: Generate bundle
+        run: |
+          make bundle VERSION=${{ env.VERSION }} \
+            HANDLER_IMAGE_TAG=v${{ env.VERSION }} \
+            OPERATOR_IMAGE_TAG=v${{ env.VERSION }} \
+            HANDLER_PULL_POLICY=IfNotPresent \
+            OPERATOR_PULL_POLICY=IfNotPresent
+
+      - name: Validate bundle
+        run: |
+          make bundle VERSION=${{ env.VERSION }}
+          # Verify bundle was generated correctly
+          if [ ! -f "bundle/manifests/${{ env.OPERATOR_NAME }}.clusterserviceversion.yaml" ]; then
+            echo "Error: CSV file not found"
+            exit 1
+          fi
+
+      - name: Display bundle info
+        run: |
+          echo "Bundle contents:"
+          ls -la bundle/
+          echo "CSV file:"
+          head -n 50 bundle/manifests/${{ env.OPERATOR_NAME }}.clusterserviceversion.yaml
+
+      - name: Checkout OperatorHub repository
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: k8s-operatorhub/${{ github.event.inputs.operator_hub_repo }}
+          path: operatorhub-repo
+          token: ${{ secrets.OPERATORHUB_TOKEN }}
+
+      - name: Configure git
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        run: |
+          git config --global user.name "kubernetes-nmstate-bot"
+          git config --global user.email "nmstate-bot@users.noreply.github.com"
+
+      - name: Create operator version directory
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        run: |
+          OPERATOR_DIR="operatorhub-repo/operators/${{ env.OPERATOR_NAME }}/${{ env.VERSION }}"
+          mkdir -p "$OPERATOR_DIR"
+
+          # Copy bundle manifests and metadata
+          cp -r bundle/manifests "$OPERATOR_DIR/"
+          cp -r bundle/metadata "$OPERATOR_DIR/"
+
+          # Copy bundle.Dockerfile if it exists
+          if [ -f "bundle.Dockerfile" ]; then
+            cp bundle.Dockerfile "$OPERATOR_DIR/"
+          fi
+
+          echo "OPERATOR_DIR=$OPERATOR_DIR" >> $GITHUB_ENV
+
+      - name: Create PR branch
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        working-directory: operatorhub-repo
+        run: |
+          BRANCH_NAME="kubernetes-nmstate-${{ env.VERSION }}"
+          git checkout -b "$BRANCH_NAME"
+          git add operators/${{ env.OPERATOR_NAME }}/${{ env.VERSION }}
+          git commit -m "operator ${{ env.OPERATOR_NAME }} (${{ env.VERSION }})"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Push branch
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        working-directory: operatorhub-repo
+        run: |
+          git push origin "${{ env.BRANCH_NAME }}"
+
+      - name: Create Pull Request
+        if: ${{ github.event.inputs.create_pr == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OPERATORHUB_TOKEN }}
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: 'k8s-operatorhub',
+              repo: '${{ github.event.inputs.operator_hub_repo }}',
+              title: 'operator ${{ env.OPERATOR_NAME }} (${{ env.VERSION }})',
+              head: '${{ env.BRANCH_NAME }}',
+              base: 'main',
+              body: `## kubernetes-nmstate-operator version ${{ env.VERSION }}
+
+            This PR adds version ${{ env.VERSION }} of the kubernetes-nmstate-operator to OperatorHub.
+
+            ### Changes
+            - Operator version: ${{ env.VERSION }}
+            - Handler image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.HANDLER_IMAGE_NAME }}:v${{ env.VERSION }}
+            - Operator image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.OPERATOR_IMAGE_NAME }}:v${{ env.VERSION }}
+
+            ### Checklist
+            - [x] Bundle manifests generated and validated
+            - [x] Image tags updated to v${{ env.VERSION }}
+            - [x] Pull policy set to IfNotPresent
+
+            This PR was automatically generated by the kubernetes-nmstate release process.
+
+            /kind operator
+            /area provider/kubernetes`
+            });
+
+            core.info(`Pull request created: ${pr.html_url}`);
+            core.setOutput('pr_url', pr.html_url);
+            core.setOutput('pr_number', pr.number);
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-bundle-${{ env.VERSION }}
+          path: |
+            bundle/
+            bundle.Dockerfile
+          retention-days: 30
+
+      - name: Job summary
+        run: |
+          echo "## OperatorHub Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target Repository**: ${{ github.event.inputs.operator_hub_repo }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Handler Image**: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.HANDLER_IMAGE_NAME }}:v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Operator Image**: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}/${{ env.OPERATOR_IMAGE_NAME }}:v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ github.event.inputs.create_pr }}" = "true" ]; then
+            echo "- **Status**: PR created to OperatorHub" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Status**: Bundle generated (PR creation disabled)" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docs/operatorhub-publishing.md
+++ b/docs/operatorhub-publishing.md
@@ -1,0 +1,247 @@
+# Publishing to OperatorHub
+
+This document describes how to publish kubernetes-nmstate to OperatorHub using GitHub Actions.
+
+## Overview
+
+The kubernetes-nmstate operator can be published to two OperatorHub repositories:
+
+1. **community-operators** - For upstream Kubernetes clusters (https://operatorhub.io)
+2. **community-operators-prod** - For OpenShift/OKD clusters (Red Hat Certified)
+
+We provide two GitHub Actions workflows for publishing:
+
+- **Manual Publishing**: `publish-operatorhub.yml` - Triggered manually for testing or specific versions
+- **Automatic Publishing**: `publish-operatorhub-on-release.yml` - Triggered automatically when a release is published
+
+## Prerequisites
+
+### Required Secrets
+
+The workflows require a GitHub secret named `OPERATORHUB_TOKEN` with permissions to:
+
+1. Fork and create PRs in the k8s-operatorhub/community-operators repository
+2. Fork and create PRs in the redhat-openshift-ecosystem/community-operators-prod repository
+
+To set up the token:
+
+1. Create a GitHub Personal Access Token (PAT) with `repo` and `workflow` scopes
+2. Add it to your repository secrets as `OPERATORHUB_TOKEN`:
+   - Go to Settings > Secrets and variables > Actions
+   - Click "New repository secret"
+   - Name: `OPERATORHUB_TOKEN`
+   - Value: Your PAT
+
+### Required Images
+
+Before publishing, ensure that the operator and handler images are built and pushed to the registry:
+
+```bash
+# Build and push handler image
+IMAGE_REGISTRY=quay.io IMAGE_REPO=nmstate HANDLER_IMAGE_TAG=v0.88.0 make push-handler
+
+# Build and push operator image
+IMAGE_REGISTRY=quay.io IMAGE_REPO=nmstate OPERATOR_IMAGE_TAG=v0.88.0 make push-operator
+```
+
+Images should be publicly accessible at:
+- `quay.io/nmstate/kubernetes-nmstate-handler:v<VERSION>`
+- `quay.io/nmstate/kubernetes-nmstate-operator:v<VERSION>`
+
+## Automatic Publishing (Recommended)
+
+The automatic workflow triggers when a GitHub release is published.
+
+### Process
+
+1. **Create and publish a release** on GitHub:
+   ```bash
+   # Tag the release
+   git tag v0.88.0
+   git push origin v0.88.0
+   ```
+
+2. **Publish the release** through the GitHub UI or using the `gh` CLI:
+   ```bash
+   gh release create v0.88.0 --title "v0.88.0" --notes "Release notes here"
+   ```
+
+3. **The workflow automatically**:
+   - Extracts the version from the release tag
+   - Generates the OLM bundle
+   - Creates a PR to `community-operators` (for all releases)
+   - Creates a PR to `community-operators-prod` (for stable releases only, not pre-releases)
+
+### Workflow Behavior
+
+- **All releases**: Published to `community-operators` (operatorhub.io)
+- **Stable releases only**: Published to `community-operators-prod` (OpenShift)
+  - Pre-releases (e.g., `v0.88.0-rc1`) are NOT published to production
+
+### Manual Trigger
+
+You can also manually trigger the automatic workflow:
+
+```bash
+gh workflow run publish-operatorhub-on-release.yml -f tag=v0.88.0
+```
+
+## Manual Publishing
+
+Use the manual workflow for testing or when you need fine-grained control.
+
+### Usage
+
+1. **Navigate to Actions** tab in GitHub
+2. **Select** "Publish to OperatorHub" workflow
+3. **Click** "Run workflow"
+4. **Fill in the parameters**:
+   - `version`: Operator version (e.g., `0.88.0` - without the 'v' prefix)
+   - `operator_hub_repo`: Choose the target repository
+     - `community-operators` - For operatorhub.io
+     - `community-operators-prod` - For OpenShift
+   - `create_pr`: Enable/disable PR creation (disable for testing)
+
+### Using GitHub CLI
+
+```bash
+# Publish to community-operators
+gh workflow run publish-operatorhub.yml \
+  -f version=0.88.0 \
+  -f operator_hub_repo=community-operators \
+  -f create_pr=true
+
+# Publish to community-operators-prod (OpenShift)
+gh workflow run publish-operatorhub.yml \
+  -f version=0.88.0 \
+  -f operator_hub_repo=community-operators-prod \
+  -f create_pr=true
+
+# Test bundle generation without creating a PR
+gh workflow run publish-operatorhub.yml \
+  -f version=0.88.0 \
+  -f operator_hub_repo=community-operators \
+  -f create_pr=false
+```
+
+## Workflow Details
+
+### What the workflows do
+
+1. **Checkout** the kubernetes-nmstate repository at the specified tag/version
+2. **Generate** the OLM bundle using `make bundle`
+3. **Validate** the bundle structure and contents
+4. **Checkout** the target OperatorHub repository
+5. **Create** a new directory for the operator version
+6. **Copy** bundle manifests, metadata, and Dockerfile
+7. **Commit** and push the changes to a new branch
+8. **Create** a Pull Request to the OperatorHub repository
+
+### Bundle Structure
+
+The generated bundle follows the Operator Framework format:
+
+```
+operators/kubernetes-nmstate-operator/<version>/
+├── manifests/
+│   ├── kubernetes-nmstate-operator.clusterserviceversion.yaml
+│   ├── nmstate.io_nmstates.yaml
+│   ├── nmstate.io_nodenetworkconfigurationenactments.yaml
+│   ├── nmstate.io_nodenetworkconfigurationpolicies.yaml
+│   └── nmstate.io_nodenetworkstates.yaml
+├── metadata/
+│   └── annotations.yaml
+└── bundle.Dockerfile
+```
+
+### Image References
+
+The workflows ensure that:
+- Handler image: `quay.io/nmstate/kubernetes-nmstate-handler:v<VERSION>`
+- Operator image: `quay.io/nmstate/kubernetes-nmstate-operator:v<VERSION>`
+- Pull policy: `IfNotPresent` (production setting)
+
+## Post-Publishing
+
+After the workflow creates a PR:
+
+1. **Monitor** the PR for CI checks in the OperatorHub repository
+2. **Address** any issues flagged by OperatorHub CI
+3. **Wait** for review and approval from OperatorHub maintainers
+4. **Merge** will be handled by OperatorHub maintainers
+
+Common CI checks include:
+- Bundle validation
+- Image accessibility checks
+- Operator scorecard tests
+- OpenShift compatibility (for community-operators-prod)
+
+## Troubleshooting
+
+### Bundle generation fails
+
+```bash
+# Locally test bundle generation
+make bundle VERSION=0.88.0 \
+  HANDLER_IMAGE_TAG=v0.88.0 \
+  OPERATOR_IMAGE_TAG=v0.88.0 \
+  HANDLER_PULL_POLICY=IfNotPresent \
+  OPERATOR_PULL_POLICY=IfNotPresent
+
+# Validate the bundle
+make bundle VERSION=0.88.0
+```
+
+### Images not found
+
+Ensure images are built and pushed:
+
+```bash
+# Check if images exist
+podman pull quay.io/nmstate/kubernetes-nmstate-handler:v0.88.0
+podman pull quay.io/nmstate/kubernetes-nmstate-operator:v0.88.0
+```
+
+### PR creation fails
+
+- Verify `OPERATORHUB_TOKEN` has correct permissions
+- Check if a PR for this version already exists
+- Ensure the bot user has access to fork repositories
+
+### Version format errors
+
+The workflows expect semantic versioning:
+- ✅ Correct: `0.88.0`, `1.0.0`, `0.88.1`
+- ❌ Incorrect: `v0.88.0`, `0.88`, `latest`
+
+For release tags, use the `v` prefix (e.g., `v0.88.0`), but for the workflow `version` input, omit it.
+
+## Testing Locally
+
+To test bundle generation locally before running the workflow:
+
+```bash
+# Set variables
+export VERSION=0.88.0
+export HANDLER_IMAGE_TAG=v0.88.0
+export OPERATOR_IMAGE_TAG=v0.88.0
+
+# Generate bundle
+make bundle VERSION=$VERSION \
+  HANDLER_IMAGE_TAG=$HANDLER_IMAGE_TAG \
+  OPERATOR_IMAGE_TAG=$OPERATOR_IMAGE_TAG \
+  HANDLER_PULL_POLICY=IfNotPresent \
+  OPERATOR_PULL_POLICY=IfNotPresent
+
+# Inspect generated files
+ls -la bundle/
+cat bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+```
+
+## References
+
+- [OperatorHub.io](https://operatorhub.io)
+- [Operator Framework Documentation](https://sdk.operatorframework.io/)
+- [community-operators Repository](https://github.com/k8s-operatorhub/community-operators)
+- [community-operators-prod Repository](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+- [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/)


### PR DESCRIPTION
**What this PR does / why we need it**:
Automate publishing kubernetes-nmstate operator to OperatorHub repositories with workflows that handle both automatic releases and manual publishing. The automatic workflow triggers on release publication and submits PRs to community-operators (all releases) and community-operators-prod (stable releases only). A manual workflow is provided for testing or controlled publishing. Includes comprehensive documentation covering setup, usage, and troubleshooting.

Closes https://github.com/nmstate/kubernetes-nmstate/issues/1095

**Release note**:

```release-note
NONE
```
