### PR TITLE
fix(handler): Pending/NotPending returning wrong condition count

### DIFF
--- a/pkg/policyconditions/conditions.go
+++ b/pkg/policyconditions/conditions.go
@@ -296,6 +296,18 @@ func setPolicyStatus(policy *nmstatev1.NodeNetworkConfigurationPolicy, policySta
 			&policy.Status.Conditions,
 			message,
 		)
+	} else if policyStatus.enactmentsCountByCondition.Pending() > 0 {
+		message = fmt.Sprintf(
+			"Policy is progressing %d/%d nodes finished, %d pending",
+			policyStatus.numberOfFinishedEnactments,
+			policyStatus.numberOfReadyNmstateMatchingNodes,
+			policyStatus.enactmentsCountByCondition.Pending(),
+		)
+		informOfNotReadyNodes(policyStatus.numberOfNotReadyNmstateMatchingNodes)
+		SetPolicyProgressing(
+			&policy.Status.Conditions,
+			message,
+		)
 	} else {
 		message = fmt.Sprintf(
 			"%d/%d nodes successfully configured",

--- a/pkg/policyconditions/conditions_test.go
+++ b/pkg/policyconditions/conditions_test.go
@@ -351,5 +351,42 @@ var _ = Describe("Policy Conditions", func() {
 			Pods:   newNmstatePods(4),
 			Policy: p(SetPolicySuccess, "3/4 nodes successfully configured, 1 nodes ignored due to NotReady state"),
 		}),
+		Entry("when some enactments are pending and not all ready nodes finished, policy is progressing", ConditionsCase{
+			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetPending),
+			},
+			Nodes:  newNodes(3),
+			Pods:   newNmstatePods(3),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 2/3 nodes finished"),
+		}),
+		Entry("when all ready nodes finished but some are pending, policy is progressing not available", ConditionsCase{
+			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
+				e("node4", "policy1", enactmentconditions.SetPending),
+			},
+			Nodes: []corev1.Node{
+				newNode(1),
+				newNode(2),
+				newNode(3),
+				newNotReadyNode(4),
+			},
+			Pods:   newNmstatePods(4),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 3/3 nodes finished, 1 pending, 1 nodes ignored due to NotReady state"),
+		}),
+		Entry("when all ready nodes finished but some are pending due to MaxUnavailable, policy is progressing", ConditionsCase{
+			Enactments: []nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				e("node1", "policy1", enactmentconditions.SetSuccess),
+				e("node2", "policy1", enactmentconditions.SetSuccess),
+				e("node3", "policy1", enactmentconditions.SetSuccess),
+				e("node4", "policy1", enactmentconditions.SetPending),
+			},
+			Nodes:  newNodes(4),
+			Pods:   newNmstatePods(4),
+			Policy: p(SetPolicyProgressing, "Policy is progressing 3/4 nodes finished"),
+		}),
 	)
 })


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
When nodes are waiting for MaxUnavailable slots, their enactments are in Pending state. The policy status calculation was not checking for pending enactments before marking the policy as Available.

This could cause the policy to be marked Available when some nodes still haven't been configured, especially when combined with NotReady nodes that reduce the denominator in the finished/ready comparison.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use NNCE pending to calculate NNCP Status
```
