### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ on:
         - release-0.47
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Check out code from ${{ github.event.inputs.baseBranch }}


### PR DESCRIPTION
Potential fix for [https://github.com/nmstate/kubernetes-nmstate/security/code-scanning/1](https://github.com/nmstate/kubernetes-nmstate/security/code-scanning/1)

In general, the problem is that the job uses the default `GITHUB_TOKEN` permissions rather than explicitly declaring what it needs. The fix is to add a `permissions` block either at the workflow root (applying to all jobs) or within the `release` job, specifying the minimal set of permissions required. Since this workflow must push a new tag, it needs `contents: write` (read-only would break the tag push). Other scopes (issues, pull-requests, etc.) are not used and should remain unset.

The best targeted fix without changing functionality is to add a `permissions` block under the `release` job, just before `runs-on`. This keeps the change localized to that job and clearly documents that it needs write access to repository contents. Concretely, in `.github/workflows/release.yml`, after line 25 (`release:`) and before line 26 (`runs-on: ubuntu-latest`), insert:

```yaml
    permissions:
      contents: write
```

No imports or additional methods are needed; GitHub Actions natively understands the `permissions` key in workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
