### PR TITLE
fix(handler): reset NNCE conditions on policy generation change

### DIFF
--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -453,7 +453,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) fillInEnactmentStatus(
 			r.APIClient,
 			nmstateapi.EnactmentKey(nodeName, policy.Name),
 			func(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus) {
-				status.PolicyGeneration = policy.Generation
+				resetPolicyGeneration(status, policy.Generation)
 			},
 		)
 		if err2 != nil {
@@ -483,12 +483,23 @@ func (r *NodeNetworkConfigurationPolicyReconciler) fillInEnactmentStatus(
 		r.APIClient,
 		nmstateapi.EnactmentKey(nodeName, policy.Name),
 		func(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus) {
+			resetPolicyGeneration(status, policy.Generation)
 			status.DesiredState = desiredStateWithDefaults
 			status.CapturedStates = capturedStates
-			status.PolicyGeneration = policy.Generation
 			status.Features = features
 		},
 	)
+}
+
+// resetPolicyGeneration updates the enactment's PolicyGeneration and clears
+// stale conditions when the generation changes. This prevents
+// policyconditions.Update on other handlers from misattributing
+// previous-generation failure conditions to the new generation.
+func resetPolicyGeneration(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus, generation int64) {
+	if status.PolicyGeneration != generation {
+		status.Conditions = nmstateapi.ConditionList{}
+	}
+	status.PolicyGeneration = generation
 }
 
 func (r *NodeNetworkConfigurationPolicyReconciler) enactmentForPolicy(

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -416,4 +416,117 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 			})
 		})
 	})
+
+	Describe("fillInEnactmentStatus", func() {
+		var (
+			reconciler *NodeNetworkConfigurationPolicyReconciler
+			s          *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			nmstatectlShowFn = func() (string, error) { return "", nil }
+			reconciler = &NodeNetworkConfigurationPolicyReconciler{}
+			s = scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NodeNetworkState{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactment{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactmentList{},
+			)
+			s.AddKnownTypes(nmstatev1.GroupVersion,
+				&nmstatev1.NodeNetworkConfigurationPolicy{},
+			)
+			reconciler.Log = ctrl.Log.WithName("test")
+		})
+
+		Context("when policy generation changes", func() {
+			It("should reset enactment conditions", func() {
+				nncp := nmstatev1.NodeNetworkConfigurationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test",
+						Generation: 2,
+					},
+				}
+				nnce := nmstatev1beta1.NodeNetworkConfigurationEnactment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: shared.EnactmentKey(nodeName, nncp.Name).Name,
+						Labels: map[string]string{
+							shared.EnactmentPolicyLabel: nncp.Name,
+						},
+					},
+					Status: shared.NodeNetworkConfigurationEnactmentStatus{
+						PolicyGeneration: 1,
+					},
+				}
+				// Set stale Failing conditions from previous generation
+				conditions.SetFailedToConfigure(&nnce.Status.Conditions, "previous generation failure")
+
+				clb := fake.ClientBuilder{}
+				clb.WithScheme(s)
+				clb.WithRuntimeObjects(&nncp, &nnce)
+				clb.WithStatusSubresource(&nnce)
+				cl := clb.Build()
+
+				reconciler.Client = cl
+				reconciler.APIClient = cl
+
+				enactmentConditions := conditions.New(cl, shared.EnactmentKey(nodeName, nncp.Name))
+
+				err := reconciler.fillInEnactmentStatus(context.TODO(), &nncp, &nnce, enactmentConditions)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedNNCE := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
+				err = cl.Get(context.TODO(), shared.EnactmentKey(nodeName, nncp.Name), updatedNNCE)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(updatedNNCE.Status.PolicyGeneration).To(Equal(int64(2)))
+				Expect(updatedNNCE.Status.Conditions).To(BeEmpty(),
+					"conditions should be reset when generation changes")
+			})
+		})
+
+		Context("when policy generation stays the same", func() {
+			It("should preserve enactment conditions", func() {
+				nncp := nmstatev1.NodeNetworkConfigurationPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test",
+						Generation: 1,
+					},
+				}
+				nnce := nmstatev1beta1.NodeNetworkConfigurationEnactment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: shared.EnactmentKey(nodeName, nncp.Name).Name,
+						Labels: map[string]string{
+							shared.EnactmentPolicyLabel: nncp.Name,
+						},
+					},
+					Status: shared.NodeNetworkConfigurationEnactmentStatus{
+						PolicyGeneration: 1,
+					},
+				}
+				conditions.SetProgressing(&nnce.Status.Conditions, "Applying desired state")
+
+				clb := fake.ClientBuilder{}
+				clb.WithScheme(s)
+				clb.WithRuntimeObjects(&nncp, &nnce)
+				clb.WithStatusSubresource(&nnce)
+				cl := clb.Build()
+
+				reconciler.Client = cl
+				reconciler.APIClient = cl
+
+				enactmentConditions := conditions.New(cl, shared.EnactmentKey(nodeName, nncp.Name))
+
+				err := reconciler.fillInEnactmentStatus(context.TODO(), &nncp, &nnce, enactmentConditions)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedNNCE := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
+				err = cl.Get(context.TODO(), shared.EnactmentKey(nodeName, nncp.Name), updatedNNCE)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(updatedNNCE.Status.PolicyGeneration).To(Equal(int64(1)))
+				Expect(updatedNNCE.Status.Conditions).ToNot(BeEmpty(),
+					"conditions should be preserved when generation stays the same")
+			})
+		})
+	})
 })


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
When fillInEnactmentStatus updates PolicyGeneration on an enactment without clearing its conditions, there is a race window where stale failure conditions from a previous generation are attributed to the new generation. If another handler's deferred policyconditions.Update runs during this window, it sees the enactment with the new generation but old Failing=True conditions, causing the NNCP to be incorrectly set to Degraded.

This was observed in CI as a periodic flake in the "rollback when name servers (configured globally) are wrong" e2e test: the AfterEach cleanup updates the policy (bumping generation), but node02's enactment retains stale Failing conditions from the bad DNS test, causing the cleanup reset policy to be marked Degraded instead of Available.

Clear enactment conditions when PolicyGeneration changes in fillInEnactmentStatus, so that policyconditions.Update cannot misattribute stale conditions to the new generation.

**Special notes for your reviewer**:
Discovered during periodic runs https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-latest/2025752632722722816

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Reset NNCE conditions on policy generation change
```
