### PR TITLE
Omitting timer properties from addresses inside NNS

### DIFF
--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -325,4 +325,68 @@ dns-resolver:
 			Expect(returnedState).To(MatchYAML(state))
 		})
 	})
+
+	Context("when there are interfaces with preferred-life-time and valid-life-time in addresses", func() {
+		BeforeEach(func() {
+			state = nmstate.NewState(`
+interfaces:
+- name: eth1
+  state: up
+  type: ethernet
+  ipv4:
+    address:
+    - ip: 192.168.1.1
+      prefix-length: 24
+      preferred-life-time: 3600
+      valid-life-time: 7200
+    dhcp: false
+    enabled: true
+  ipv6:
+    address:
+    - ip: 2001:db8::1
+      prefix-length: 64
+      preferred-life-time: 1800
+      valid-life-time: 3600
+    - ip: fe80::1
+      prefix-length: 64
+      preferred-life-time: forever
+      valid-life-time: forever
+    autoconf: false
+    dhcp: false
+    enabled: true
+routes:
+  config: []
+  running: []
+`)
+			filteredState = nmstate.NewState(`
+interfaces:
+- name: eth1
+  state: up
+  type: ethernet
+  ipv4:
+    address:
+    - ip: 192.168.1.1
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  ipv6:
+    address:
+    - ip: 2001:db8::1
+      prefix-length: 64
+    - ip: fe80::1
+      prefix-length: 64
+    autoconf: false
+    dhcp: false
+    enabled: true
+routes:
+  config: []
+  running: []
+`)
+		})
+		It("should remove preferred-life-time and valid-life-time from address entries", func() {
+			returnedState, err := filterOut(state)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(returnedState).To(MatchYAML(filteredState))
+		})
+	})
 })


### PR DESCRIPTION
The `preferred-life-time` and `valid-life-time` keep changing every time we do `nmstatectl show`. Because of this, NodeNetworkState is updated all the time.

In order to reduce the number of updates we are removing those dynamic properties and introduce `dynamic: true` instead.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NodeNetworkState does not contain `preferred-life-time` and `valid-life-time` any more. Instead, `dynamic: true` is added. This is at `status.currentState.interfaces[].ipv4.address` (and respectively for IPv6).
```
