### PR TITLE
Add periodic resync to operator reconciler

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -25,11 +25,13 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -88,6 +90,16 @@ func main() {
 			BindAddress: "0", // disable metrics
 		},
 		HealthProbeBindAddress: ":8081",
+		Cache: cache.Options{
+			// The operator watches the handler namespace to revert external
+			// modifications to its metadata. Restrict the cache to just that
+			// namespace so we do not cache/watch every namespace in the cluster.
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Namespace{}: {
+					Field: fields.OneTermEqualSelector("metadata.name", os.Getenv("HANDLER_NAMESPACE")),
+				},
+			},
+		},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrlOptions)

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -53,6 +54,12 @@ import (
 
 const (
 	nmstateOperatorFieldOwner = client.FieldOwner("nmstate-operator")
+
+	// The periodic resync interval.
+	// We will re-run the reconciliation logic, even if the NMState
+	// configuration hasn't changed. This ensures that externally
+	// modified resources (e.g. namespace annotations) are restored.
+	ResyncPeriod = 5 * time.Minute
 )
 
 // NMStateReconciler reconciles a NMState object
@@ -141,7 +148,7 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	r.Log.Info("Reconcile complete.")
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: ResyncPeriod}, nil
 }
 
 func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -58,6 +59,12 @@ import (
 
 const (
 	nmstateOperatorFieldOwner = client.FieldOwner("nmstate-operator")
+
+	// The periodic resync interval.
+	// We will re-run the reconciliation logic, even if the NMState
+	// configuration hasn't changed. This ensures that externally
+	// modified resources (e.g. namespace annotations) are restored.
+	ResyncPeriod = 5 * time.Minute
 )
 
 // NMStateReconciler reconciles a NMState object
@@ -166,7 +173,7 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	r.Log.Info("Reconcile complete.")
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: ResyncPeriod}, nil
 }
 
 func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -180,7 +180,13 @@ func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&nmstatev1.NMState{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&appsv1.DaemonSet{})
+		Owns(&appsv1.DaemonSet{}).
+		// Watch the handler namespace so that externally modified metadata
+		// (e.g. annotations) is restored without waiting for the periodic
+		// resync. The manager cache is restricted to the handler namespace
+		// for Namespace objects, but we filter here too in case that ever
+		// changes.
+		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(r.nmstateRequestsFromHandlerNamespace))
 
 	// On OpenShift, watch APIServer CR changes to detect TLS profile updates.
 	// This triggers a reconcile that updates the TLS ConfigMap and rolls
