### PR TITLE
fix(e2e): Wait for nodes to reboot

### DIFF
--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -127,6 +127,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 			nodeToReboot := nodes[0]
 			Byf("Reboot node %s and verify that bond still has ip of primary nic", nodeToReboot)
 			restartNodeWithoutWaiting(nodeToReboot)
+			waitForNodeToStart(nodeToReboot)
 
 			By("Wait for policy re-reconciled after node reboot")
 			policy.WaitForPolicyTransitionUpdate(TestPolicy)

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -142,6 +142,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network", func(
 				nodeToReboot := nodes[0]
 
 				restartNodeWithoutWaiting(nodeToReboot)
+				waitForNodeToStart(nodeToReboot)
 
 				By("Wait for policy re-reconciled after node reboot")
 				policy.WaitForPolicyTransitionUpdate(DefaultNetwork)

--- a/test/e2e/handler/default_ovs_bridged_network_test.go
+++ b/test/e2e/handler/default_ovs_bridged_network_test.go
@@ -154,6 +154,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy default ovs-bridged network", f
 
 				It("should keep the default IP address after node reboot", func() {
 					restartNodeWithoutWaiting(node)
+					waitForNodeToStart(node)
 
 					By("Wait for policy re-reconciled after node reboot")
 					policy.WaitForPolicyTransitionUpdate(ovsDefaultNetwork)

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -283,13 +283,12 @@ func restartNodeWithoutWaiting(node string) {
 func waitForNodeToStart(node string) {
 	Byf("Waiting till node %s is rebooted", node)
 	// It will wait till uptime -p will return up that means that node was currently rebooted and is 0 min up
-	Eventually(func() string {
+	Eventually(func(g Gomega) string {
 		output, err := runner.RunAtNode(node, "uptime", "-p")
-		if err != nil {
-			return "not yet"
-		}
+		// Using g.Expect makes Eventually retry on errors directly
+		g.Expect(err).NotTo(HaveOccurred())
 		return output
-	}, 300*time.Second, 5*time.Second).ShouldNot(Equal("up"), fmt.Sprintf("Node %s failed to start after reboot", node))
+	}, 300*time.Second, 5*time.Second).Should(ContainSubstring("up"), fmt.Sprintf("Node %s failed to start after reboot", node))
 }
 
 func createDummyConnection(nodesToModify []string, dummyName string) []error {


### PR DESCRIPTION

**What this PR does / why we need it**:
The test were rebooting nodes and they were directly eventually checking NNCPs, this can introduce race conditions since how much time it takes for nodes to reboot is quite random, this fix add a explicit wait of node readiness, if it fails we will know for sure that the node didn't fully reboot instead of weird "Missing enacment" error.



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
