### PR TITLE
fix(test): delete policy before cleanup in invalid config AfterEach

### DIFF
--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -78,6 +78,12 @@ var _ = Describe("EnactmentCondition", func() {
 		})
 
 		AfterEach(func() {
+			// Delete the policy first to clear FailedToConfigure enactments left
+			// by the intentionally invalid configuration. Without this, updating
+			// the policy to remove the bridge inherits the failed enactment state,
+			// which can leave the policy stuck in Degraded and cause a flaky timeout.
+			By("Delete the policy to clear stale failed enactments")
+			deletePolicy(TestPolicy)
 			By("Remove the bridge")
 			updateDesiredStateAndWait(linuxBrAbsent(bridge1))
 			By("Reset desired state at all nodes")


### PR DESCRIPTION
**What this PR does / why we need it**:
The "EnactmentCondition when applying invalid configuration" AfterEach was flaky because it called updateDesiredStateAndWait (which expects the policy to reach Available) while enactments still carried FailedToConfigure status from the intentionally invalid configuration. When a node's handler was unstable (restarts, reboots), the stale failed enactment prevented the cleanup policy from ever reaching Available, causing a timeout.

Delete the policy first so that all enactments (including the failed ones) are removed. The subsequent bridge-removal policy then starts with a clean slate and can reach Available reliably. This matches the cleanup pattern already used in nncp_cleanup_test.go.

**Release note**:

```release-note
NONE
```
