### PR TITLE
fix(handler): create one ping probe per gateway for dual-stack support

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -140,22 +140,23 @@ func checkNodeReadiness(ctx context.Context, cli client.Client) (bool, error) {
 	return false, nil
 }
 
-func defaultGw(currentState gjson.Result) (Route, error) {
-	var found Route
+func defaultGws(currentState gjson.Result) ([]Route, error) {
+	var found []Route
 	currentState.Get("routes.running").ForEach(
 		func(_, v gjson.Result) bool {
-			// we want to pick the next hop related to the "main" table because we may have multiple tables
+			// we want to pick the next hops related to the "main" table because we may have multiple tables
 			if (v.Get("destination").String() == "0.0.0.0/0" || v.Get("destination").String() == "::/0") &&
 				v.Get("table-id").Int() == mainRoutingTableID {
-				found.nextHop = net.ParseIP(v.Get("next-hop-address").String())
-				found.iface = v.Get("next-hop-interface").String()
-				return false
+				found = append(found, Route{
+					nextHop: net.ParseIP(v.Get("next-hop-address").String()),
+					iface:   v.Get("next-hop-interface").String(),
+				})
 			}
 			return true
 		},
 	)
 
-	if found.nextHop == nil {
+	if len(found) == 0 {
 		msg := "default gw missing"
 		defaultGwLog := log.WithValues("path", "routes.running.next-hop-address", "table-id", mainRoutingTableID)
 		defaultGwLogDebug := defaultGwLog.V(1)
@@ -164,35 +165,71 @@ func defaultGw(currentState gjson.Result) (Route, error) {
 		} else {
 			defaultGwLog.Info(msg)
 		}
-		return Route{}, errors.New(msg)
+		return nil, errors.New(msg)
 	}
 	return found, nil
 }
 
-func pingCondition(cli client.Client, timeout time.Duration) wait.ConditionWithContextFunc {
-	return func(context.Context) (bool, error) {
-		return runPing(cli)
+func pingConditionForGateway(gwIP net.IP) func(client.Client, time.Duration) wait.ConditionWithContextFunc {
+	return func(_ client.Client, _ time.Duration) wait.ConditionWithContextFunc {
+		return func(context.Context) (bool, error) {
+			// Re-discover the current route for this gateway IP so that the interface
+			// is up to date (e.g. after NNCP moves eth0 under a bridge or bond).
+			gjsonCurrentState, err := currentStateAsGJson()
+			if err != nil {
+				log.Error(err, "failed retrieving current state for ping probe")
+				return false, nil
+			}
+			gws, err := defaultGws(gjsonCurrentState)
+			if err != nil {
+				log.Error(err, "failed to retrieve default gateways for ping probe")
+				return false, nil
+			}
+			for _, gw := range gws {
+				if gw.nextHop.Equal(gwIP) {
+					pingOutput, err := ping(gw)
+					if err != nil {
+						log.Error(err, fmt.Sprintf("error pinging gateway %s via %s -> output: '%s'", gw.nextHop, gw.iface, pingOutput))
+						return false, nil
+					}
+					return true, nil
+				}
+			}
+			log.Info(fmt.Sprintf("gateway %s no longer in routing table", gwIP))
+			return false, nil
+		}
 	}
 }
 
-func runPing(_ client.Client) (bool, error) {
+func selectPingProbes(ctx context.Context, cli client.Client) []Probe {
+	var probes []Probe
+
 	gjsonCurrentState, err := currentStateAsGJson()
 	if err != nil {
-		return false, errors.Wrap(err, "failed retrieving current state to retrieve default gw")
+		log.Error(err, "failed retrieving current state for ping probe gateway discovery")
+		return probes
 	}
 
-	defaultGw, err := defaultGw(gjsonCurrentState)
+	gws, err := defaultGws(gjsonCurrentState)
 	if err != nil {
-		log.Error(err, "failed to retrieve default gw")
-		return false, nil
+		log.Info(fmt.Sprintf("WARNING: no default gateways found for ping probes: %v", err))
+		return probes
 	}
 
-	pingOutput, err := ping(defaultGw)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("error pinging default gateway -> output: '%s'", pingOutput))
-		return false, nil
+	for _, gw := range gws {
+		p := Probe{
+			name:      fmt.Sprintf("ping-%s", gw.nextHop),
+			timeout:   defaultGwProbeTimeout,
+			condition: pingConditionForGateway(gw.nextHop),
+		}
+		err := wait.PollUntilContextTimeout(ctx, time.Second, p.timeout, true, p.condition(cli, p.timeout))
+		if err == nil {
+			probes = append(probes, p)
+		} else {
+			log.Info(fmt.Sprintf("WARNING not selecting %s probe", p.name))
+		}
 	}
-	return true, nil
+	return probes
 }
 
 func ping(target Route) (string, error) {
@@ -269,27 +306,18 @@ func runDNS(_ client.Client, timeout time.Duration) (bool, error) {
 // Select will return the external connectivity probes that are working (ping and dns) and
 // the internal connectivity probes
 func Select(ctx context.Context, cli client.Client) []Probe {
-	probes := []Probe{}
-	externalConnectivityProbes := []Probe{
-		{
-			name:      "ping",
-			timeout:   defaultGwProbeTimeout,
-			condition: pingCondition,
-		},
-		{
-			name:      "dns",
-			timeout:   defaultDNSProbeTimeout,
-			condition: dnsCondition,
-		},
-	}
+	probes := selectPingProbes(ctx, cli)
 
-	for _, p := range externalConnectivityProbes {
-		err := wait.PollUntilContextTimeout(ctx, time.Second, p.timeout, true /*immediate*/, p.condition(cli, p.timeout))
-		if err == nil {
-			probes = append(probes, p)
-		} else {
-			log.Info(fmt.Sprintf("WARNING not selecting %s probe", p.name))
-		}
+	dnsProbe := Probe{
+		name:      "dns",
+		timeout:   defaultDNSProbeTimeout,
+		condition: dnsCondition,
+	}
+	err := wait.PollUntilContextTimeout(ctx, time.Second, dnsProbe.timeout, true /*immediate*/, dnsProbe.condition(cli, dnsProbe.timeout))
+	if err == nil {
+		probes = append(probes, dnsProbe)
+	} else {
+		log.Info(fmt.Sprintf("WARNING not selecting %s probe", dnsProbe.name))
 	}
 
 	probes = append(probes,

--- a/pkg/probe/probes_test.go
+++ b/pkg/probe/probes_test.go
@@ -25,11 +25,10 @@ import (
 // nolint: funlen
 func TestDefaultGatewayParsing(t *testing.T) {
 	tests := []struct {
-		desc          string
-		status        string
-		expectedGw    string
-		expectedIface string
-		shouldErr     bool
+		desc           string
+		status         string
+		expectedRoutes []Route
+		shouldErr      bool
 	}{
 		{
 			desc: "one single gateway",
@@ -45,8 +44,9 @@ func TestDefaultGatewayParsing(t *testing.T) {
     metric: 48
     table-id: 254
 `,
-			expectedGw:    "10.46.55.254",
-			expectedIface: "eth1",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("10.46.55.254"), iface: "eth1"},
+			},
 		}, {
 			desc: "two gateways, one on custom routing table",
 			status: `routes:
@@ -65,8 +65,9 @@ func TestDefaultGatewayParsing(t *testing.T) {
     metric: 48
     table-id: 254
 `,
-			expectedGw:    "10.46.55.254",
-			expectedIface: "eth1",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("10.46.55.254"), iface: "eth1"},
+			},
 		}, {
 			desc: "no next-hop-address",
 			status: `routes:
@@ -86,8 +87,9 @@ func TestDefaultGatewayParsing(t *testing.T) {
     next-hop-address: fe80::dead:beef:fe51:782d
     table-id: 254
 `,
-			expectedGw:    "fe80::dead:beef:fe51:782d",
-			expectedIface: "eth0",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("fe80::dead:beef:fe51:782d"), iface: "eth0"},
+			},
 		}, {
 			desc: "two IPv6 gateways, one on custom routing table",
 			status: `routes:
@@ -101,8 +103,9 @@ func TestDefaultGatewayParsing(t *testing.T) {
     next-hop-address: fe80::baad:cafe:fe51:782d
     table-id: 56
 `,
-			expectedGw:    "fe80::dead:beef:fe51:782d",
-			expectedIface: "eth0",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("fe80::dead:beef:fe51:782d"), iface: "eth0"},
+			},
 		}, {
 			desc: "dual-stack with single gateway per IP stack",
 			status: `routes:
@@ -116,8 +119,10 @@ func TestDefaultGatewayParsing(t *testing.T) {
     next-hop-address: fe80::dead:beef:fe51:782d
     table-id: 254
 `,
-			expectedGw:    "10.46.55.254",
-			expectedIface: "eth0",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("10.46.55.254"), iface: "eth0"},
+				{nextHop: net.ParseIP("fe80::dead:beef:fe51:782d"), iface: "eth0"},
+			},
 		}, {
 			desc: "dual-stack with missing IPv4 default gateway",
 			status: `routes:
@@ -131,8 +136,9 @@ func TestDefaultGatewayParsing(t *testing.T) {
     next-hop-address: fe80::dead:beef:fe51:782d
     table-id: 254
 `,
-			expectedGw:    "fe80::dead:beef:fe51:782d",
-			expectedIface: "eth1",
+			expectedRoutes: []Route{
+				{nextHop: net.ParseIP("fe80::dead:beef:fe51:782d"), iface: "eth1"},
+			},
 		},
 	}
 
@@ -142,21 +148,25 @@ func TestDefaultGatewayParsing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse test status, %v", err)
 			}
-			defaultGw, err := defaultGw(gJSON)
+			gws, err := defaultGws(gJSON)
 			if err != nil && !test.shouldErr {
 				t.Fatalf("unexpected error %v", err)
 			}
 			if test.shouldErr && err == nil {
 				t.Fatalf("expecting error, did not fail")
 			}
-
-			expectedRoute := Route{
-				nextHop: net.ParseIP(test.expectedGw),
-				iface:   test.expectedIface,
+			if test.shouldErr {
+				return
 			}
 
-			if !expectedRoute.nextHop.Equal(defaultGw.nextHop) || expectedRoute.iface != defaultGw.iface {
-				t.Fatalf("expecting %+v, got %+v", expectedRoute, defaultGw)
+			if len(gws) != len(test.expectedRoutes) {
+				t.Fatalf("expecting %d gateways, got %d: %+v", len(test.expectedRoutes), len(gws), gws)
+			}
+
+			for i, expected := range test.expectedRoutes {
+				if !expected.nextHop.Equal(gws[i].nextHop) || expected.iface != gws[i].iface {
+					t.Fatalf("gateway %d: expecting %+v, got %+v", i, expected, gws[i])
+				}
 			}
 		})
 	}

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -37,6 +37,10 @@ func boundUpWithPrimaryAndSecondary(bondName string) nmstate.State {
     ipv4:
       dhcp: true
       enabled: true
+    ipv6:
+      autoconf: true
+      dhcp: true
+      enabled: true
     link-aggregation:
       mode: active-backup
       options:
@@ -57,6 +61,10 @@ func bondAbsentWithPrimaryUp(bondName string) nmstate.State {
     state: up
     type: ethernet
     ipv4:
+      dhcp: true
+      enabled: true
+    ipv6:
+      autoconf: true
       dhcp: true
       enabled: true
 `, bondName, primaryNic))

--- a/test/e2e/handler/default_bridged_network_test.go
+++ b/test/e2e/handler/default_bridged_network_test.go
@@ -41,6 +41,10 @@ func createBridgeOnTheDefaultInterface() nmstate.State {
     ipv4:
       dhcp: true
       enabled: true
+    ipv6:
+      autoconf: true
+      dhcp: true
+      enabled: true
     bridge:
       options:
         stp:
@@ -58,6 +62,10 @@ func resetDefaultInterface() nmstate.State {
     ipv4:
       enabled: true
       dhcp: true
+    ipv6:
+      autoconf: true
+      dhcp: true
+      enabled: true
   - name: brext
     type: linux-bridge
     state: absent

--- a/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
+++ b/test/e2e/handler/default_bridged_network_with_nmpolicy_test.go
@@ -64,6 +64,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
     ipv4:
       dhcp: true
       enabled: true
+    ipv6:
+      autoconf: true
+      dhcp: true
+      enabled: true
     bridge:
       options:
         stp:
@@ -92,6 +96,10 @@ var _ = Describe("NodeNetworkConfigurationPolicy default bridged network with nm
     ipv4:
       enabled: true
       dhcp: true
+    ipv6:
+      autoconf: true
+      dhcp: true
+      enabled: true
   - name: brext
     type: linux-bridge
     state: absent

--- a/test/e2e/handler/default_ovs_bridged_network_test.go
+++ b/test/e2e/handler/default_ovs_bridged_network_test.go
@@ -36,6 +36,10 @@ func ovsBridgeWithTheDefaultInterface(ovsBridgeName, defaultInterfaceMac string)
   ipv4:
     enabled: true
     dhcp: true
+  ipv6:
+    autoconf: true
+    dhcp: true
+    enabled: true
   mac-address: %s
 - name: %s
   type: ovs-bridge
@@ -57,6 +61,10 @@ func ovsBridgeWithTheDefaultInterfaceAbsent(ovsBridgeName, ovsBridgeInternalPort
   ipv4:
     enabled: true
     dhcp: true
+  ipv6:
+    autoconf: true
+    dhcp: true
+    enabled: true
 - name: %s
   type: ovs-interface
   state: absent


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind enhancement

**What this PR does / why we need it**:
The gateway ping probe previously returned only the first default gateway found, missing the second gateway in dual-stack (IPv4+IPv6) scenarios. This meant broken connectivity to the untested gateway would not trigger a rollback. Now all default gateways from routing table 254 are discovered and each gets its own independent ping probe.

**Release note**:
```release-note
Support dual stack at gw ping probe
```
