### PR TITLE
fix(handler): Pending/NotPending returning wrong condition count

### DIFF
--- a/pkg/enactmentstatus/conditions/counter.go
+++ b/pkg/enactmentstatus/conditions/counter.go
@@ -96,10 +96,10 @@ func (c ConditionCount) NotProgressing() int {
 	return c.progressing().false()
 }
 func (c ConditionCount) Pending() int {
-	return c.progressing().true()
+	return c.pending().true()
 }
 func (c ConditionCount) NotPending() int {
-	return c.progressing().false()
+	return c.pending().false()
 }
 func (c ConditionCount) Available() int {
 	return c.available().true()

--- a/pkg/enactmentstatus/conditions/counter_test.go
+++ b/pkg/enactmentstatus/conditions/counter_test.go
@@ -294,4 +294,32 @@ var _ = Describe("Enactment condition counter", func() {
 			},
 		}),
 	)
+
+	Describe("helper methods", func() {
+		It("should return pending count from pending condition, not progressing", func() {
+			// Two pending enactments: pending=2, progressing=0
+			count := Count(enactments(
+				enactment(1, SetPending),
+				enactment(1, SetPending),
+			), 1)
+
+			Expect(count.Pending()).To(Equal(2))
+			Expect(count.NotPending()).To(Equal(0))
+			Expect(count.Progressing()).To(Equal(0))
+			Expect(count.NotProgressing()).To(Equal(2))
+		})
+
+		It("should return correct counts for mixed pending and progressing", func() {
+			// One pending, one progressing: pending=1, progressing=1
+			count := Count(enactments(
+				enactment(1, SetPending),
+				enactment(1, SetProgressing),
+			), 1)
+
+			Expect(count.Pending()).To(Equal(1))
+			Expect(count.NotPending()).To(Equal(1))
+			Expect(count.Progressing()).To(Equal(1))
+			Expect(count.NotProgressing()).To(Equal(1))
+		})
+	})
 })


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The Pending() and NotPending() methods were incorrectly using progressing() instead of pending(), returning wrong counts.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The Pending() and NotPending() methods were incorrectly using progressing() instead of pending(), returning wrong counts.
```
