### PR TITLE
fix(handler): eliminate API server dependency at startup for TLS config

### DIFF
--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -16,6 +16,7 @@ COPY --from=build /manager /usr/local/bin/manager
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/
 COPY deploy/handler/namespace.yaml /bindata/kubernetes-nmstate/namespace/
 COPY deploy/handler/operator.yaml /bindata/kubernetes-nmstate/handler/handler.yaml
+COPY deploy/handler/tls_config.yaml /bindata/kubernetes-nmstate/handler/tls_config.yaml
 COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -152,6 +152,14 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - console.openshift.io
           resources:
           - consoleplugins

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -68,11 +68,13 @@ import (
 	nmstatelog "github.com/nmstate/kubernetes-nmstate/pkg/log"
 	"github.com/nmstate/kubernetes-nmstate/pkg/monitoring"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
-	nmstatetls "github.com/nmstate/kubernetes-nmstate/pkg/tls"
 	"github.com/nmstate/kubernetes-nmstate/pkg/webhook"
 )
 
-const generalExitStatus int = 1
+const (
+	generalExitStatus    int    = 1
+	tlsProfileConfigPath string = "/etc/nmstate/tls/profile.json"
+)
 
 const (
 	defaultRetriesUntilFail = 5
@@ -143,37 +145,36 @@ func mainHandler() int {
 
 	cfg := ctrl.GetConfigOrDie()
 
-	// Detect OpenShift and fetch TLS profile early, before creating the
-	// manager, so both the metrics server and webhooks share the same config.
-	platformTLSOpts, err := cluster.FetchOpenShiftTLSOpts(cfg, scheme)
-	if err != nil {
-		setupLog.Error(err, "unable to fetch TLS configuration")
-		return generalExitStatus
+	// Detect OpenShift from env var set by the operator, avoiding an API
+	// server call that can fail when network connectivity is temporarily
+	// unavailable (e.g. during default interface reconfiguration).
+	isOpenShift := cluster.IsOpenShiftFromEnv()
+
+	var platformTLSOpts func(*tls.Config)
+	// Only load TLS profile on OpenShift for components that serve TLS
+	// (webhook and metrics). The handler DaemonSet uses default TLS.
+	// Read from a ConfigMap-mounted file to avoid API server calls.
+	// TLS profile changes are handled by the operator: it updates the
+	// ConfigMap and rolls the Deployments via a hash annotation.
+	if isOpenShift && !environment.IsHandler() {
+		opts, _, err := cluster.FetchTLSProfileFromFile(tlsProfileConfigPath)
+		if err != nil {
+			setupLog.Error(err, "unable to load TLS configuration from file")
+			return generalExitStatus
+		}
+		platformTLSOpts = opts
 	}
 
 	// Compose the TLS opts applied to all TLS-enabled servers.
 	tlsOpts := composeTLSOpts(platformTLSOpts)
 
-	mgr, err := createManager(cfg, tlsOpts, platformTLSOpts != nil /*isOpenShift*/)
+	mgr, err := createManager(cfg, tlsOpts, platformTLSOpts != nil)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		return generalExitStatus
 	}
 
-	// Create a cancellable context so that controllers (e.g. the TLS
-	// security profile watcher) can trigger a graceful shutdown.
-	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
-	defer cancel()
-
-	// On OpenShift, watch for TLS profile changes on processes that serve
-	// TLS (webhook and metrics) and trigger a graceful shutdown so they
-	// restart with the new configuration.
-	if platformTLSOpts != nil && (environment.IsWebhook() || environment.IsMetricsManager()) {
-		if err := setupTLSProfileWatcher(mgr, cancel); err != nil {
-			setupLog.Error(err, "unable to set up TLS profile watcher")
-			return generalExitStatus
-		}
-	}
+	ctx := ctrl.SetupSignalHandler()
 
 	if err := setupControllersByEnvironment(mgr, tlsOpts); err != nil {
 		return generalExitStatus
@@ -217,32 +218,6 @@ func composeTLSOpts(tlsOpts func(*tls.Config)) func(*tls.Config) {
 		}
 		c.NextProtos = []string{"http/1.1"}
 	}
-}
-
-// setupTLSProfileWatcher watches for platform TLS profile changes and
-// triggers a graceful shutdown so the process restarts with the new config.
-func setupTLSProfileWatcher(mgr manager.Manager, cancel context.CancelFunc) error {
-	// Use a non-cached client for the initial fetch because the manager's
-	// cache is not started yet at this point.
-	apiClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
-	if err != nil {
-		return fmt.Errorf("failed creating client for TLS profile watcher: %w", err)
-	}
-
-	tlsProfileSpec, err := nmstatetls.FetchAPIServerTLSProfile(context.Background(), apiClient)
-	if err != nil {
-		return fmt.Errorf("unable to get initial TLS profile for watcher: %w", err)
-	}
-
-	return (&nmstatetls.SecurityProfileWatcher{
-		Client:                mgr.GetClient(),
-		InitialTLSProfileSpec: tlsProfileSpec,
-		OnProfileChange: func(ctx context.Context, oldSpec, newSpec nmstatetls.TLSProfileSpec) {
-			setupLog.Info("TLS profile has changed, initiating shutdown to reload",
-				"oldProfile", oldSpec, "newProfile", newSpec)
-			cancel()
-		},
-	}).SetupWithManager(mgr)
 }
 
 // createManager creates and configures the controller manager.

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -19,6 +19,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,12 +45,15 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/nmstate/kubernetes-nmstate/api/names"
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 	"github.com/nmstate/kubernetes-nmstate/pkg/environment"
 	"github.com/nmstate/kubernetes-nmstate/pkg/render"
+	nmstatetls "github.com/nmstate/kubernetes-nmstate/pkg/tls"
 )
 
 const (
@@ -82,6 +87,7 @@ type NMStateReconciler struct {
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;get;watch;update
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors;prometheusrules,verbs=list;get;watch;update;create;patch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs="*"
+// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers,verbs=get;list;watch
 
 func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("nmstate", req.NamespacedName)
@@ -145,11 +151,33 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&nmstatev1.NMState{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&appsv1.DaemonSet{}).
-		Complete(r)
+		Owns(&appsv1.DaemonSet{})
+
+	// On OpenShift, watch APIServer CR changes to detect TLS profile updates.
+	// This triggers a reconcile that updates the TLS ConfigMap and rolls
+	// webhook/metrics Deployments via a hash annotation.
+	if r.IsOpenShift {
+		apiServerObj := &unstructured.Unstructured{}
+		apiServerObj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "config.openshift.io",
+			Version: "v1",
+			Kind:    "APIServer",
+		})
+		builder = builder.WatchesRawSource(source.Kind(
+			mgr.GetCache(),
+			apiServerObj,
+			handler.TypedEnqueueRequestsFromMapFunc(
+				func(ctx context.Context, obj *unstructured.Unstructured) []ctrl.Request {
+					return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: "nmstate"}}}
+				},
+			),
+		))
+	}
+
+	return builder.Complete(r)
 }
 
 func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx context.Context) error {
@@ -360,6 +388,23 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["NNCPMaxRetries"] = environment.GetEnvVar("NNCP_MAX_RETRIES", "5")
 	data.Data["NNCPMaxBackoffSeconds"] = environment.GetEnvVar("NNCP_MAX_BACKOFF_SECONDS", "30")
 	data.Data["NNCPInitialBackoffSeconds"] = environment.GetEnvVar("NNCP_INITIAL_BACKOFF_SECONDS", "1")
+
+	// On OpenShift, fetch and serialize the TLS profile so handler-deployed
+	// pods can read it from a ConfigMap instead of calling the API server.
+	// A hash annotation on the pod templates triggers a rolling restart
+	// when the TLS profile changes.
+	if r.IsOpenShift {
+		tlsProfileSpec, err := nmstatetls.FetchAPIServerTLSProfile(ctx, r.APIClient)
+		if err != nil {
+			return fmt.Errorf("failed fetching TLS profile for ConfigMap: %w", err)
+		}
+		tlsJSON, err := json.Marshal(tlsProfileSpec)
+		if err != nil {
+			return fmt.Errorf("failed serializing TLS profile: %w", err)
+		}
+		data.Data["TLSProfileJSON"] = string(tlsJSON)
+		data.Data["TLSProfileHash"] = fmt.Sprintf("%x", sha256.Sum256(tlsJSON))
+	}
 
 	return r.renderAndApply(ctx, instance, data, "handler", true)
 }

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -27,6 +27,9 @@ spec:
         description: kubernetes-nmstate-metrics dump nmstate metrics
         target.workload.openshift.io/management: |
           {"effect": "PreferredDuringScheduling"}
