### PR TITLE
fix: reconcile NNCP status on node deletion

### DIFF
--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -99,6 +99,20 @@ var (
 			return false
 		},
 	}
+	onEnactmentDeleted = predicate.TypedFuncs[*nmstatev1beta1.NodeNetworkConfigurationEnactment]{
+		CreateFunc: func(event.TypedCreateEvent[*nmstatev1beta1.NodeNetworkConfigurationEnactment]) bool {
+			return false
+		},
+		DeleteFunc: func(event.TypedDeleteEvent[*nmstatev1beta1.NodeNetworkConfigurationEnactment]) bool {
+			return true
+		},
+		UpdateFunc: func(event.TypedUpdateEvent[*nmstatev1beta1.NodeNetworkConfigurationEnactment]) bool {
+			return false
+		},
+		GenericFunc: func(event.TypedGenericEvent[*nmstatev1beta1.NodeNetworkConfigurationEnactment]) bool {
+			return false
+		},
+	}
 	nmstatectlShowFn = nmstatectl.Show
 )
 
@@ -348,7 +362,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Man
 		return errors.Wrap(err, "failed to add watch for NNCPs")
 	}
 
-	// Add watch to enque all NNCPs on nod label changes
+	// Add watch to enqueue all NNCPs on node label changes
 	err = c.Watch(
 		source.Kind(
 			mgr.GetCache(),
@@ -359,6 +373,29 @@ func (r *NodeNetworkConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Man
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to add watch to enqueue NNCPs reconcile on node label change")
+	}
+
+	// Add watch on NNCE deletions (e.g. from ownerRef GC when a node is removed)
+	// to trigger NNCP reconciliation and recalculate policy conditions.
+	enactmentToPolicy := handler.TypedEnqueueRequestsFromMapFunc[*nmstatev1beta1.NodeNetworkConfigurationEnactment](
+		func(ctx context.Context, nnce *nmstatev1beta1.NodeNetworkConfigurationEnactment) []reconcile.Request {
+			policyName, ok := nnce.GetLabels()[nmstateapi.EnactmentPolicyLabel]
+			if !ok || policyName == "" {
+				return nil
+			}
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: policyName}}}
+		},
+	)
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&nmstatev1beta1.NodeNetworkConfigurationEnactment{},
+			enactmentToPolicy,
+			onEnactmentDeleted,
+		),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to add watch to enqueue NNCPs reconcile on enactment deletion")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes #1098

When a node is removed from the cluster, its per-node `NodeNetworkConfigurationEnactment` (NNCE) is garbage collected via ownerRef, but the parent `NodeNetworkConfigurationPolicy` (NNCP) status conditions (e.g. *"2/2 nodes successfully configured"*) are never recalculated — leaving stale counts indefinitely.

**Root cause:** No cluster-scoped component watched for NNCE deletions. The handler runs as a DaemonSet with per-node cache filtering, so each handler pod only sees NNCEs for its own node and cannot observe NNCE deletions caused by other nodes being removed.

**Fix:** Add a new lightweight controller to the operator binary that watches NNCE deletions cluster-wide. When a node is deleted, its NNCE is garbage collected (ownerRef), which triggers the new controller to enqueue the affected NNCP (via the `nmstate.io/policy` label) and recalculate policy conditions using `policyconditions.Update`.

The operator has no per-node cache filtering, so it can observe all NNCE lifecycle events across the cluster. Race conditions with handler-side `policyconditions.Update` calls are safe due to existing conflict retry logic.

## Test plan

- Tested on OCP 4.21.10 (kubernetes-nmstate 4.21.0-202604012149)
- Created NNCP targeting 2 worker nodes → status showed "2/2 nodes successfully configured"
- **Without fix:** deleted a worker node → NNCP status stayed at "2/2" indefinitely (bug confirmed)
- **With fix:** deleted a worker node → NNCP status updated to "1/1 nodes successfully configured" within ~15 seconds
- Unit tests pass (`go test ./controllers/handler/... ./pkg/policyconditions/... ./pkg/node/...`)

```release-note
Fix NNCP status conditions not being recalculated after a node is removed from the cluster, leaving stale node counts indefinitely.
```