### PR TITLE
metrics: introduce metrics based on the NNS

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -83,6 +83,8 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 
 	metrics.Registry.MustRegister(monitoring.AppliedFeatures)
+	metrics.Registry.MustRegister(monitoring.NetworkInterfaces)
+	metrics.Registry.MustRegister(monitoring.NetworkRoutes)
 }
 
 func main() {
@@ -390,6 +392,17 @@ func setupMetricsManager(mgr manager.Manager) error {
 		setupLog.Error(err, "unable to create NodeNetworkConfigurationEnactment metrics controller", "metrics", "NMState")
 		return err
 	}
+
+	setupLog.Info("Creating Metrics NodeNetworkState controller")
+	if err := (&controllersmetrics.NodeNetworkStateReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("metrics").WithName("NodeNetworkState"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create NodeNetworkState metrics controller", "metrics", "NMState")
+		return err
+	}
+
 	return nil
 }
 

--- a/controllers/metrics/nodenetworkstate_controller.go
+++ b/controllers/metrics/nodenetworkstate_controller.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/nmstate/kubernetes-nmstate/pkg/monitoring"
+	"github.com/nmstate/kubernetes-nmstate/pkg/state"
+)
+
+// NodeNetworkStateReconciler reconciles a NodeNetworkState object for metrics
+type NodeNetworkStateReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	// Track interface types per node to clean up stale metrics
+	oldInterfaceTypes map[string]map[string]struct{} // node name -> set of interface types
+	// Track route keys per node to clean up stale metrics
+	oldRouteKeys map[string]map[state.RouteKey]struct{} // node name -> set of route keys
+}
+
+// Reconcile reads the state of the cluster for a NodeNetworkState object and calculates
+// metrics for network interface counts by type and node.
+func (r *NodeNetworkStateReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("metrics.nodenetworkstate", request.NamespacedName)
+	log.Info("Reconcile")
+
+	nodeName := request.Name
+
+	nnsInstance := &nmstatev1beta1.NodeNetworkState{}
+	err := r.Client.Get(ctx, request.NamespacedName, nnsInstance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// NNS has been deleted, clean up metrics for this node
+			r.deleteNodeMetrics(nodeName)
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Error retrieving NodeNetworkState")
+		return ctrl.Result{}, err
+	}
+
+	// Count interfaces by type for this node
+	counts, err := state.CountInterfacesByType(nnsInstance.Status.CurrentState)
+	if err != nil {
+		log.Error(err, "Failed to count interfaces by type")
+		return ctrl.Result{}, err
+	}
+
+	// Update interface metrics for this node
+	r.updateNodeInterfaceMetrics(nodeName, counts)
+
+	// Count routes by IP stack and type for this node
+	routeCounts, err := state.CountRoutes(nnsInstance.Status.CurrentState)
+	if err != nil {
+		log.Error(err, "Failed to count routes")
+		return ctrl.Result{}, err
+	}
+
+	// Update route metrics for this node
+	r.updateNodeRouteMetrics(nodeName, routeCounts)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeNetworkStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.oldInterfaceTypes = make(map[string]map[string]struct{})
+	r.oldRouteKeys = make(map[string]map[state.RouteKey]struct{})
+
+	onCreationOrUpdateForThisNNS := predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNNS, ok := e.ObjectOld.(*nmstatev1beta1.NodeNetworkState)
+			if !ok {
+				return false
+			}
+			newNNS, ok := e.ObjectNew.(*nmstatev1beta1.NodeNetworkState)
+			if !ok {
+				return false
+			}
+
+			// Reconcile if the current state has changed
+			return oldNNS.Status.CurrentState.String() != newNNS.Status.CurrentState.String()
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&nmstatev1beta1.NodeNetworkState{}).
+		WithEventFilter(onCreationOrUpdateForThisNNS).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed to add controller to NNS metrics Reconciler")
+	}
+
+	return nil
+}
+
+// updateNodeInterfaceMetrics sets the interface count metrics for a specific node
+func (r *NodeNetworkStateReconciler) updateNodeInterfaceMetrics(nodeName string, counts map[string]int) {
+	// Get the old interface types for this node to detect removed types
+	oldTypes := r.oldInterfaceTypes[nodeName]
+	newTypes := make(map[string]struct{})
+
+	// Set metrics for current interface types
+	for ifaceType, count := range counts {
+		monitoring.NetworkInterfaces.With(prometheus.Labels{
+			"type": ifaceType,
+			"node": nodeName,
+		}).Set(float64(count))
+		newTypes[ifaceType] = struct{}{}
+	}
+
+	// Delete metrics for interface types that no longer exist on this node
+	for oldType := range oldTypes {
+		if _, exists := newTypes[oldType]; !exists {
+			monitoring.NetworkInterfaces.Delete(prometheus.Labels{
+				"type": oldType,
+				"node": nodeName,
+			})
+		}
+	}
+
+	// Store current types for next reconcile
+	r.oldInterfaceTypes[nodeName] = newTypes
+}
+
+// updateNodeRouteMetrics sets the route count metrics for a specific node
+func (r *NodeNetworkStateReconciler) updateNodeRouteMetrics(nodeName string, counts map[state.RouteKey]int) {
+	// Get the old route keys for this node to detect removed keys
+	oldKeys := r.oldRouteKeys[nodeName]
+	newKeys := make(map[state.RouteKey]struct{})
+
+	// Set metrics for current route keys
+	for key, count := range counts {
+		monitoring.NetworkRoutes.With(prometheus.Labels{
+			"node":     nodeName,
+			"ip_stack": key.IPStack,
+			"type":     key.Type,
+		}).Set(float64(count))
+		newKeys[key] = struct{}{}
+	}
+
+	// Delete metrics for route keys that no longer exist on this node
+	for oldKey := range oldKeys {
+		if _, exists := newKeys[oldKey]; !exists {
+			monitoring.NetworkRoutes.Delete(prometheus.Labels{
+				"node":     nodeName,
+				"ip_stack": oldKey.IPStack,
+				"type":     oldKey.Type,
+			})
+		}
+	}
+
+	// Store current keys for next reconcile
+	r.oldRouteKeys[nodeName] = newKeys
+}
+
+// deleteNodeMetrics removes all interface and route count metrics for a specific node
+func (r *NodeNetworkStateReconciler) deleteNodeMetrics(nodeName string) {
+	// Delete interface metrics
+	if oldTypes, ok := r.oldInterfaceTypes[nodeName]; ok {
+		for ifaceType := range oldTypes {
+			monitoring.NetworkInterfaces.Delete(prometheus.Labels{
+				"type": ifaceType,
+				"node": nodeName,
+			})
+		}
+		delete(r.oldInterfaceTypes, nodeName)
+	}
+
+	// Delete route metrics
+	if oldKeys, ok := r.oldRouteKeys[nodeName]; ok {
+		for key := range oldKeys {
+			monitoring.NetworkRoutes.Delete(prometheus.Labels{
+				"node":     nodeName,
+				"ip_stack": key.IPStack,
+				"type":     key.Type,
+			})
+		}
+		delete(r.oldRouteKeys, nodeName)
+	}
+}

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -29,12 +29,35 @@ var (
 		Help: "Number of nmstate features applied labeled by its name",
 	}
 
