### PR TITLE
Remove nodeAffinity for `node-role.kubernetes.io/master`

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -218,11 +218,6 @@ spec:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
                     weight: 10
-                  - preference:
-                      matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
-                    weight: 1
               containers:
               - args:
                 - --zap-time-encoding=iso8601

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -36,11 +36,6 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
This node label is [removed since Kubernetes 1.24
](https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24)
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:

Removes the following warning during deployment:
```
Warning: spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].preference.matchExpressions[0].key: node-role.kubernetes.io/master is use "node-role.kubernetes.io/control-plane" instead
```


```release-note
Remove nodeAffinity for `node-role.kubernetes.io/master` (only used in Kubernetes < 1.24)
```
