### PR TITLE
test: add cleanup in BeforeEach to avoid duplicated policies

### DIFF
--- a/test/e2e/handler/default_ovs_bridged_network_test.go
+++ b/test/e2e/handler/default_ovs_bridged_network_test.go
@@ -200,6 +200,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 			}
 
 			BeforeEach(func() {
+				// Ensure ovsWrongIPPolicy doesn't exist before the test runs
+				// This prevents stale enactments from previous test runs causing cleanup failures
+				deletePolicy(ovsWrongIPPolicy)
+
 				node = nodes[0]
 
 				Byf("Check %s is the default route interface and has dynamic address", primaryNic)

--- a/test/e2e/handler/upgrade_test.go
+++ b/test/e2e/handler/upgrade_test.go
@@ -36,6 +36,10 @@ import (
 var _ = Describe("NodeNetworkConfigurationPolicy upgrade", func() {
 	Context("when v1beta1 is populated", func() {
 		BeforeEach(func() {
+			// Ensure TestPolicy doesn't exist before creating v1beta1 policy
+			// This prevents "already exists" errors if a previous test's cleanup was incomplete
+			deletePolicy(TestPolicy)
+
 			maxUnavailableIntOrString := intstr.FromString(maxUnavailable)
 			policy := nmstatev1beta1.NodeNetworkConfigurationPolicy{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This change attempts to remediate an issue where test fails because of a duplicated policy, i.e.

```
nodenetworkconfigurationpolicies.nmstate.io "test-policy" already exists
```

which may potentially be an outcome of a missing cleanup in some other test. With this change we will always try to create the policy first before starting a test to ensure a clean starting state.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