@@ -204,6 +210,25 @@ func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return builder.Complete(r)
+}
+
+// nmstateRequestsFromHandlerNamespace maps events on the handler namespace to
+// reconcile requests for the deployed NMState CRs so that externally modified
+// namespace metadata (e.g. annotations) is restored.
+func (r *NMStateReconciler) nmstateRequestsFromHandlerNamespace(ctx context.Context, obj client.Object) []ctrl.Request {
+	if obj.GetName() != os.Getenv("HANDLER_NAMESPACE") {
+		return nil
+	}
+	nmstateList := &nmstatev1.NMStateList{}
+	if err := r.List(ctx, nmstateList); err != nil {
+		r.Log.Error(err, "failed listing NMState CRs to enqueue from namespace event")
+		return nil
+	}
+	requests := []ctrl.Request{}
+	for i := range nmstateList.Items {
+		requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{Name: nmstateList.Items[i].Name}})
+	}
+	return requests
 }
 
 func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx context.Context) error {

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -218,10 +218,10 @@ var _ = Describe("NMState controller reconcile", func() {
 		BeforeEach(func() {
 			request.Name = existingNMStateName
 		})
-		It("should return a Result", func() {
+		It("should return a Result with RequeueAfter", func() {
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 	})
 	Context("when one of manifest directory is empty", func() {
@@ -272,7 +272,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should not add default NodeSelector to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -313,7 +313,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add Tolerations to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -342,7 +342,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add InfraNodeSelector to webhook deployment", func() {
 			deployment := &appsv1.Deployment{}
@@ -384,7 +384,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add InfraTolerations to webhook deployment", func() {
 			deployment := &appsv1.Deployment{}
@@ -427,7 +427,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add DNS probe host to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -449,7 +449,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should apply network policies", func() {
 			netpols := &networkingv1.NetworkPolicyList{}
@@ -475,7 +475,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -503,7 +503,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should not add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -530,7 +530,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should not add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -589,7 +589,7 @@ var _ = Describe("NMState controller reconcile", func() {
 
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 
 		Context("On single node cluster", func() {

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -276,10 +276,10 @@ var _ = Describe("NMState controller reconcile", func() {
 		BeforeEach(func() {
 			request.Name = existingNMStateName
 		})
-		It("should return a Result", func() {
+		It("should return a Result with RequeueAfter", func() {
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 	})
 	Context("when one of manifest directory is empty", func() {
@@ -330,7 +330,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should not add default NodeSelector to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -371,7 +371,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add Tolerations to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -400,7 +400,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add InfraNodeSelector to webhook deployment", func() {
 			deployment := &appsv1.Deployment{}
@@ -442,7 +442,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add InfraTolerations to webhook deployment", func() {
 			deployment := &appsv1.Deployment{}
@@ -485,7 +485,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should add DNS probe host to handler daemonset", func() {
 			ds := &appsv1.DaemonSet{}
@@ -507,7 +507,7 @@ var _ = Describe("NMState controller reconcile", func() {
 			request.Name = existingNMStateName
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 		It("should apply network policies", func() {
 			netpols := &networkingv1.NetworkPolicyList{}
@@ -533,7 +533,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -561,7 +561,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should not add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -588,7 +588,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				request.Name = existingNMStateName
 				result, err := reconciler.Reconcile(context.Background(), request)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 			})
 			It("should not add verbose arguments to handler daemonset container args", func() {
 				ds := &appsv1.DaemonSet{}
@@ -647,7 +647,7 @@ var _ = Describe("NMState controller reconcile", func() {
 
 			result, err := reconciler.Reconcile(context.Background(), request)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 
 		Context("On single node cluster", func() {

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -282,6 +282,19 @@ var _ = Describe("NMState controller reconcile", func() {
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: ResyncPeriod}))
 		})
 	})
+	Context("when handler namespace events are mapped to reconcile requests", func() {
+		newNamespace := func(name string) *corev1.Namespace {
+			return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		}
+		It("should enqueue a request for the NMState CR on handler namespace events", func() {
+			requests := reconciler.nmstateRequestsFromHandlerNamespace(context.Background(), newNamespace(handlerNamespace))
+			Expect(requests).To(ConsistOf(ctrl.Request{NamespacedName: types.NamespacedName{Name: existingNMStateName}}))
+		})
+		It("should not enqueue requests for other namespaces", func() {
+			requests := reconciler.nmstateRequestsFromHandlerNamespace(context.Background(), newNamespace("some-other-namespace"))
+			Expect(requests).To(BeEmpty())
+		})
+	})
 	Context("when one of manifest directory is empty", func() {
 		var (
 			request ctrl.Request


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

**Problem**: The operator only reconciles on NMState CR, Deployment, or DaemonSet changes. If the `openshift.io/node-selector: ""` namespace annotation is removed externally, the reconciler never fires and pods remain stuck in Pending state on clusters with `defaultNodeSelector` configured.

**Fix** (belt and suspenders, per review):
- Returns `ctrl.Result{RequeueAfter: 5 * time.Minute}` from `Reconcile`, adding a periodic resync similar to what CNO does with its 3-minute resync timer
- Watches the handler namespace via `Watches` + `EnqueueRequestsFromMapFunc`, mapping its events to NMState reconcile requests so external modifications are reverted immediately
- Restricts the manager cache for Namespace objects to `metadata.name == HANDLER_NAMESPACE`, so the operator does not cache/watch every namespace in the cluster

This ensures that externally modified resources are restored to their desired state — immediately on namespace events, and at worst within the resync period for anything else.

Ref: https://redhat.atlassian.net/browse/OCPBUGS-67277

**Special notes for your reviewer**:
Inspired by CNO's `ResyncPeriod` approach. The 5-minute interval is conservative enough to not cause excessive API server load but responsive enough to fix the issue within a reasonable time window.

**Release note**:
```release-note
The NMState operator now watches its handler namespace and periodically reconciles its managed resources every 5 minutes, ensuring that externally modified namespace annotations (such as openshift.io/node-selector) are restored. This fixes an issue where pods could get stuck in Pending state on clusters with defaultNodeSelector configured if the annotation was removed.
```