+{{- if .IsOpenShift }}
+        nmstate.io/tls-profile-hash: "{{ .TLSProfileHash }}"
+{{- end }}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -78,6 +81,8 @@ spec:
               value: "6060"
             - name: METRICS_BIND_ADDRESS
               value: ":8443"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           ports:
           - containerPort: 8443
             name: metrics
@@ -100,10 +105,16 @@ spec:
           - name: metrics-tls
             readOnly: true
             mountPath: /tmp/k8s-metrics-server/serving-certs
+          - name: tls-config
+            readOnly: true
+            mountPath: /etc/nmstate/tls
       volumes:
         - name: metrics-tls
           secret:
             secretName: {{template "handlerPrefix" .}}openshift-nmstate-metrics
+        - name: tls-config
+          configMap:
+            name: {{template "handlerPrefix" .}}nmstate-tls-config
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -131,6 +142,9 @@ spec:
         description: kubernetes-nmstate-webhook resets NNCP status
         target.workload.openshift.io/management: |
           {"effect": "PreferredDuringScheduling"}
+{{- if .IsOpenShift }}
+        nmstate.io/tls-profile-hash: "{{ .TLSProfileHash }}"
+{{- end }}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -180,6 +194,8 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           ports:
           - containerPort: 9443
             name: webhook-server
