### PR TITLE
Fix typos and grammar in all readmes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ If you don't comply with these rules, you waste your energy, time of reviewers
 and cause suffering of future generations.
 -->
 
-**Is this a BUG FIX or a FEATURE ?**:
+**Is this a BUG FIX or a FEATURE?**:
 
 > Uncomment only one, leave it on its own line:
 >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Design
 
-The system is implemented as an k8s operator using the
+The system is implemented as a k8s operator using the
 [operator-sdk](https://github.com/operator-framework/operator-sdk) but is
 deployed as a DaemonSet instead of Deployment with
 [filtering](https://sdk.operatorframework.io/docs/building-operators/golang/references/event-filtering/)
@@ -40,7 +40,7 @@ documentation.
 Common new contributor PR issues are:
 
 - Missing DCO sign-off:\
-  Developers Certificate of Origin (DCO) Sign-off is a requirement for getting
+  Developer Certificate of Origin (DCO) Sign-off is a requirement for getting
   patches into the project (see [Developers Certificate of
   Origin](https://developercertificate.org/)). You can "sign" this certificate
   by including a line in the git commit of "Signed-off-by: Legal Name
@@ -73,11 +73,11 @@ need you to:
 
 # Releasing
 
-To cut a release, push images to quay and publish it on GitHub
-the command `make release` do all this automatically, the version  is at
+To cut a release, push images to quay and publish it on GitHub.
+The command `make release` does all this automatically; the version is at
 `version/version.go` and the description at `version/description`.
 
-So the step would be:
+So the steps would be:
  - Prepare a release calling `make prepare-(patch|minor|major)`
  - Edit version/description to set a description and order commits
  - Create a PR to review it
@@ -116,7 +116,7 @@ In Ubuntu 18.04 they introduced netplan for the network configuration. So to ena
 follow these steps:
 
 ```yaml
-# 1.- - edit /etc/netplan with:
+# 1. edit /etc/netplan with:
 network:
   version: 2
   renderer: NetworkManager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please use the [Private Vulnerability Reporting Feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) on GitHub. We will endevour to respond within 48 hours of reporting.
+To report a vulnerability, please use the [Private Vulnerability Reporting Feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) on GitHub. We will endeavour to respond within 48 hours of reporting.
 If a vulnerability is reported but considered low priority it may be converted into an issue and handled on the public issue tracker.
 Should a vulnerability be considered severe we will endeavour to patch it within 48 hours of acceptance, and may ask for you to collaborate with us on a temporary private fork of the repository.

--- a/design-proposals/customize-dns-probe-globally.md
+++ b/design-proposals/customize-dns-probe-globally.md
@@ -6,8 +6,8 @@ Support customize kubernetes-nmstate DNS resolving probes at NMState CR.
 
 ## Motivation
 
-At some cluster their network configuration is not compatible with DNS health
-probe the kubernetes-nmstate cluster health probes, so the NNCPs will fail.
+In some clusters, the network configuration is not compatible with the
+kubernetes-nmstate DNS health probes, so the NNCPs will fail.
 
 ### User Stories
 
@@ -36,8 +36,8 @@ networking and install operators
 
 ### Workflow Description (go back to default DNS probe)
 
-1. The cluster admin remove the DNS probe customization
-2. The cluster admin creates an NNCP and the default name resolution is use for the DNS probe
+1. The cluster admin removes the DNS probe customization
+2. The cluster admin creates an NNCP and the DNS probe will use the default name resolution
 
 ### Alternatives
 

--- a/docs/content/deployment/arbitrary-cluster.md
+++ b/docs/content/deployment/arbitrary-cluster.md
@@ -47,7 +47,7 @@ to learn about supported versions of NetworkManager.
 Finally, we can install kubernetes-nmstate on our cluster. In order to do that,
 please find the [latest
 release](https://github.com/nmstate/kubernetes-nmstate/releases) and follow the
-the Installation guide attached to it.
+Installation guide attached to it.
 
 You can stop here and play with the cluster on your own or continue with one of
 the [user guides]({{< relref "/user-guide" >}}) that will guide you through

--- a/docs/content/deployment/local-cluster.md
+++ b/docs/content/deployment/local-cluster.md
@@ -5,7 +5,7 @@ type: docs
 ---
 
 Kubernetes-nmstate project allows you to spin up a virtualized
-Kubernets/OpenShift cluster thanks to
+Kubernetes/OpenShift cluster thanks to
 [kubevirtci](https://github.com/kubevirt/kubevirtci) project.
 In this guide, we will create a local Kubernetes
 cluster with two nodes and preinstalled node dependencies. Then we will deploy

--- a/docs/content/user-guide/102-configuration.md
+++ b/docs/content/user-guide/102-configuration.md
@@ -26,7 +26,7 @@ configuration is persistent on the node and survives reboots.
 ## Creating interfaces
 
 Each Policy has a name (`metadata.name`) and desired state
-(`spec.desiredState`). The desired state can contains declarative specification
+(`spec.desiredState`). The desired state can contain a declarative specification
 of the node network configuration following [nmstate
 API](https://nmstate.github.io/).
 

--- a/docs/content/user-guide/103-troubleshooting.md
+++ b/docs/content/user-guide/103-troubleshooting.md
@@ -6,8 +6,8 @@ type: docs
 
 Node network configuration is a risky business. A lot can go wrong and when it
 does, it can render the whole node unreachable and non-operational. This guide
-will show you how to obtain information about failed configuration and how does
-the operator protect the user from breaking the cluster networking.
+will show you how to obtain information about failed configuration and how the
+operator protects the user from breaking the cluster networking.
 
 ## Invalid configuration
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

Fixes #1490

Fix typos, grammar issues, and formatting inconsistencies across all README and documentation files:

- CONTRIBUTING.md: Fix "an k8s" to "a k8s", correct "Developers Certificate" to "Developer Certificate", fix verb agreement in "make release do" to "make release does", change "step" to "steps", and clean up formatting in netplan example
- SECURITY.md: Correct "endevour" to "endeavour"
- docs/content/deployment/local-cluster.md: Fix typo "Kubernets" to "Kubernetes"
- docs/content/deployment/arbitrary-cluster.md: Remove duplicate "the" in installation guide reference
- docs/content/user-guide/102-configuration.md: Fix "can contains" to "can contain"
- docs/content/user-guide/103-troubleshooting.md: Improve grammar in "how does the operator protect" to "how the operator protects"
- design-proposals/customize-dns-probe-globally.md: Fix multiple grammar issues including "At some cluster their" to "In some clusters, the", verb agreement in workflow descriptions
- .github/PULL_REQUEST_TEMPLATE.md: Remove extra space before question mark in "FEATURE ?" to "FEATURE?"

**Special notes for your reviewer**:

This is a documentation-only change with no code impact.

**Release note**:

```release-note
NONE
```

<!-- ai-agent-bot -->