+	NetworkInterfacesOpts = prometheus.GaugeOpts{
+		Name: "kubernetes_nmstate_network_interfaces",
+		Help: "Number of network interfaces labeled by its type",
+	}
+
+	NetworkRoutesOpts = prometheus.GaugeOpts{
+		Name: "kubernetes_nmstate_routes",
+		Help: "Number of network routes labeled by node, IP stack and type (static/dynamic)",
+	}
+
 	AppliedFeatures = prometheus.NewGaugeVec(
 		AppliedFeaturesOpts,
 		[]string{"name"},
 	)
+
+	NetworkInterfaces = prometheus.NewGaugeVec(
+		NetworkInterfacesOpts,
+		[]string{"type", "node"},
+	)
+
+	NetworkRoutes = prometheus.NewGaugeVec(
+		NetworkRoutesOpts,
+		[]string{"node", "ip_stack", "type"},
+	)
+
 	gaugeOpts = []prometheus.GaugeOpts{
 		AppliedFeaturesOpts,
+		NetworkInterfacesOpts,
+		NetworkRoutesOpts,
 	}
 )
 

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -59,10 +59,12 @@ type DNSResolverData struct {
 // interfaceFields allows unmarshaling directly into the defined fields
 type interfaceFields struct {
 	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // routeFields allows unmarshaling directly into the defined fields
 type routeFields struct {
+	Destination      string `json:"destination"        yaml:"destination"`
 	NextHopInterface string `json:"next-hop-interface" yaml:"next-hop-interface"`
 }
 
@@ -81,11 +83,13 @@ func (i *interfaceState) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("failed Unmarshaling raw: %w", err)
 	}
 	i.Data["name"] = ifaceFields.Name
+	i.Data["type"] = ifaceFields.Type
 	i.interfaceFields = ifaceFields
 	return nil
 }
 
 func (r routeState) MarshalJSON() (output []byte, err error) {
+	r.Data["destination"] = r.Destination
 	r.Data["next-hop-interface"] = r.NextHopInterface
 	return json.Marshal(r.Data)
 }
@@ -99,6 +103,7 @@ func (r *routeState) UnmarshalJSON(b []byte) error {
 	if err := yaml.Unmarshal(b, &fields); err != nil {
 		return fmt.Errorf("failed Unmarchaling raw: %w", err)
 	}
+	r.Data["destination"] = fields.Destination
 	r.Data["next-hop-interface"] = fields.NextHopInterface
 	r.routeFields = fields
 	return nil


### PR DESCRIPTION
This PR introduces a small set of metrics based on the NodeNetworkState, i.e. `kubernetes_nmstate_network_interfaces` and
`kubernetes_nmstate_routes`. Those track number of network interfaces and number of routes for every node in the cluster where nmstate handler pods are running.

This creates a skeleton for k-nmstate to create metrics based on the effective state of the network on the system and not only based on the content of NNCP.

In the future it may be used to create statistics about network topologies of clusters.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
New metrics `kubernetes_nmstate_network_interfaces` and `kubernetes_nmstate_routes` are introduced to track number of network interfaces and number of routes configured per node.
```
