### PR TITLE
Split ping probe into ping4 and ping6 for dual-stack support

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -57,17 +57,24 @@ type Route struct {
 }
 
 const (
-	defaultGwRetrieveTimeout  = 120 * time.Second
 	defaultGwProbeTimeout     = 120 * time.Second
 	defaultDNSProbeTimeout    = 120 * time.Second
 	apiServerProbeTimeout     = 120 * time.Second
 	nodeReadinessProbeTimeout = 120 * time.Second
 	mainRoutingTableID        = 254
-	ProbesTotalTimeout        = defaultGwRetrieveTimeout +
-		defaultDNSProbeTimeout +
-		defaultDNSProbeTimeout +
-		apiServerProbeTimeout +
-		nodeReadinessProbeTimeout
+
+	// ProbesTotalTimeout is the worst-case total time for Select() + Run()
+	// on a dual-stack cluster where both ping4 and ping6 are active.
+	// Select: ping4 + ping6 + dns
+	// Run:    ping4 + ping6 + dns + api-server + node-readiness
+	ProbesTotalTimeout = defaultGwProbeTimeout + // Select: ping4
+		defaultGwProbeTimeout + // Select: ping6
+		defaultDNSProbeTimeout + // Select: dns
+		defaultGwProbeTimeout + // Run: ping4
+		defaultGwProbeTimeout + // Run: ping6
+		defaultDNSProbeTimeout + // Run: dns
+		apiServerProbeTimeout + // Run: api-server
+		nodeReadinessProbeTimeout // Run: node-readiness
 )
 
 func currentStateAsGJson() (gjson.Result, error) {
@@ -140,12 +147,20 @@ func checkNodeReadiness(ctx context.Context, cli client.Client) (bool, error) {
 	return false, nil
 }
 
-func defaultGw(currentState gjson.Result) (Route, error) {
+func defaultGw4(currentState gjson.Result) (Route, error) {
+	return defaultGwByDestination(currentState, "0.0.0.0/0")
+}
+
+func defaultGw6(currentState gjson.Result) (Route, error) {
+	return defaultGwByDestination(currentState, "::/0")
+}
+
+func defaultGwByDestination(currentState gjson.Result, destination string) (Route, error) {
 	var found Route
 	currentState.Get("routes.running").ForEach(
 		func(_, v gjson.Result) bool {
 			// we want to pick the next hop related to the "main" table because we may have multiple tables
-			if (v.Get("destination").String() == "0.0.0.0/0" || v.Get("destination").String() == "::/0") &&
+			if v.Get("destination").String() == destination &&
 				v.Get("table-id").Int() == mainRoutingTableID {
 				found.nextHop = net.ParseIP(v.Get("next-hop-address").String())
 				found.iface = v.Get("next-hop-interface").String()
@@ -156,8 +171,8 @@ func defaultGw(currentState gjson.Result) (Route, error) {
 	)
 
 	if found.nextHop == nil {
-		msg := "default gw missing"
-		defaultGwLog := log.WithValues("path", "routes.running.next-hop-address", "table-id", mainRoutingTableID)
+		msg := fmt.Sprintf("default gw missing for destination %s", destination)
+		defaultGwLog := log.WithValues("path", "routes.running.next-hop-address", "table-id", mainRoutingTableID, "destination", destination)
 		defaultGwLogDebug := defaultGwLog.V(1)
 		if defaultGwLogDebug.Enabled() {
 			defaultGwLogDebug.Info(msg, "state", currentState.String())
@@ -169,25 +184,31 @@ func defaultGw(currentState gjson.Result) (Route, error) {
 	return found, nil
 }
 
-func pingCondition(cli client.Client, timeout time.Duration) wait.ConditionWithContextFunc {
+func ping4Condition(cli client.Client, timeout time.Duration) wait.ConditionWithContextFunc {
 	return func(context.Context) (bool, error) {
-		return runPing(cli)
+		return runPingByFamily(cli, defaultGw4)
 	}
 }
 
-func runPing(_ client.Client) (bool, error) {
+func ping6Condition(cli client.Client, timeout time.Duration) wait.ConditionWithContextFunc {
+	return func(context.Context) (bool, error) {
+		return runPingByFamily(cli, defaultGw6)
+	}
+}
+
+func runPingByFamily(_ client.Client, gwFunc func(gjson.Result) (Route, error)) (bool, error) {
 	gjsonCurrentState, err := currentStateAsGJson()
 	if err != nil {
 		return false, errors.Wrap(err, "failed retrieving current state to retrieve default gw")
 	}
 
-	defaultGw, err := defaultGw(gjsonCurrentState)
+	gw, err := gwFunc(gjsonCurrentState)
 	if err != nil {
 		log.Error(err, "failed to retrieve default gw")
 		return false, nil
 	}
 
-	pingOutput, err := ping(defaultGw)
+	pingOutput, err := ping(gw)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error pinging default gateway -> output: '%s'", pingOutput))
 		return false, nil
@@ -270,18 +291,51 @@ func runDNS(_ client.Client, timeout time.Duration) (bool, error) {
 // the internal connectivity probes
 func Select(ctx context.Context, cli client.Client) []Probe {
 	probes := []Probe{}
-	externalConnectivityProbes := []Probe{
-		{
-			name:      "ping",
-			timeout:   defaultGwProbeTimeout,
-			condition: pingCondition,
-		},
-		{
-			name:      "dns",
-			timeout:   defaultDNSProbeTimeout,
-			condition: dnsCondition,
-		},
+	externalConnectivityProbes := []Probe{}
+
+	// Pre-check which address families have a default gateway to avoid
+	// waiting for the full probe timeout on single-stack clusters.
+	// Both default to false so that a transient pre-check failure
+	// (currentStateAsGJson error) skips ping probes entirely rather
+	// than adding a probe whose trial would time out for 120s on
+	// clusters lacking that address family.
+	hasGw4, hasGw6 := false, false
+	currentState, err := currentStateAsGJson()
+	if err != nil {
+		log.Info(fmt.Sprintf("WARNING: failed to retrieve current state for gateway pre-check, skipping ping probes: %v", err))
+	} else {
+		if _, err := defaultGw4(currentState); err != nil {
+			log.Info("No IPv4 default gateway found, skipping ping4 probe selection")
+		} else {
+			hasGw4 = true
+		}
+		if _, err := defaultGw6(currentState); err != nil {
+			log.Info("No IPv6 default gateway found, skipping ping6 probe selection")
+		} else {
+			hasGw6 = true
+		}
 	}
+
+	if hasGw4 {
+		externalConnectivityProbes = append(externalConnectivityProbes, Probe{
+			name:      "ping4",
+			timeout:   defaultGwProbeTimeout,
+			condition: ping4Condition,
+		})
+	}
+	if hasGw6 {
+		externalConnectivityProbes = append(externalConnectivityProbes, Probe{
+			name:      "ping6",
+			timeout:   defaultGwProbeTimeout,
+			condition: ping6Condition,
+		})
+	}
+
+	externalConnectivityProbes = append(externalConnectivityProbes, Probe{
+		name:      "dns",
+		timeout:   defaultDNSProbeTimeout,
+		condition: dnsCondition,
+	})
 
 	for _, p := range externalConnectivityProbes {
 		err := wait.PollUntilContextTimeout(ctx, time.Second, p.timeout, true /*immediate*/, p.condition(cli, p.timeout))

--- a/pkg/probe/probes_test.go
+++ b/pkg/probe/probes_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // nolint: funlen
-func TestDefaultGatewayParsing(t *testing.T) {
+func TestDefaultGw4Parsing(t *testing.T) {
 	tests := []struct {
 		desc          string
 		status        string
@@ -32,7 +32,7 @@ func TestDefaultGatewayParsing(t *testing.T) {
 		shouldErr     bool
 	}{
 		{
-			desc: "one single gateway",
+			desc: "one single IPv4 gateway",
 			status: `routes:
   running:
   - destination: 172.30.0.0/16
@@ -48,7 +48,7 @@ func TestDefaultGatewayParsing(t *testing.T) {
 			expectedGw:    "10.46.55.254",
 			expectedIface: "eth1",
 		}, {
-			desc: "two gateways, one on custom routing table",
+			desc: "two IPv4 gateways, one on custom routing table",
 			status: `routes:
   running:
   - destination: 172.30.0.0/16
@@ -68,7 +68,7 @@ func TestDefaultGatewayParsing(t *testing.T) {
 			expectedGw:    "10.46.55.254",
 			expectedIface: "eth1",
 		}, {
-			desc: "no next-hop-address",
+			desc: "no IPv4 default gateway",
 			status: `routes:
   running:
   - destination: 172.30.0.0/16
@@ -78,6 +78,69 @@ func TestDefaultGatewayParsing(t *testing.T) {
 `,
 			shouldErr: true,
 		}, {
+			desc: "only IPv6 gateway present",
+			status: `routes:
+  running:
+  - destination: ::/0
+    next-hop-interface: eth0
+    next-hop-address: fe80::dead:beef:fe51:782d
+    table-id: 254
+`,
+			shouldErr: true,
+		}, {
+			desc: "dual-stack picks IPv4 gateway",
+			status: `routes:
+  running:
+  - destination: 0.0.0.0/0
+    next-hop-interface: eth0
+    next-hop-address: 10.46.55.254
+    table-id: 254
+  - destination: ::/0
+    next-hop-interface: eth0
+    next-hop-address: fe80::dead:beef:fe51:782d
+    table-id: 254
+`,
+			expectedGw:    "10.46.55.254",
+			expectedIface: "eth0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gJSON, err := yamlToGJson(test.status)
+			if err != nil {
+				t.Fatalf("failed to parse test status, %v", err)
+			}
+			gw, err := defaultGw4(gJSON)
+			if err != nil && !test.shouldErr {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if test.shouldErr && err == nil {
+				t.Fatalf("expecting error, did not fail")
+			}
+
+			expectedRoute := Route{
+				nextHop: net.ParseIP(test.expectedGw),
+				iface:   test.expectedIface,
+			}
+
+			if !expectedRoute.nextHop.Equal(gw.nextHop) || expectedRoute.iface != gw.iface {
+				t.Fatalf("expecting %+v, got %+v", expectedRoute, gw)
+			}
+		})
+	}
+}
+
+// nolint: funlen
+func TestDefaultGw6Parsing(t *testing.T) {
+	tests := []struct {
+		desc          string
+		status        string
+		expectedGw    string
+		expectedIface string
+		shouldErr     bool
+	}{
+		{
 			desc: "one single IPv6 gateway",
 			status: `routes:
   running:
@@ -104,7 +167,27 @@ func TestDefaultGatewayParsing(t *testing.T) {
 			expectedGw:    "fe80::dead:beef:fe51:782d",
 			expectedIface: "eth0",
 		}, {
-			desc: "dual-stack with single gateway per IP stack",
+			desc: "no IPv6 default gateway",
+			status: `routes:
+  running:
+  - destination: 172.30.0.0/16
+    next-hop-interface: eth0
+    next-hop-address: 169.254.169.4
+    table-id: 254
+`,
+			shouldErr: true,
+		}, {
+			desc: "only IPv4 gateway present",
+			status: `routes:
+  running:
+  - destination: 0.0.0.0/0
+    next-hop-interface: eth1
+    next-hop-address: 10.46.55.254
+    table-id: 254
+`,
+			shouldErr: true,
+		}, {
+			desc: "dual-stack picks IPv6 gateway",
 			status: `routes:
   running:
   - destination: 0.0.0.0/0
@@ -116,23 +199,8 @@ func TestDefaultGatewayParsing(t *testing.T) {
     next-hop-address: fe80::dead:beef:fe51:782d
     table-id: 254
 `,
-			expectedGw:    "10.46.55.254",
-			expectedIface: "eth0",
-		}, {
-			desc: "dual-stack with missing IPv4 default gateway",
-			status: `routes:
-  running:
-  - destination: 172.30.0.0/16
-    next-hop-interface: eth0
-    next-hop-address: 169.254.169.4
-    table-id: 254
-  - destination: ::/0
-    next-hop-interface: eth1
-    next-hop-address: fe80::dead:beef:fe51:782d
-    table-id: 254
-`,
 			expectedGw:    "fe80::dead:beef:fe51:782d",
-			expectedIface: "eth1",
+			expectedIface: "eth0",
 		},
 	}
 
@@ -142,7 +210,7 @@ func TestDefaultGatewayParsing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse test status, %v", err)
 			}
-			defaultGw, err := defaultGw(gJSON)
+			gw, err := defaultGw6(gJSON)
 			if err != nil && !test.shouldErr {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -155,8 +223,8 @@ func TestDefaultGatewayParsing(t *testing.T) {
 				iface:   test.expectedIface,
 			}
 
-			if !expectedRoute.nextHop.Equal(defaultGw.nextHop) || expectedRoute.iface != defaultGw.iface {
-				t.Fatalf("expecting %+v, got %+v", expectedRoute, defaultGw)
+			if !expectedRoute.nextHop.Equal(gw.nextHop) || expectedRoute.iface != gw.iface {
+				t.Fatalf("expecting %+v, got %+v", expectedRoute, gw)
 			}
 		})
 	}


### PR DESCRIPTION
The single "ping" connectivity probe checked only one default gateway (whichever appeared first), making it impossible to detect when only one IP stack broke after applying an NNCP on dual-stack systems.

Split into separate "ping4" (0.0.0.0/0) and "ping6" (::/0) probes that track each IP stack independently. In single-stack clusters, the missing stack's probe is simply not selected during Select().

Fixes: https://github.com/nmstate/kubernetes-nmstate/issues/1411

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Ping probe becomes now Ping4 and Ping6 for supporting dual-stack environments
```
