### PR TITLE
Speed up E2E tests by automatically configuring lower NNCP retry values

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -74,6 +74,12 @@ import (
 
 const generalExitStatus int = 1
 
+const (
+	defaultRetriesUntilFail = 5
+	defaultMaxBackoff       = 30 * time.Second
+	defaultInitialBackoff   = 1 * time.Second
+)
+
 type ProfilerConfig struct {
 	EnableProfiler bool   `envconfig:"ENABLE_PROFILER"`
 	ProfilerPort   string `envconfig:"PROFILER_PORT" default:"6060"`
@@ -479,7 +485,10 @@ func setupHandlerControllers(mgr manager.Manager) error {
 		Log:       ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationPolicy"),
 		Scheme:    mgr.GetScheme(),
 		//nolint:staticcheck // TODO: migrate to GetEventRecorder
-		Recorder: mgr.GetEventRecorderFor(fmt.Sprintf("%s.nmstate-handler", environment.NodeName())),
+		Recorder:           mgr.GetEventRecorderFor(fmt.Sprintf("%s.nmstate-handler", environment.NodeName())),
+		RetriesUntilFail:   getEnvAsInt("NNCP_MAX_RETRIES", defaultRetriesUntilFail),
+		MaximumTimeBackoff: getEnvAsDuration("NNCP_MAX_BACKOFF_SECONDS", defaultMaxBackoff),
+		InitialBackoff:     getEnvAsDuration("NNCP_INITIAL_BACKOFF_SECONDS", defaultInitialBackoff),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create NodeNetworkConfigurationPolicy controller", "controller", "NMState")
 		return err
@@ -655,6 +664,31 @@ func lockHandler() (*flock.Flock, error) {
 			return locked, nil
 		})
 	return handlerLock, err
+}
+
+// getEnvAsInt reads an integer from an environment variable with a default fallback.
+func getEnvAsInt(key string, defaultVal int) int {
+	if value, exists := os.LookupEnv(key); exists {
+		if intVal, err := strconv.Atoi(value); err == nil {
+			return intVal
+		} else {
+			setupLog.Info(fmt.Sprintf("WARNING: invalid integer for %s=%q, using default %d: %v", key, value, defaultVal, err))
+		}
+	}
+	return defaultVal
+}
+
+// getEnvAsDuration reads a seconds value from an environment variable and
+// returns it as a time.Duration, falling back to defaultVal if unset or invalid.
+func getEnvAsDuration(key string, defaultVal time.Duration) time.Duration {
+	if value, exists := os.LookupEnv(key); exists {
+		if intVal, err := strconv.Atoi(value); err == nil {
+			return time.Duration(intVal) * time.Second
+		} else {
+			setupLog.Info(fmt.Sprintf("WARNING: invalid integer for %s=%q, using default %d: %v", key, value, defaultVal, err))
+		}
+	}
+	return defaultVal
 }
 
 func dumpMetricFamiliesToStdout() int {

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -252,10 +252,7 @@ func setupTLSProfileWatcher(mgr manager.Manager, cancel context.CancelFunc) erro
 // metrics endpoint via TokenReview/SubjectAccessReview.
 func createManager(cfg *rest.Config, tlsOpts func(*tls.Config), isOpenShift bool) (manager.Manager, error) {
 	// Get metrics bind address from environment variable, with default fallback
-	metricsBindAddress := os.Getenv("METRICS_BIND_ADDRESS")
-	if metricsBindAddress == "" {
-		metricsBindAddress = ":8089"
-	}
+	metricsBindAddress := environment.GetEnvVar("METRICS_BIND_ADDRESS", ":8089")
 
 	metricsOpts := metricsserver.Options{
 		BindAddress:   metricsBindAddress,
@@ -486,9 +483,9 @@ func setupHandlerControllers(mgr manager.Manager) error {
 		Scheme:    mgr.GetScheme(),
 		//nolint:staticcheck // TODO: migrate to GetEventRecorder
 		Recorder:           mgr.GetEventRecorderFor(fmt.Sprintf("%s.nmstate-handler", environment.NodeName())),
-		RetriesUntilFail:   getEnvAsInt("NNCP_MAX_RETRIES", defaultRetriesUntilFail),
-		MaximumTimeBackoff: getEnvAsDuration("NNCP_MAX_BACKOFF_SECONDS", defaultMaxBackoff),
-		InitialBackoff:     getEnvAsDuration("NNCP_INITIAL_BACKOFF_SECONDS", defaultInitialBackoff),
+		RetriesUntilFail:   environment.GetEnvVarAsInt("NNCP_MAX_RETRIES", defaultRetriesUntilFail),
+		MaximumTimeBackoff: environment.GetEnvVarAsDuration("NNCP_MAX_BACKOFF_SECONDS", defaultMaxBackoff),
+		InitialBackoff:     environment.GetEnvVarAsDuration("NNCP_INITIAL_BACKOFF_SECONDS", defaultInitialBackoff),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create NodeNetworkConfigurationPolicy controller", "controller", "NMState")
 		return err
@@ -535,7 +532,7 @@ func checkNmstateIsWorking() error {
 
 func retrieveCertAndCAIntervals() (certificate.Options, error) {
 	certManagerOpts := certificate.Options{
-		Namespace:   os.Getenv("POD_NAMESPACE"),
+		Namespace:   environment.GetEnvVar("POD_NAMESPACE", ""),
 		WebhookName: "nmstate",
 		WebhookType: certificate.MutatingWebhook,
 		ExtraLabels: names.IncludeRelationshipLabels(nil),
@@ -664,31 +661,6 @@ func lockHandler() (*flock.Flock, error) {
 			return locked, nil
 		})
 	return handlerLock, err
-}
-
-// getEnvAsInt reads an integer from an environment variable with a default fallback.
-func getEnvAsInt(key string, defaultVal int) int {
-	if value, exists := os.LookupEnv(key); exists {
-		if intVal, err := strconv.Atoi(value); err == nil {
-			return intVal
-		} else {
-			setupLog.Info(fmt.Sprintf("WARNING: invalid integer for %s=%q, using default %d: %v", key, value, defaultVal, err))
-		}
-	}
-	return defaultVal
-}
-
-// getEnvAsDuration reads a seconds value from an environment variable and
-// returns it as a time.Duration, falling back to defaultVal if unset or invalid.
-func getEnvAsDuration(key string, defaultVal time.Duration) time.Duration {
-	if value, exists := os.LookupEnv(key); exists {
-		if intVal, err := strconv.Atoi(value); err == nil {
-			return time.Duration(intVal) * time.Second
-		} else {
-			setupLog.Info(fmt.Sprintf("WARNING: invalid integer for %s=%q, using default %d: %v", key, value, defaultVal, err))
-		}
-	}
-	return defaultVal
 }
 
 func dumpMetricFamiliesToStdout() int {

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -63,9 +63,7 @@ import (
 )
 
 const (
-	ReconcileFailed    = "ReconcileFailed"
-	MaximumTimeBackoff = 30
-	RetriesUntilFail   = 5
+	ReconcileFailed = "ReconcileFailed"
 )
 
 var (
@@ -111,6 +109,15 @@ type NodeNetworkConfigurationPolicyReconciler struct {
 	Log       logr.Logger
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder
+	// RetriesUntilFail is the number of retry attempts before marking an NNCE as failed.
+	// Expected range: >= 1. Defaults to 5 via NNCP_MAX_RETRIES env var.
+	RetriesUntilFail int
+	// MaximumTimeBackoff is the upper bound for exponential backoff between retries.
+	// Expected range: > 0. Defaults to 30s via NNCP_MAX_BACKOFF_SECONDS env var.
+	MaximumTimeBackoff time.Duration
+	// InitialBackoff is the starting backoff duration for the first retry.
+	// Expected range: > 0. Defaults to 1s via NNCP_INITIAL_BACKOFF_SECONDS env var.
+	InitialBackoff time.Duration
 }
 
 func init() {
@@ -213,10 +220,10 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	// This prevents unnecessary network disruption when a spurious reconcile
 	// (e.g., from informer re-list after reconnection) re-triggers processing
 	// of an already-failed policy.
-	if enactmentInstance.Status.RetryCount[generationKey] >= RetriesUntilFail {
+	if enactmentInstance.Status.RetryCount[generationKey] >= r.RetriesUntilFail {
 		log.Info("Retry count already exhausted, skipping apply",
 			"retryCount", enactmentInstance.Status.RetryCount[generationKey],
-			"maxRetries", RetriesUntilFail,
+			"maxRetries", r.RetriesUntilFail,
 			"generation", generationKey)
 		return ctrl.Result{}, nil
 	}
@@ -264,7 +271,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 			return ctrl.Result{}, err
 		}
 
-		if enactmentInstance.Status.RetryCount[generationKey] >= RetriesUntilFail {
+		if enactmentInstance.Status.RetryCount[generationKey] >= r.RetriesUntilFail {
 			enactmentConditions.NotifyFailedToConfigure(ctx, errmsg)
 			if r.Recorder != nil {
 				r.Recorder.Event(instance,
@@ -272,7 +279,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 					ReconcileFailed,
 					fmt.Errorf(
 						"reconciliation of enactment %q has failed after %d retries",
-						enactmentInstance.Name, RetriesUntilFail).Error())
+						enactmentInstance.Name, r.RetriesUntilFail).Error())
 			}
 			return ctrl.Result{}, nil
 		}
@@ -281,7 +288,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 			fmt.Errorf("failed to reconcile NodeNetworkConfigurationPolicy on node %s. Retrying %d/%d",
 				nodeName,
 				enactmentInstance.Status.RetryCount[generationKey]+1,
-				RetriesUntilFail),
+				r.RetriesUntilFail),
 		)
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -329,7 +336,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Man
 		mgr,
 		controller.Options{
 			Reconciler:  r,
-			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, time.Second*MaximumTimeBackoff),
+			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](r.InitialBackoff, r.MaximumTimeBackoff),
 		})
 	if err != nil {
 		return errors.Wrap(err, "failed to create NodeNetworkConfigurationPolicy controller")

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,7 +95,11 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 	DescribeTable("when claimNodeRunningUpdate is called and",
 		func(c incrementUnavailableNodeCountCase) {
 			nmstatectlShowFn = func() (string, error) { return "", nil }
-			reconciler := NodeNetworkConfigurationPolicyReconciler{}
+			reconciler := NodeNetworkConfigurationPolicyReconciler{
+				RetriesUntilFail:   5,
+				MaximumTimeBackoff: 30 * time.Second,
+				InitialBackoff:     1 * time.Second,
+			}
 			s := scheme.Scheme
 			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
 				&nmstatev1beta1.NodeNetworkState{},
@@ -305,7 +310,11 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 		)
 
 		BeforeEach(func() {
-			reconciler = &NodeNetworkConfigurationPolicyReconciler{}
+			reconciler = &NodeNetworkConfigurationPolicyReconciler{
+				RetriesUntilFail:   5,
+				MaximumTimeBackoff: 30 * time.Second,
+				InitialBackoff:     1 * time.Second,
+			}
 			s = scheme.Scheme
 			s.AddKnownTypes(nmstatev1.GroupVersion,
 				&nmstatev1.NodeNetworkConfigurationPolicy{},
@@ -425,7 +434,11 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 
 		BeforeEach(func() {
 			nmstatectlShowFn = func() (string, error) { return "", nil }
-			reconciler = &NodeNetworkConfigurationPolicyReconciler{}
+			reconciler = &NodeNetworkConfigurationPolicyReconciler{
+				RetriesUntilFail:   5,
+				MaximumTimeBackoff: 30 * time.Second,
+				InitialBackoff:     1 * time.Second,
+			}
 			s = scheme.Scheme
 			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
 				&nmstatev1beta1.NodeNetworkState{},

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -357,6 +357,9 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["LogLevelHandlerCommandArg"] = logLevelHandlerCommandArg
 	data.Data["HandlerReadinessProbeExtraArg"] = handlerReadinessProbeExtraArg
 	data.Data["IsOpenShift"] = r.IsOpenShift
+	data.Data["NNCPMaxRetries"] = environment.GetEnvVar("NNCP_MAX_RETRIES", "5")
+	data.Data["NNCPMaxBackoffSeconds"] = environment.GetEnvVar("NNCP_MAX_BACKOFF_SECONDS", "30")
+	data.Data["NNCPInitialBackoffSeconds"] = environment.GetEnvVar("NNCP_INITIAL_BACKOFF_SECONDS", "1")
 
 	return r.renderAndApply(ctx, instance, data, "handler", true)
 }

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -192,8 +192,8 @@ func (r *NMStateReconciler) applyCRDs(ctx context.Context, instance *nmstatev1.N
 
 func (r *NMStateReconciler) applyNamespace(ctx context.Context, instance *nmstatev1.NMState) error {
 	data := render.MakeRenderData()
-	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
-	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
+	data.Data["HandlerNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	data.Data["HandlerPrefix"] = environment.GetEnvVar("HANDLER_PREFIX", "")
 	data.Data["IsOpenShift"] = r.IsOpenShift
 
 	return r.renderAndApply(ctx, instance, data, "namespace", false)
@@ -201,9 +201,9 @@ func (r *NMStateReconciler) applyNamespace(ctx context.Context, instance *nmstat
 
 func (r *NMStateReconciler) applyNetworkPolicies(ctx context.Context, instance *nmstatev1.NMState) error {
 	data := render.MakeRenderData()
-	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
-	data.Data["OperatorNamespace"] = os.Getenv("OPERATOR_NAMESPACE")
-	data.Data["PluginNamespace"] = os.Getenv("HANDLER_NAMESPACE")
+	data.Data["HandlerNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	data.Data["OperatorNamespace"] = environment.GetEnvVar("OPERATOR_NAMESPACE", "")
+	data.Data["PluginNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
 	data.Data["IsOpenShift"] = r.IsOpenShift
 
 	return r.renderAndApply(ctx, instance, data, "netpol", true)
@@ -211,10 +211,10 @@ func (r *NMStateReconciler) applyNetworkPolicies(ctx context.Context, instance *
 
 func (r *NMStateReconciler) applyRBAC(ctx context.Context, instance *nmstatev1.NMState) error {
 	data := render.MakeRenderData()
-	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
-	data.Data["HandlerImage"] = os.Getenv("RELATED_IMAGE_HANDLER_IMAGE")
-	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
-	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
+	data.Data["HandlerNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	data.Data["HandlerImage"] = environment.GetEnvVar("RELATED_IMAGE_HANDLER_IMAGE", "")
+	data.Data["HandlerPullPolicy"] = environment.GetEnvVar("HANDLER_IMAGE_PULL_POLICY", "")
+	data.Data["HandlerPrefix"] = environment.GetEnvVar("HANDLER_PREFIX", "")
 
 	if err := setClusterReaderExist(ctx, r.Client, data); err != nil {
 		return errors.Wrap(err, "failed checking if cluster-reader ClusterRole exists")
@@ -337,12 +337,12 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		handlerReadinessProbeExtraArg = "-vv"
 	}
 
-	data.Data["HandlerNamespace"] = os.Getenv("HANDLER_NAMESPACE")
-	data.Data["HandlerImage"] = os.Getenv("RELATED_IMAGE_HANDLER_IMAGE")
-	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
-	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
-	data.Data["MonitoringNamespace"] = os.Getenv("MONITORING_NAMESPACE")
-	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
+	data.Data["HandlerNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	data.Data["HandlerImage"] = environment.GetEnvVar("RELATED_IMAGE_HANDLER_IMAGE", "")
+	data.Data["HandlerPullPolicy"] = environment.GetEnvVar("HANDLER_IMAGE_PULL_POLICY", "")
+	data.Data["HandlerPrefix"] = environment.GetEnvVar("HANDLER_PREFIX", "")
+	data.Data["MonitoringNamespace"] = environment.GetEnvVar("MONITORING_NAMESPACE", "")
+	data.Data["KubeRBACProxyImage"] = environment.GetEnvVar("KUBE_RBAC_PROXY_IMAGE", "")
 	data.Data["InfraNodeSelector"] = infraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations
 	data.Data["WebhookAffinity"] = infraAffinity
@@ -418,8 +418,8 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 	if r.IsOpenShift {
 		err := r.Delete(ctx, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: os.Getenv("HANDLER_NAMESPACE"),
-				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
+				Namespace: environment.GetEnvVar("HANDLER_NAMESPACE", ""),
+				Name:      environment.GetEnvVar("HANDLER_PREFIX", "") + "nmstate-cert-manager",
 			},
 		})
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -429,8 +429,8 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 		// Remove the non openshift secret
 		err = r.Delete(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: os.Getenv("HANDLER_NAMESPACE"),
-				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-webhook",
+				Namespace: environment.GetEnvVar("HANDLER_NAMESPACE", ""),
+				Name:      environment.GetEnvVar("HANDLER_PREFIX", "") + "nmstate-webhook",
 			},
 		})
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -413,6 +413,12 @@ spec:
               value: "{{ .ProbeConfiguration.DNS.Host }}"
             - name: METRICS_BIND_ADDRESS
               value: "{{ .MetricsConfiguration.BindAddress }}"
+            - name: NNCP_MAX_RETRIES
+              value: "{{ .NNCPMaxRetries }}"
+            - name: NNCP_MAX_BACKOFF_SECONDS
+              value: "{{ .NNCPMaxBackoffSeconds }}"
+            - name: NNCP_INITIAL_BACKOFF_SECONDS
+              value: "{{ .NNCPInitialBackoffSeconds }}"
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -19,6 +19,7 @@ package environment
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ func IsHandler() bool {
 
 // Returns node name runnig the pod
 func NodeName() string {
-	return os.Getenv("NODE_NAME")
+	return GetEnvVar("NODE_NAME", "")
 }
 
 func LookupAsDuration(varName string) (time.Duration, error) {
@@ -77,4 +78,26 @@ func GetEnvVar(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// GetEnvVarAsInt reads an integer from an environment variable, returning
+// defaultVal if the variable is unset or not a valid integer.
+func GetEnvVarAsInt(key string, defaultVal int) int {
+	if value, exists := os.LookupEnv(key); exists {
+		if intVal, err := strconv.Atoi(value); err == nil {
+			return intVal
+		}
+	}
+	return defaultVal
+}
+
+// GetEnvVarAsDuration reads a seconds value from an environment variable and
+// returns it as a time.Duration, falling back to defaultVal if unset or invalid.
+func GetEnvVarAsDuration(key string, defaultVal time.Duration) time.Duration {
+	if value, exists := os.LookupEnv(key); exists {
+		if intVal, err := strconv.Atoi(value); err == nil {
+			return time.Duration(intVal) * time.Second
+		}
+	}
+	return defaultVal
 }

--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -70,6 +70,9 @@ var _ = BeforeSuite(func() {
 
 	testenv.Start()
 
+	By("Configuring lower retry values for E2E tests to speed up retry tests")
+	testenv.PatchHandlerRetryConfig()
+
 	portFieldName = "port"
 	miimonFormat = "%d"
 

--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -62,6 +62,9 @@ var _ = BeforeSuite(func() {
 
 	testenv.Start()
 
+	By("Configuring lower retry values for E2E tests to speed up retry tests")
+	testenv.PatchHandlerRetryConfig()
+
 	By("Getting node list from cluster")
 	nodeList := corev1.NodeList{}
 	Expect(testenv.Client.List(context.TODO(), &nodeList, &client.ListOptions{})).To(Succeed())

--- a/test/e2e/operator/main_test.go
+++ b/test/e2e/operator/main_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
 	knmstatereporter "github.com/nmstate/kubernetes-nmstate/test/reporter"
 )
 
@@ -56,7 +57,7 @@ var _ = BeforeSuite(func() {
 	// Change to root directory some test expect that
 	os.Chdir("../../../")
 
-	defaultOperator = NewOperatorTestData(os.Getenv("HANDLER_NAMESPACE"), manifestsDir, manifestFiles)
+	defaultOperator = NewOperatorTestData(environment.GetVarWithDefault("HANDLER_NAMESPACE", "nmstate"), manifestsDir, manifestFiles)
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -104,7 +105,7 @@ func podsShouldBeDistributedAtNodes(selectedNodes []corev1.Node, listOptions ...
 }
 
 func isKubevirtciCluster() bool {
-	return strings.Contains(os.Getenv("KUBECONFIG"), "kubevirtci")
+	return strings.Contains(environment.GetVarWithDefault("KUBECONFIG", ""), "kubevirtci")
 }
 
 func controlPlaneNodes() []corev1.Node {

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -20,7 +20,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"time"
 
@@ -42,6 +41,7 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
 	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
+	"github.com/nmstate/kubernetes-nmstate/test/environment"
 	"k8s.io/kubectl/pkg/drain"
 )
 
@@ -120,7 +120,7 @@ var _ = Describe("NMState operator", func() {
 				altOperator TestData
 			)
 			BeforeEach(func() {
-				altOperator = NewOperatorTestData(os.Getenv("HANDLER_NAMESPACE")+"-alt", manifestsDir, manifestFiles)
+				altOperator = NewOperatorTestData(environment.GetVarWithDefault("HANDLER_NAMESPACE", "nmstate")+"-alt", manifestsDir, manifestFiles)
 				By("Wait for operand to be ready")
 				EventuallyOperandIsReady(defaultOperator)
 

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -18,11 +18,19 @@ limitations under the License.
 package env
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -69,4 +77,120 @@ func Start() {
 
 	KubeClient, err = kubernetes.NewForConfig(cfg)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+}
+
+// PatchHandlerRetryConfig sets lower NNCP retry values for faster E2E tests.
+// It patches the operator Deployment's env vars so that the operator re-renders
+// the handler DaemonSet template with the new values, then waits for the
+// handler pods to come up with the updated configuration.
+// If the operator Deployment does not exist, the patching is skipped.
+func PatchHandlerRetryConfig() {
+	ctx := context.Background()
+
+	// Patch the operator Deployment so it passes the lower retry values
+	// to the handler DaemonSet template on its next reconciliation.
+	// Use RetryOnConflict to handle optimistic concurrency conflicts (HTTP 409).
+	desiredEnvVars := map[string]string{
+		"NNCP_MAX_RETRIES":             "2",
+		"NNCP_MAX_BACKOFF_SECONDS":     "5",
+		"NNCP_INITIAL_BACKOFF_SECONDS": "1",
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		operatorDeploy := &appsv1.Deployment{}
+		if err := Client.Get(ctx, client.ObjectKey{
+			Namespace: OperatorNamespace,
+			Name:      "nmstate-operator",
+		}, operatorDeploy); err != nil {
+			return err
+		}
+
+		// Containers[0] is the nmstate-operator container, which is always first.
+		found := map[string]bool{}
+		for i := range operatorDeploy.Spec.Template.Spec.Containers[0].Env {
+			env := &operatorDeploy.Spec.Template.Spec.Containers[0].Env[i]
+			if val, ok := desiredEnvVars[env.Name]; ok {
+				env.Value = val
+				found[env.Name] = true
+			}
+		}
+		for name, val := range desiredEnvVars {
+			if !found[name] {
+				operatorDeploy.Spec.Template.Spec.Containers[0].Env = append(
+					operatorDeploy.Spec.Template.Spec.Containers[0].Env,
+					corev1.EnvVar{Name: name, Value: val},
+				)
+			}
+		}
+
+		return Client.Update(ctx, operatorDeploy)
+	})
+	if apierrors.IsNotFound(err) {
+		fmt.Println("nmstate-operator Deployment not found, skipping retry config patching")
+		return
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	// If the handler DaemonSet already exists (handler e2e tests), wait for
+	// the operator to re-render it with the new values and for pods to restart.
+	// If it doesn't exist yet (operator e2e tests), skip — the operator will
+	// create it with the correct values when the NMState CR is reconciled.
+	ds := &appsv1.DaemonSet{}
+	err = Client.Get(ctx, client.ObjectKey{
+		Namespace: OperatorNamespace,
+		Name:      "nmstate-handler",
+	}, ds)
+	if apierrors.IsNotFound(err) {
+		fmt.Println("nmstate-handler DaemonSet not yet created, skipping wait for handler pods")
+		return
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func(g Gomega) {
+		freshDS := &appsv1.DaemonSet{}
+		err := Client.Get(ctx, client.ObjectKey{
+			Namespace: OperatorNamespace,
+			Name:      "nmstate-handler",
+		}, freshDS)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify the DaemonSet template has the updated env var.
+		// Containers[0] is the handler container, which is always first.
+		hasCorrectRetries := false
+		expectedRetries := desiredEnvVars["NNCP_MAX_RETRIES"]
+		for _, env := range freshDS.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == "NNCP_MAX_RETRIES" && env.Value == expectedRetries {
+				hasCorrectRetries = true
+				break
+			}
+		}
+		g.Expect(hasCorrectRetries).To(BeTrue(), "DaemonSet should have NNCP_MAX_RETRIES=%s", expectedRetries)
+
+		// Verify all handler pods are ready with the new config
+		podList := corev1.PodList{}
+		filterHandlers := client.MatchingLabels{"component": "kubernetes-nmstate-handler"}
+		err = Client.List(ctx, &podList, filterHandlers, client.InNamespace(OperatorNamespace))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(podList.Items).ToNot(BeEmpty())
+		for _, pod := range podList.Items {
+			podReady := false
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					podReady = true
+					break
+				}
+			}
+			g.Expect(podReady).To(BeTrue(), "Pod %s should be ready", pod.Name)
+
+			// Containers[0] is the handler container, which is always first.
+			hasRetries := false
+			for _, env := range pod.Spec.Containers[0].Env {
+				if env.Name == "NNCP_MAX_RETRIES" && env.Value == expectedRetries {
+					hasRetries = true
+					break
+				}
+			}
+			g.Expect(hasRetries).To(BeTrue(), "Pod %s should have NNCP_MAX_RETRIES=%s", pod.Name, expectedRetries)
+		}
+	}, 5*time.Minute, 5*time.Second).Should(Succeed())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Automatically configure lower retry values in E2E tests             

Patch handler DaemonSet in E2E test BeforeSuite to use
* NNCP_MAX_RETRIES=2
* NNCP_MAX_BACKOFF_SECONDS=5

instead of production defaults. 
This speeds up retry related tests by 3-5x while maintaining full validation coverage.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