@@ -211,6 +227,11 @@ spec:
           - name: tls-key-pair
             readOnly: true
             mountPath: /tmp/k8s-webhook-server/serving-certs/
+{{- if .IsOpenShift }}
+          - name: tls-config
+            readOnly: true
+            mountPath: /etc/nmstate/tls
+{{- end }}
       volumes:
         - name: tls-key-pair
           secret:
@@ -218,6 +239,11 @@ spec:
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
 {{- else }}
             secretName: {{template "handlerPrefix" .}}openshift-nmstate-webhook
+{{- end }}
+{{- if .IsOpenShift }}
+        - name: tls-config
+          configMap:
+            name: {{template "handlerPrefix" .}}nmstate-tls-config
 {{- end }}
 {{- if not .IsOpenShift }}
 ---
@@ -419,6 +445,8 @@ spec:
               value: "{{ .NNCPMaxBackoffSeconds }}"
             - name: NNCP_INITIAL_BACKOFF_SECONDS
               value: "{{ .NNCPInitialBackoffSeconds }}"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket

--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -149,14 +149,6 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - apiservers
-  verbs:
-  - get
-  - list
-  - watch
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/handler/tls_config.yaml
+++ b/deploy/handler/tls_config.yaml
@@ -1,0 +1,10 @@
+{{define "handlerPrefix"}}{{with $prefix := .HandlerPrefix}}{{$prefix | printf "%s-"}}{{end -}}{{end}}
+{{- if .IsOpenShift }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-tls-config
+  namespace: {{ .HandlerNamespace }}
+data:
+  profile.json: '{{ .TLSProfileJSON }}'
+{{- end }}

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -50,6 +50,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -18,14 +18,13 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nmstatetls "github.com/nmstate/kubernetes-nmstate/pkg/tls"
@@ -50,32 +49,33 @@ func IsOpenShift(kclient client.Client) (bool, error) {
 	return true, nil
 }
 
-// FetchOpenShiftTLSOpts detects OpenShift and fetches the TLS profile for
-// secure serving. Returns nil on non-OpenShift clusters.
-func FetchOpenShiftTLSOpts(cfg *rest.Config, scheme *runtime.Scheme) (func(*tls.Config), error) {
-	kclient, err := client.New(cfg, client.Options{Scheme: scheme})
+// IsOpenShiftFromEnv returns true if the IS_OPENSHIFT environment variable
+// is set to "true". The operator sets this variable on all handler-deployed
+// pods so they can skip the API server discovery call at startup.
+func IsOpenShiftFromEnv() bool {
+	return os.Getenv("IS_OPENSHIFT") == "true"
+}
+
+// FetchTLSProfileFromFile reads a TLS profile spec from a JSON file (mounted
+// from a ConfigMap) and returns the TLS options function and the raw spec.
+// This avoids calling the API server at startup, which is critical when
+// network connectivity may be temporarily unavailable.
+func FetchTLSProfileFromFile(path string) (func(*tls.Config), nmstatetls.TLSProfileSpec, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating client for TLS profile detection: %w", err)
+		return nil, nmstatetls.TLSProfileSpec{}, fmt.Errorf("failed reading TLS profile from %s: %w", path, err)
 	}
 
-	isOCP, err := IsOpenShift(kclient)
-	if err != nil {
-		return nil, fmt.Errorf("could not determine if running on OpenShift: %w", err)
-	}
-	if !isOCP {
-		return nil, nil
+	var spec nmstatetls.TLSProfileSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, nmstatetls.TLSProfileSpec{}, fmt.Errorf("failed parsing TLS profile from %s: %w", path, err)
 	}
 
-	tlsProfileSpec, err := nmstatetls.FetchAPIServerTLSProfile(context.Background(), kclient)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get TLS profile from API server: %w", err)
-	}
-
-	tlsOpts, unsupportedCiphers := nmstatetls.NewTLSConfigFromProfile(tlsProfileSpec)
+	tlsOpts, unsupportedCiphers := nmstatetls.NewTLSConfigFromProfile(spec)
 	if len(unsupportedCiphers) > 0 {
 		log.Info("TLS configuration contains unsupported ciphers that will be ignored",
 			"unsupportedCiphers", unsupportedCiphers)
 	}
 
-	return tlsOpts, nil
+	return tlsOpts, spec, nil
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Eliminates API server calls at handler startup for TLS configuration, preventing crash loops when network connectivity is temporarily unavailable.

The handler binary calls the API server at startup to detect OpenShift (`IsOpenShift()` → `GET /api`) and fetch the TLS security profile (`FetchAPIServerTLSProfile()`). When the default network interface is being reconfigured (e.g., bond removal in e2e tests), the API server is temporarily unreachable, causing a 30s timeout → handler crash → restart loop (12 restarts observed in [build 2036339976228048896](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/nmstate_kubernetes-nmstate/1465/pull-kubernetes-nmstate-e2e-handler-k8s/2036339976228048896)).

The fix:
1. **`IS_OPENSHIFT` env var** — Operator passes platform detection to all handler-deployed pods, eliminating the `IsOpenShift()` API discovery call
2. **TLS profile ConfigMap** — On OpenShift, the operator fetches the TLS profile and writes it to a ConfigMap. Webhook and metrics pods mount it and read from file. Kubelet caches ConfigMap volumes locally, so they survive container restarts without API server connectivity
3. **Handler skips TLS profile** — The handler DaemonSet doesn't serve platform-specific TLS endpoints (webhook and metrics are separate Deployments), so it skips TLS profile loading entirely
4. **Operator-driven TLS profile updates** — The `SecurityProfileWatcher` is removed from webhook/metrics pods. Instead, the operator watches the `APIServer` CR for TLS profile changes, updates the ConfigMap, and rolls webhook/metrics Deployments automatically via a `nmstate.io/tls-profile-hash` annotation on the pod template

**Special notes for your reviewer**:

On container restart (the key scenario):
1. Pod starts with API server connectivity → kubelet mounts ConfigMap
2. Bond removal disrupts connectivity → handler crashes
3. Kubelet restarts container → volumes already cached locally
4. Handler reads config from file → no API server call → starts successfully

TLS profile change flow (OpenShift only):
1. Admin changes TLS profile on `APIServer` CR
2. Operator's watch triggers reconcile
3. Operator re-fetches TLS profile, updates ConfigMap, re-renders Deployments with new hash annotation
4. Kubernetes rolls webhook/metrics Deployments with updated TLS config

Openshift test:
- https://github.com/openshift/kubernetes-nmstate/pull/739

**Release note**:

```release-note
Fix handler crash loop when default network interface is temporarily reconfigured by eliminating API server dependency at startup for TLS configuration.
```