### PR TITLE
Enable golangci-lint modernize linter to replace interface{} with any

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - lll
     - misspell
     - mnd
+    - modernize
     - nakedret
     - noctx
     - rowserrcheck

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func exitWithError(err error, cause string, args ...interface{}) {
+func exitWithError(err error, cause string, args ...any) {
 	fmt.Fprintf(os.Stderr, "render-manifests.go: error: %v\n", errors.Wrapf(err, cause, args...))
 	os.Exit(1)
 }

--- a/pkg/bridge/bridge.go
+++ b/pkg/bridge/bridge.go
@@ -31,11 +31,11 @@ import (
 const minVlanID = 2
 const maxVlanID = 4094
 
-var defaultVlanFiltering = map[string]interface{}{
+var defaultVlanFiltering = map[string]any{
 	"mode": "trunk",
-	"trunk-tags": []map[string]interface{}{
+	"trunk-tags": []map[string]any{
 		{
-			"id-range": map[string]interface{}{
+			"id-range": map[string]any{
 				"min": minVlanID,
 				"max": maxVlanID,
 			},

--- a/pkg/render/funcs.go
+++ b/pkg/render/funcs.go
@@ -26,7 +26,7 @@ import (
 // getOr returns the value of m[key] if it exists, fallback otherwise.
 // As a special case, it also returns fallback if the value of m[key] is
 // the empty string
-func getOr(m map[string]interface{}, key string, fallback interface{}) interface{} {
+func getOr(m map[string]any, key string, fallback any) any {
 	val, ok := m[key]
 	if !ok {
 		return fallback
@@ -42,7 +42,7 @@ func getOr(m map[string]interface{}, key string, fallback interface{}) interface
 
 // isSet returns the value of m[key] if key exists, otherwise false
 // Different from getOr because it will return zero values.
-func isSet(m map[string]interface{}, key string) interface{} {
+func isSet(m map[string]any, key string) any {
 	val, ok := m[key]
 	if !ok {
 		return false

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -36,13 +36,13 @@ import (
 
 type RenderData struct {
 	Funcs template.FuncMap
-	Data  map[string]interface{}
+	Data  map[string]any
 }
 
 func MakeRenderData() RenderData {
 	return RenderData{
 		Funcs: template.FuncMap{},
-		Data:  map[string]interface{}{},
+		Data:  map[string]any{},
 	}
 }
 

--- a/pkg/render/yaml.go
+++ b/pkg/render/yaml.go
@@ -27,7 +27,7 @@ import (
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func ToYaml(v interface{}) string {
+func ToYaml(v any) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.

--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -130,12 +130,12 @@ func isInInterfaces(interfaceName string, interfaces []interfaceState) bool {
 	return false
 }
 
-func filterOutDynamicAttributes(iface map[string]interface{}) {
+func filterOutDynamicAttributes(iface map[string]any) {
 	filterOutBridgeDynamicAttributes(iface)
 	filterOutIPAddressLifetimeAttributes(iface)
 }
 
-func filterOutBridgeDynamicAttributes(iface map[string]interface{}) {
+func filterOutBridgeDynamicAttributes(iface map[string]any) {
 	// The gc-timer and hello-time are deep into linux-bridge like this
 	//    - bridge:
 	//        options:
@@ -149,7 +149,7 @@ func filterOutBridgeDynamicAttributes(iface map[string]interface{}) {
 	if !hasBridge {
 		return
 	}
-	bridge, ok := bridgeRaw.(map[string]interface{})
+	bridge, ok := bridgeRaw.(map[string]any)
 	if !ok {
 		return
 	}
@@ -158,7 +158,7 @@ func filterOutBridgeDynamicAttributes(iface map[string]interface{}) {
 	if !hasOptions {
 		return
 	}
-	options, ok := optionsRaw.(map[string]interface{})
+	options, ok := optionsRaw.(map[string]any)
 	if !ok {
 		return
 	}
@@ -167,7 +167,7 @@ func filterOutBridgeDynamicAttributes(iface map[string]interface{}) {
 	delete(options, "hello-timer")
 }
 
-func filterOutIPAddressLifetimeAttributes(iface map[string]interface{}) {
+func filterOutIPAddressLifetimeAttributes(iface map[string]any) {
 	// The preferred-life-time and valid-life-time are in IPv4/IPv6 address entries like this:
 	//    - ipv4:
 	//        address:
@@ -179,19 +179,19 @@ func filterOutIPAddressLifetimeAttributes(iface map[string]interface{}) {
 	filterOutAddressLifetimes(iface, "ipv6")
 }
 
-func filterOutAddressLifetimes(iface map[string]interface{}, ipVersion string) {
-	ip, ok := iface[ipVersion].(map[string]interface{})
+func filterOutAddressLifetimes(iface map[string]any, ipVersion string) {
+	ip, ok := iface[ipVersion].(map[string]any)
 	if !ok {
 		return
 	}
 
-	addresses, ok := ip["address"].([]interface{})
+	addresses, ok := ip["address"].([]any)
 	if !ok {
 		return
 	}
 
 	for _, addrRaw := range addresses {
-		addr, ok := addrRaw.(map[string]interface{})
+		addr, ok := addrRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -212,11 +212,11 @@ func filterOutInterfaces(ifacesState []interfaceState) []interfaceState {
 	return filteredInterfaces
 }
 
-func isVeth(ifaceData map[string]interface{}) bool {
+func isVeth(ifaceData map[string]any) bool {
 	return ifaceData["type"] == "veth"
 }
 
-func isUnmanaged(ifaceData map[string]interface{}) bool {
+func isUnmanaged(ifaceData map[string]any) bool {
 	return ifaceData["state"] == "ignore"
 }
 

--- a/pkg/state/type.go
+++ b/pkg/state/type.go
@@ -38,12 +38,12 @@ type routes struct {
 
 type routeState struct {
 	routeFields `yaml:",inline"`
-	Data        map[string]interface{}
+	Data        map[string]any
 }
 
 type interfaceState struct {
 	interfaceFields `yaml:",inline"`
-	Data            map[string]interface{}
+	Data            map[string]any
 }
 
 type dnsResolver struct {
@@ -52,8 +52,8 @@ type dnsResolver struct {
 }
 
 type DNSResolverData struct {
-	Search []interface{} `json:"search" yaml:"search"`
-	Server []interface{} `json:"server" yaml:"server"`
+	Search []any `json:"search" yaml:"search"`
+	Server []any `json:"server" yaml:"server"`
 }
 
 // interfaceFields allows unmarshaling directly into the defined fields

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -67,7 +67,7 @@ func FetchAPIServerTLSProfile(ctx context.Context, k8sClient client.Client) (TLS
 }
 
 // parseTLSSecurityProfile extracts the TLS profile type and custom spec from an unstructured APIServer object.
-func parseTLSSecurityProfile(obj map[string]interface{}) (*tlsSecurityProfile, error) {
+func parseTLSSecurityProfile(obj map[string]any) (*tlsSecurityProfile, error) {
 	profileMap, found, err := unstructured.NestedMap(obj, "spec", "tlsSecurityProfile")
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract spec.tlsSecurityProfile: %w", err)

--- a/test/e2e/daemonset/matchers.go
+++ b/test/e2e/daemonset/matchers.go
@@ -35,7 +35,7 @@ type BeReadyMatcher struct {
 	obtainedDaemonSet *v1.DaemonSet
 }
 
-func (matcher *BeReadyMatcher) Match(obtained interface{}) (success bool, err error) {
+func (matcher *BeReadyMatcher) Match(obtained any) (success bool, err error) {
 	obtainedDaemonset, ok := obtained.(v1.DaemonSet)
 
 	if !ok {
@@ -50,11 +50,11 @@ func (matcher *BeReadyMatcher) Match(obtained interface{}) (success bool, err er
 	return matcher.expectedNumberOfPods() == matcher.availableNumberOfPods(), nil
 }
 
-func (matcher *BeReadyMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *BeReadyMatcher) FailureMessage(actual any) (message string) {
 	return matcher.message("to equal")
 }
 
-func (matcher *BeReadyMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *BeReadyMatcher) NegatedFailureMessage(actual any) (message string) {
 	return matcher.message("to not equal")
 }
 

--- a/test/e2e/deployment/matchers.go
+++ b/test/e2e/deployment/matchers.go
@@ -36,7 +36,7 @@ type BeReadyMatcher struct {
 	obtainedDeployment *appsv1.Deployment
 }
 
-func (matcher *BeReadyMatcher) Match(obtained interface{}) (success bool, err error) {
+func (matcher *BeReadyMatcher) Match(obtained any) (success bool, err error) {
 	obtainedDeployment, ok := obtained.(appsv1.Deployment)
 
 	if !ok {
@@ -53,11 +53,11 @@ func (matcher *BeReadyMatcher) Match(obtained interface{}) (success bool, err er
 	return cond.Status == corev1.ConditionTrue, nil
 }
 
-func (matcher *BeReadyMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *BeReadyMatcher) FailureMessage(actual any) (message string) {
 	return matcher.message("to equal")
 }
 
-func (matcher *BeReadyMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *BeReadyMatcher) NegatedFailureMessage(actual any) (message string) {
 	return matcher.message("to not equal")
 }
 

--- a/test/e2e/handler/bonding_default_interface_test.go
+++ b/test/e2e/handler/bonding_default_interface_test.go
@@ -139,7 +139,7 @@ var _ = Describe("NodeNetworkConfigurationPolicy bonding default interface", fun
 	})
 })
 
-func verifyBondIsUpWithPrimaryNicIP(node string, expectedBond map[string]interface{}, ip string) {
+func verifyBondIsUpWithPrimaryNicIP(node string, expectedBond map[string]any, ip string) {
 	interfacesForNode(node).Should(ContainElement(matchingBond(expectedBond)))
 
 	Eventually(func() string {

--- a/test/e2e/handler/states.go
+++ b/test/e2e/handler/states.go
@@ -333,9 +333,9 @@ routes:
 `)
 }
 
-func matchingBond(expectedBond map[string]interface{}) types.GomegaMatcher {
-	expectedLinkAggregation := expectedBond["link-aggregation"].(map[string]interface{})
-	expectedOptions := expectedLinkAggregation["options"].(map[string]interface{})
+func matchingBond(expectedBond map[string]any) types.GomegaMatcher {
+	expectedLinkAggregation := expectedBond["link-aggregation"].(map[string]any)
+	expectedOptions := expectedLinkAggregation["options"].(map[string]any)
 	return SatisfyAll(
 		HaveKeyWithValue("name", expectedBond["name"]),
 		HaveKeyWithValue("type", expectedBond["type"]),

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -60,12 +60,12 @@ var (
 	maxUnavailable = environment.GetVarWithDefault("NMSTATE_MAX_UNAVAILABLE", nmstatenode.DefaultMaxunavailable)
 )
 
-func Byf(message string, arguments ...interface{}) {
+func Byf(message string, arguments ...any) {
 	By(fmt.Sprintf(message, arguments...))
 }
 
-func interfaceName(iface interface{}) string {
-	name, hasName := iface.(map[string]interface{})["name"]
+func interfaceName(iface any) string {
+	name, hasName := iface.(map[string]any)["name"]
 	Expect(hasName).
 		To(
 			BeTrue(),
@@ -75,7 +75,7 @@ func interfaceName(iface interface{}) string {
 	return name.(string)
 }
 
-func interfacesName(interfaces []interface{}) []string {
+func interfacesName(interfaces []any) []string {
 	var names []string
 	for _, iface := range interfaces {
 		names = append(names, interfaceName(iface))
@@ -83,11 +83,11 @@ func interfacesName(interfaces []interface{}) []string {
 	return names
 }
 
-func interfaceByName(interfaces []interface{}, searchedName string) map[string]interface{} {
-	var dummy map[string]interface{}
+func interfaceByName(interfaces []any, searchedName string) map[string]any {
+	var dummy map[string]any
 	for _, iface := range interfaces {
 		if interfaceName(iface) == searchedName {
-			return iface.(map[string]interface{})
+			return iface.(map[string]any)
 		}
 	}
 	Fail(fmt.Sprintf("interface %s not found at %+v", searchedName, interfaces))
@@ -400,11 +400,11 @@ func deleteConnectionAndWait(nodesToModify []string, interfaceName string) {
 	waitForInterfaceDeletion(nodesToModify, interfaceName)
 }
 
-func interfaces(state nmstate.State) []interface{} {
-	var stateUnstructured map[string]interface{}
+func interfaces(state nmstate.State) []any {
+	var stateUnstructured map[string]any
 	err := yaml.Unmarshal(state.Raw, &stateUnstructured)
 	Expect(err).ToNot(HaveOccurred(), "Should parse correctly yaml: %s", state)
-	interfaces := stateUnstructured["interfaces"].([]interface{})
+	interfaces := stateUnstructured["interfaces"].([]any)
 	return interfaces
 }
 
@@ -464,7 +464,7 @@ func vrfForNodeInterfaceEventually(node, vrfID string) AsyncAssertion {
 }
 
 func interfacesForNode(node string) AsyncAssertion {
-	return Eventually(func() []interface{} {
+	return Eventually(func() []any {
 		var currentStateYaml nmstate.State
 		currentState(node, &currentStateYaml).ShouldNot(BeEmpty())
 
@@ -628,7 +628,7 @@ func interfacesState(state nmstate.State, exclude []string) map[string]string {
 		if ifaceInSlice(name, exclude) {
 			continue
 		}
-		state, hasState := iface.(map[string]interface{})["state"]
+		state, hasState := iface.(map[string]any)["state"]
 		if !hasState {
 			state = "unknown"
 		}

--- a/test/reporter/writers.go
+++ b/test/reporter/writers.go
@@ -297,7 +297,7 @@ func writeString(writer io.Writer, message string) {
 	writer.Write([]byte(message))
 }
 
-func writeMessage(writer io.Writer, message string, args ...interface{}) {
+func writeMessage(writer io.Writer, message string, args ...any) {
 	formattedMessage := message
 	if len(args) > 0 {
 		formattedMessage = fmt.Sprintf(formattedMessage, args)


### PR DESCRIPTION
Fixes #1487

**Is this a BUG FIX or a FEATURE?**:

/kind enhancement

**What this PR does / why we need it**:

This PR enables the `modernize` linter in `.golangci.yml` and replaces all instances of `interface{}` with the `any` alias introduced in Go 1.18.

The changes ensure:
1. The codebase uses modern Go language features consistently
2. The `modernize` linter enforces this going forward, preventing reintroduction of `interface{}`
3. Code is more readable with the shorter `any` type alias

Approximately 55 instances of `interface{}` were replaced across 14 files in the codebase, including core packages (`pkg/bridge`, `pkg/state`, `pkg/render`, `pkg/tls`) and test utilities.

**Special notes for your reviewer**:

All changes are mechanical replacements of `interface{}` with `any`. There are no behavioral changes - `any` is simply a type alias for `interface{}` introduced in Go 1.18.

The `modernize` linter is now enabled in `.golangci.yml` to enforce this standard going forward.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot -->