### PR TITLE
Fix GCS docs preview URL navigation by enabling uglyURLs for CI builds

### DIFF
--- a/automation/check-patch.docs.sh
+++ b/automation/check-patch.docs.sh
@@ -10,7 +10,7 @@ preview_baseurl="${url}/kubevirt-prow/pr-logs/pull/nmstate_kubernetes-nmstate${b
 ${IMAGE_BUILDER} run -v $(pwd)/docs:/docs/ -w /docs \
     -e GOBIN=/usr/local/bin \
     docker.io/hugomods/hugo:exts \
-    sh -c "npm install && command -v htmltest || go install github.com/wjdp/htmltest@latest && hugo --baseURL / --destination build/ && htmltest && hugo --baseURL '${preview_baseurl}' --destination build/"
+    sh -c "npm install && command -v htmltest || go install github.com/wjdp/htmltest@latest && hugo --config hugo.yaml,hugo.preview.yaml --baseURL / --destination build/ && htmltest && hugo --config hugo.yaml,hugo.preview.yaml --baseURL '${preview_baseurl}' --destination build/"
 
 # Copy the docs to the artifacts
 mkdir -p $ARTIFACTS/gh-pages

--- a/docs/hugo.preview.yaml
+++ b/docs/hugo.preview.yaml
@@ -1,0 +1,4 @@
+# hugo.preview.yaml - Configuration for CI preview builds
+# The config is merged with hugo.yaml and enables uglyURLs for GCS CI docs preview
+
+uglyURLs: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
GCS direct URLs don't auto-append index.html for directory paths, causing the "key not found" errors we are seeing in CI docs preview when navigating to subsites like /developer-guide/.

This PR uses Hugo's uglyURLs configuration for CI preview builds only to generate direct file URLs (e.g., /developer-guide.html) that work with GCS object keys.

Production deployment remains unchanged with clean URLs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
