### PR TITLE
fix(operator): add dedicated service account for console plugin

### DIFF
--- a/deploy/openshift/ui-plugin/deployment.yaml
+++ b/deploy/openshift/ui-plugin/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       {{- if .InfraAffinity }}
       affinity: {{ toYaml .InfraAffinity | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ .PluginName }}
       containers:
         - name: {{ .PluginName }}
           image: {{ .PluginImage }}

--- a/deploy/openshift/ui-plugin/service_account.yaml
+++ b/deploy/openshift/ui-plugin/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .PluginName }}
+  namespace: {{ .PluginNamespace }}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The `nmstate-console-plugin` deployment was using the `default` service account, which triggers the OpenShift monitor `no-default-service-account-operator-checker`:

> all pods in openshift-nmstate namespace must not use the default service account

This PR adds a dedicated `ServiceAccount` for the console plugin and references it in the deployment spec.

**Special notes for your reviewer**:

The `RenderDir` function sorts manifests alphabetically by filename, so `service_account.yaml` is applied after `deployment.yaml`. This is the same pattern used by the handler component and is safe because the rolling update strategy keeps the old pod running until the new one is ready.

**Release note**:

```release-note
Fix console plugin pod using the default service account, which violated OpenShift's no-default-service-account policy.
```