### PR TITLE
e2e(metrics): Prevent ip conflicts

### DIFF
--- a/test/e2e/handler/metrics_test.go
+++ b/test/e2e/handler/metrics_test.go
@@ -207,19 +207,19 @@ routes:
 			})
 
 			AfterEach(func() {
-				updateDesiredStateAndWait(staticRouteAbsent(firstSecondaryNic))
+				updateDesiredStateAtNodeAndWait(nodes[0], staticRouteAbsent(firstSecondaryNic))
 				resetDesiredStateForNodes()
 			})
 
 			It("should increase and decrease static route count", func() {
 				By("Creating a static route")
-				updateDesiredStateAndWait(staticRouteState(firstSecondaryNic, "192.168.100.1", "192.168.200.0/24", "192.168.100.254"))
+				updateDesiredStateAtNodeAndWait(nodes[0], staticRouteState(firstSecondaryNic, "192.168.100.1", "192.168.200.0/24", "192.168.100.254"))
 
 				token, err := getPrometheusToken()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for static route count to increase")
-				expectedAfterCreate := initialStaticRouteCount + len(nodes)
+				expectedAfterCreate := initialStaticRouteCount + 1
 				Eventually(func() int {
 					metrics := getMetrics(token)
 					return sumRouteMetric(metrics, "ipv4", "static")
@@ -229,7 +229,7 @@ routes:
 					Should(Equal(expectedAfterCreate))
 
 				By("Deleting the static route")
-				updateDesiredStateAndWait(staticRouteAbsent(firstSecondaryNic))
+				updateDesiredStateAtNodeAndWait(nodes[0], staticRouteAbsent(firstSecondaryNic))
 
 				By("Verifying static route count decreased back to initial")
 				Eventually(func() int {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
The [periodic](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-latest/2005458904351248384) CI metrics tests where failing with: 

```
 NetworkManager Error (from NetworkManager.log):
  IP address 192.168.100.1 cannot be configured because it is already in use
  in the network by host 52:55:00:D1:56:06
```

This is failing after merging https://github.com/nmstate/kubernetes-nmstate/pull/1414, since it includes a e2e test that configure static routes at all the nodes with same IP and at newer NetworkManager ip collision detection is activated by default.

This PR configure static routes at just one node to prevent ip collision, is enough to check if counters are counting.

**Release note**:

```release-note
NONE
```
