### PR TITLE
fix(e2e): set maxUnavailable to 2 to preserve parallel test coverage

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -48,6 +48,7 @@ teardown() {
 
 main() {
     export KUBEVIRT_NUM_NODES=4 # 1 control-plane, 3 workers
+    export NMSTATE_MAX_UNAVAILABLE=2
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -718,7 +718,7 @@ func skipIfNotKubernetes() {
 }
 
 func maxUnavailableNodes() int {
-	m, _ := nmstatenode.ScaledMaxUnavailableNodeCount(len(nodes), intstr.FromString(nmstatenode.DefaultMaxunavailable))
+	m, _ := nmstatenode.ScaledMaxUnavailableNodeCount(len(nodes), intstr.FromString(maxUnavailable))
 	return m
 }
 


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:

Sets `NMSTATE_MAX_UNAVAILABLE=2` in the e2e handler CI script to preserve parallel processing test coverage after the node reduction in #1464.

With 3 workers and the default `maxUnavailable` of `50%`, only 1 node can progress at a time (`floor(3 * 0.5) = 1`). This means the `should be progressing on multiple nodes` test no longer validates that multiple nodes process in parallel — it effectively tests serial execution.

Setting `maxUnavailable=2` ensures 2 out of 3 workers progress simultaneously while 1 is aborted, keeping meaningful coverage of the maxUnavailable capping and abort logic.

**Special notes for your reviewer**:

The `NMSTATE_MAX_UNAVAILABLE` env var is already supported by the test framework (`test/e2e/handler/utils.go:60`) and feeds into every NNCP's `maxUnavailable` field. No test code changes needed.

**Release note**:

```release-note
NONE
```