### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly-job-slack-bot.yml
+++ b/.github/workflows/nightly-job-slack-bot.yml
@@ -14,6 +14,8 @@ jobs:
     name: Latest-job slack bot
     if: github.repository == 'nmstate/kubernetes-nmstate'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/nmstate/kubernetes-nmstate/security/code-scanning/2](https://github.com/nmstate/kubernetes-nmstate/security/code-scanning/2)

In general, the fix is to explicitly specify a `permissions` block in the workflow or job so that the `GITHUB_TOKEN` has only the minimal rights required. Since this job only checks out code and builds/runs a Go program, it should only need read access to repository contents. Therefore, we can set `permissions: contents: read`. We can apply this at the job level for `build-and-run-slack-bot`, which directly addresses the highlighted job and avoids affecting other workflows.

Edit `.github/workflows/nightly-job-slack-bot.yml` in the `jobs.build-and-run-slack-bot` section. Directly under the existing job keys (e.g., after `runs-on: ubuntu-latest`), add a `permissions:` mapping with `contents: read`. No additional imports, methods, or other definitions are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
