### PR TITLE
probes: prefer ipv4 gateway over ipv6 for ping probes

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -141,19 +141,36 @@ func checkNodeReadiness(ctx context.Context, cli client.Client) (bool, error) {
 }
 
 func defaultGw(currentState gjson.Result) (Route, error) {
-	var found Route
+	var ipv4Gw, ipv6Gw Route
 	currentState.Get("routes.running").ForEach(
 		func(_, v gjson.Result) bool {
-			// we want to pick the next hop related to the "main" table because we may have multiple tables
-			if (v.Get("destination").String() == "0.0.0.0/0" || v.Get("destination").String() == "::/0") &&
-				v.Get("table-id").Int() == mainRoutingTableID {
-				found.nextHop = net.ParseIP(v.Get("next-hop-address").String())
-				found.iface = v.Get("next-hop-interface").String()
-				return false
+			if v.Get("table-id").Int() != mainRoutingTableID {
+				return true
+			}
+			dest := v.Get("destination").String()
+			switch dest {
+			case "0.0.0.0/0":
+				if ipv4Gw.nextHop == nil {
+					ipv4Gw.nextHop = net.ParseIP(v.Get("next-hop-address").String())
+					ipv4Gw.iface = v.Get("next-hop-interface").String()
+				}
+			case "::/0":
+				if ipv6Gw.nextHop == nil {
+					ipv6Gw.nextHop = net.ParseIP(v.Get("next-hop-address").String())
+					ipv6Gw.iface = v.Get("next-hop-interface").String()
+				}
 			}
 			return true
 		},
 	)
+
+	// Prefer IPv4 default route over IPv6 (e.g. avoid IPv6 link-local ping issues)
+	var found Route
+	if ipv4Gw.nextHop != nil {
+		found = ipv4Gw
+	} else if ipv6Gw.nextHop != nil {
+		found = ipv6Gw
+	}
 
 	if found.nextHop == nil {
 		msg := "default gw missing"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**: I have encountered ping probe issues when it uses ipv6 for ping probes with ipv6 link local addresses. Ping probe was failing for ipv6 link-local address and this adds 2minutes delay for the NNCP/NNCE status to be set to Available. 
I suggest to prefer using ipv4 gateway for ping probe over ipv6 if both are present.

> Uncomment only one, leave it on its own line:
>
> /kind bug
 /kind enhancement

**What this PR does / why we need it**: Improve time to report Policy status

**Special notes for your reviewer**: 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
