### PR TITLE
Add terminationMessagePolicy to operator pod

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/nmstate/kubernetes-nmstate-operator:latest
-    createdAt: "2025-09-08T08:04:38Z"
+    createdAt: "2025-11-20T17:23:43Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
@@ -288,6 +288,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -88,6 +88,7 @@ spec:
             limits:
               cpu: "500m"
               memory: "1Gi"
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind enhancement

**What this PR does / why we need it**:
It is recommended to use `terminationMessagePolicy: FallbackToLogsOnError`. This PR adds it to the defintion of operator pod. All the other pods already have this parameter configured.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
`terminationMessagePolicy` is now set to `FallbackToLogsOnError` for all the pods.
```
