### PR TITLE
fix: use Set/Delete instead of Inc/Dec for applied features gauge

### DIFF
--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -135,20 +135,6 @@ func NewStats(features []string) *Stats {
 	return &stats
 }
 
-func (s *Stats) Subtract(statsToSubstract *Stats) Stats {
-	// Clone the features
-	result := Stats{Features: map[string]bool{}}
-	for k, v := range s.Features {
-		result.Features[k] = v
-	}
-
-	// Subtract the selected ones
-	for f := range statsToSubstract.Features {
-		delete(result.Features, f)
-	}
-	return result
-}
-
 func Statistic(desiredState nmstate.State) (*Stats, error) {
 	statsOutput, err := nmstatectlWithInput(
 		[]string{"st", "-"},

--- a/test/e2e/handler/metrics_test.go
+++ b/test/e2e/handler/metrics_test.go
@@ -137,7 +137,7 @@ routes:
 					}).
 						WithPolling(time.Second).
 						WithTimeout(2 * time.Second).
-						Should(HaveKeyWithValue(monitoring.AppliedFeaturesOpts.Name+`{name="dhcpv4-custom-hostname"}`, "0"))
+						ShouldNot(HaveKey(monitoring.AppliedFeaturesOpts.Name + `{name="dhcpv4-custom-hostname"}`))
 				})
 			})
 		})


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The NNCE metrics controller used `Inc()`/`Dec()` with an `oldNNCEs` map to
track feature gauge transitions. This is fundamentally broken when
multiple NNCEs change the same feature simultaneously (the normal case
-- a policy targets all nodes), as `Inc`/`Dec` accumulates errors across
concurrent reconciliations.

Replace the `Inc()`/`Dec()` approach with `Set(1)`/`Delete()`, following the
same pattern used by the NNS metrics controller (`updateNodeInterfaceMetrics`).
On each reconciliation the full NNCE list is fetched, a deduplicated feature
set is built, and absolute gauge values are set. An `oldFeatures` set tracks
previously-seen feature names so stale metrics are cleaned up when a feature
disappears.

Also removes the now-dead `Stats.Subtract()` helper from `nmstatectl` and
fixes the e2e test to expect metric deletion instead of a zero value.

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
Fix applied features gauge double-counting by using absolute Set/Delete instead of incremental Inc/Dec
```