### PR TITLE
Add VRF route persistence test using vrf-name

### DIFF
--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -237,6 +237,34 @@ func vrfAbsent(vrfID string) nmstate.State {
 `, vrfID))
 }
 
+// vrfRouteWithVrfName creates a VRF interface and a route using vrf-name instead of table-id.
+func vrfRouteWithVrfName(vrfID, vrfName, iface, ipAddress, destIPAddress, prefixLen, nextHopIPAddress string) nmstate.State {
+	return nmstate.NewState(fmt.Sprintf(`interfaces:
+    - name: %s
+      type: vrf
+      state: up
+      vrf:
+        port: [%s]
+        route-table-id: %s
+    - name: %s
+      type: ethernet
+      state: up
+      ipv4:
+        address:
+        - ip: %s
+          prefix-length: %s
+        dhcp: false
+        enabled: true
+routes:
+    config:
+    - destination: %s
+      metric: 150
+      next-hop-address: %s
+      next-hop-interface: %s
+      vrf-name: %s
+`, vrfName, iface, vrfID, iface, ipAddress, prefixLen, destIPAddress, nextHopIPAddress, iface, vrfName))
+}
+
 func interfaceAbsent(iface string) nmstate.State {
 	return nmstate.NewState(fmt.Sprintf(`interfaces:
     - name: %s


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
Add e2e test to verify VRF routes specified by vrf-name persist across node reboots. This tests the new vrf-name parameter for routes that allows referencing VRF route tables by interface name instead of numeric table-id.

The test includes:
   - Basic verification test for vrf-name route configuration
   - Reboot persistence test to ensure routes survive node restart

**Special notes for your reviewer**:
Depeds-on: nmstate 2.2.55

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
