### PR TITLE
reporter: add --notify-on flag to filter Slack notifications

### DIFF
--- a/.github/workflows/nightly-job-slack-bot.yml
+++ b/.github/workflows/nightly-job-slack-bot.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           NMSTATE_SLACK_WEBHOOK_URL: ${{ secrets.NMSTATE_SLACK_WEBHOOK_URL }}
         run: |
-          ./nmstate-latest-reporter
+          ./nmstate-latest-reporter --notify-on=failure --notify-on=stale

--- a/automation/nmstate-latest-reporter/README.md
+++ b/automation/nmstate-latest-reporter/README.md
@@ -12,15 +12,23 @@ The following GitHub secret needs to be configured in the repository:
 
 - `NMSTATE_SLACK_WEBHOOK_URL`: The Slack incoming webhook URL for posting messages
 
+### Command Line Flags
+
+- `--notify-on`: Events to notify on (can be specified multiple times). Valid values: `success`, `failure`, `stale`. Default: all events
+- `--fake`: Generate a fake report for testing. Valid values: `success`, `failure`, `stale`
+- `--dry-run`: Print the message without sending it to Slack
+
 ## How it Works
 
 1. The GitHub Action runs daily at 5:30 AM UTC (configurable via cron schedule)
 2. The reporter fetches the latest build information from the Prow storage bucket
 3. It checks the build status and timestamp
-4. A Slack message is posted with one of the following scenarios:
+4. Based on the `--notify-on` configuration, a Slack message may be posted for:
    - **Success**: Build passed - posts a success message with build details
    - **Failure**: Build failed - posts a failure message with build details
-   - **No Recent Build**: No build in the last 24 hours - posts a warning message
+   - **Stale**: No build in the last 24 hours - posts a warning message
+
+By default, the GitHub Action is configured to only notify on failures and stale builds to reduce noise.
 
 ## Message Format
 
@@ -48,6 +56,12 @@ export NMSTATE_SLACK_WEBHOOK_URL="your-webhook-url"
 # Build and run
 go build -v .
 ./nmstate-latest-reporter
+
+# Only notify on failures and stale builds (skip success)
+./nmstate-latest-reporter --notify-on=failure --notify-on=stale
+
+# Only notify on failures
+./nmstate-latest-reporter --notify-on=failure
 ```
 
 ### Testing with Fake Reports
@@ -56,10 +70,19 @@ You can generate fake reports for testing without fetching real Prow data:
 
 ```bash
 # Generate a fake success report
-./nmstate-latest-reporter -fake success
+./nmstate-latest-reporter --fake=success
 
 # Generate a fake failure report
-./nmstate-latest-reporter -fake failure
+./nmstate-latest-reporter --fake=failure
+
+# Generate a fake stale report
+./nmstate-latest-reporter --fake=stale
+
+# Test with dry-run (doesn't send to Slack)
+./nmstate-latest-reporter --fake=success --dry-run
+
+# Test notification filtering with fake data
+./nmstate-latest-reporter --fake=success --notify-on=failure --dry-run
 ```
 
 This is useful for:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new --notify-on flag to nmstate-latest-reporter that allows filtering which events trigger Slack notifications. The flag can be specified multiple times to select events (success, failure, stale).

Configure the GitHub Actions workflow to only notify on failures and stale builds, reducing noise from successful nightly builds while maintaining visibility into issues.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
