### PR TITLE
 OCPBUGS-78801: Nodeselector Description update

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -24,8 +24,10 @@ import (
 
 // NodeNetworkConfigurationPolicySpec defines the desired state of NodeNetworkConfigurationPolicy
 type NodeNetworkConfigurationPolicySpec struct {
-	// NodeSelector is a selector which must be true for the policy to be applied to the node.
-	// Selector which must match a node's labels for the policy to be scheduled on that node.
+	// NodeSelector is a selector that determines which nodes the policy will be applied to.
+	// It uses simple key-value label matching (equality-based selection only). All specified
+	// labels must match a node's labels for the policy to be scheduled on that node.
+	// Note: matchLabels and matchExpressions are not supported; only direct key-value pair matching is available.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	// +optional
 	// +kubebuilder:validation:MaxProperties=256

--- a/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -75,8 +75,10 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  NodeSelector is a selector which must be true for the policy to be applied to the node.
-                  Selector which must match a node's labels for the policy to be scheduled on that node.
+                  NodeSelector is a selector that determines which nodes the policy will be applied to.
+                  It uses simple key-value label matching (equality-based selection only). All specified
+                  labels must match a node's labels for the policy to be scheduled on that node.
+                  Note: matchLabels and matchExpressions are not supported; only direct key-value pair matching is available.
                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                 maxProperties: 256
                 type: object
@@ -193,8 +195,10 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  NodeSelector is a selector which must be true for the policy to be applied to the node.
-                  Selector which must match a node's labels for the policy to be scheduled on that node.
+                  NodeSelector is a selector that determines which nodes the policy will be applied to.
+                  It uses simple key-value label matching (equality-based selection only). All specified
+                  labels must match a node's labels for the policy to be scheduled on that node.
+                  Note: matchLabels and matchExpressions are not supported; only direct key-value pair matching is available.
                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                 maxProperties: 256
                 type: object

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -75,8 +75,10 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  NodeSelector is a selector which must be true for the policy to be applied to the node.
-                  Selector which must match a node's labels for the policy to be scheduled on that node.
+                  NodeSelector is a selector that determines which nodes the policy will be applied to.
+                  It uses simple key-value label matching (equality-based selection only). All specified
+                  labels must match a node's labels for the policy to be scheduled on that node.
+                  Note: matchLabels and matchExpressions are not supported; only direct key-value pair matching is available.
                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                 maxProperties: 256
                 type: object
@@ -193,8 +195,10 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  NodeSelector is a selector which must be true for the policy to be applied to the node.
-                  Selector which must match a node's labels for the policy to be scheduled on that node.
+                  NodeSelector is a selector that determines which nodes the policy will be applied to.
+                  It uses simple key-value label matching (equality-based selection only). All specified
+                  labels must match a node's labels for the policy to be scheduled on that node.
+                  Note: matchLabels and matchExpressions are not supported; only direct key-value pair matching is available.
                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                 maxProperties: 256
                 type: object


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind enhancement
  
**What this PR does / why we need it**:

Updates the NodeSelector field description in the NodeNetworkConfigurationPolicy CRD to clarify that it only supports simple equality-based key-value label matching. The previous description referenced general Kubernetes node selector semantics, which could imply support for advanced features like matchExpressions, but the implementation only supports basic key-value matching.
  
**Special notes for your reviewer**:

  - Fixed indentation bug (spaces → tabs) in the Go source file as requested
  - Regenerated all CRD manifests from the corrected Go source
  - No functional changes, documentation clarification only

**Release note**:   

```release-note
Update NodeSelector field description to clarify it uses equality-based matching only and does not support matchLabels or matchExpressions