### PR TITLE
Fix typos in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ only events for the DaemonSet pod node.
 # NetworkManager compatibility
 
 kubernetes-nmstate is connecting to NetworkManager running on a host. That
-implies following dependency requirements:
+implies the following dependency requirements:
 
 | kubernetes-nmstate version | NetworkManager version |
 | ---                        | ---                    |
@@ -94,7 +94,7 @@ There is a possibility to enable golang pprof profiler.
  - You can change profiler port by editing 'PROFILER_PORT' - default is 6060
  - Deploy new code to cluster - example:  `make cluster-sync`
  - Find nmstate-handler pod name - `kubectl get pods -n nmstate`
- - Create port forwarding to pod - example: `kubectl port-forward pod pod_name 6060:6060 -n nmstate`
+ - Create port forwarding to pod - example: `kubectl port-forward pod/pod_name 6060:6060 -n nmstate`
  - Use `go tool pprof ...` to gather relevant metrics.
    Examples:
     - open in browser `http://localhost:6060/debug/pprof/`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnmstate%2Fkubernetes-nmstate.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnmstate%2Fkubernetes-nmstate?ref=badge_shield)
 
 
-<img src="logo/fullcolor.png" alias="project logo" />
+<img src="logo/fullcolor.png" alt="project logo" />
 
 [keɪ ɛn ɛm steɪt] Declarative node network configuration driven through Kubernetes API.
 
@@ -41,7 +41,7 @@ You can choose to deploy this operator on a
 [local virtualized cluster](https://nmstate.github.io/kubernetes-nmstate/deployment/local-cluster) or on your
 [arbitrary cluster](https://nmstate.github.io/kubernetes-nmstate/deployment/arbitrary-cluster).
 
-Following comprehensive 101 series is the best place to start learning about all
+The following comprehensive 101 series is the best place to start learning about all
 the features:
 
 1. [Reporting](https://nmstate.github.io/kubernetes-nmstate/user-guide/101-reporting) -
@@ -82,7 +82,7 @@ others that extend support for [Open vSwitch bridges](https://github.com/kubevir
 [SR-IOV](https://github.com/hustcat/sriov-cni), and more...
 
 However, in all of these cases, the node must have the networks setup before the
-pod is scheduled. Setting up the networks in a dynamic and heterogenous cluster,
+pod is scheduled. Setting up the networks in a dynamic and heterogeneous cluster,
 with dynamic networking requirements, is a challenge by itself - and this is
 what this project is addressing.
 


### PR DESCRIPTION
## Summary

- Fix `<img>` attribute `alias` to correct `alt` in README.md
- Add missing article "The" before "following comprehensive 101 series" in README.md
- Fix misspelling "heterogenous" -> "heterogeneous" in README.md
- Add missing article "the" before "following dependency requirements" in CONTRIBUTING.md
- Fix `kubectl port-forward` syntax from `pod pod_name` to `pod/pod_name` in CONTRIBUTING.md
- 
**Release note**:
```release-note
NONE
```