### PR TITLE
For OCP node-selector should be annotation not a label

### DIFF
--- a/deploy/handler/namespace.yaml
+++ b/deploy/handler/namespace.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .HandlerNamespace }}
+{{- if .IsOpenShift }}
+  annotations:
+    openshift.io/node-selector: ""
+{{- end }}
   labels:
     name: {{ .HandlerNamespace }}
     pod-security.kubernetes.io/enforce: privileged
@@ -9,5 +13,4 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
 {{- if .IsOpenShift }}
     openshift.io/cluster-monitoring: "true"
-    openshift.io/node-selector: ""
 {{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
`openshift.io/node-selector` was mistakenly added as a label and not as an annotation to the namespace. It is now fixed
```
