### PR TITLE
Add macOS development support via Lima VM and external cluster

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,13 @@
-FROM registry.access.redhat.com/ubi9/ubi AS build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi AS build
 ARG GO_VERSION=1.25
+ARG TARGETARCH
 
 COPY . .
 
 RUN ./build/install-go.sh ${GO_VERSION}
 ENV PATH=/usr/local/go/bin/:$PATH
 
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false go build -o manager ./cmd/handler
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOARCH=${TARGETARCH} go build -o manager ./cmd/handler
 
 FROM quay.io/centos/centos:stream9
 

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -1,5 +1,6 @@
-FROM registry.access.redhat.com/ubi9/ubi AS build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi AS build
 ARG GO_VERSION=1.25
+ARG TARGETARCH
 
 COPY . .
 
@@ -7,7 +8,7 @@ RUN ./build/install-go.sh ${GO_VERSION}
 ENV PATH=/usr/local/go/bin/:$PATH
 
 
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false go build -o manager ./cmd/operator
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=false GOARCH=${TARGETARCH} go build -o manager ./cmd/operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -51,11 +51,11 @@ function isRemoved {
 }
 
 function isHandlerRemoved {
-    isRemoved daemonset ${HANDLER_NAMESPACE} app=kubernetes-nmstate
+    isRemoved daemonset ${HANDLER_NAMESPACE:-nmstate} app=kubernetes-nmstate
 }
 
 function isWebhookRemoved {
-    isRemoved deployment ${HANDLER_NAMESPACE} app=kubernetes-nmstate
+    isRemoved deployment ${HANDLER_NAMESPACE:-nmstate} app=kubernetes-nmstate
 }
 
 function wait_removed() {

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+source ./cluster/lima.sh
+lima::ensure_linux
+
 function eventually {
     timeout=15
     interval=5

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ERROR: make cluster-down is not supported on macOS." >&2
+    echo "" >&2
+    echo "kubevirtci requires x86_64 Linux. Manage your external cluster directly." >&2
+    exit 1
+fi
+
 source ./cluster/kubevirtci.sh
 kubevirtci::install
 

--- a/cluster/lima.sh
+++ b/cluster/lima.sh
@@ -17,7 +17,7 @@ function lima::ensure_linux() {
         exit 1
     fi
 
-    if ! limactl list --json 2>/dev/null | grep -q "\"name\":\"${LIMA_VM_NAME}\""; then
+    if [[ -z $(limactl list "${LIMA_VM_NAME}" --json 2>/dev/null) ]]; then
         echo "Lima VM '${LIMA_VM_NAME}' not found. Creating it..." >&2
         echo "This will download a VM image and install dependencies (Docker, Go, etc.)." >&2
         echo "First-time setup — this is a one-time operation." >&2
@@ -30,10 +30,7 @@ function lima::ensure_linux() {
     fi
 
     local status
-    status=$(limactl list --json 2>/dev/null \
-        | grep "\"name\":\"${LIMA_VM_NAME}\"" \
-        | sed -n 's/.*"status":"\([^"]*\)".*/\1/p' \
-        | head -n1)
+    status=$(limactl list "${LIMA_VM_NAME}" --json 2>/dev/null | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
 
     if [[ "$status" != "Running" ]]; then
         echo "Starting Lima VM '${LIMA_VM_NAME}'..." >&2

--- a/cluster/lima.sh
+++ b/cluster/lima.sh
@@ -24,20 +24,16 @@ function lima::ensure_linux() {
         if ! limactl start "${LIMA_TEMPLATE}" --name "${LIMA_VM_NAME}" --tty=false; then
             echo "ERROR: Lima VM creation failed." >&2
             echo "Serial log (last 50 lines):" >&2
-            tail -50 "${HOME}/.lima/${LIMA_VM_NAME}/serial.log" 2>/dev/null || true
+            tail -50 "${LIMA_HOME:-$HOME/.lima}/${LIMA_VM_NAME}/serial.log" 2>/dev/null || true
             exit 1
         fi
     fi
 
     local status
-    status=$(limactl list --json 2>/dev/null | python3 -c "
-import sys, json
-for line in sys.stdin:
-    obj = json.loads(line)
-    if obj.get('name') == '${LIMA_VM_NAME}':
-        print(obj.get('status', ''))
-        break
-" 2>/dev/null || echo "")
+    status=$(limactl list --json 2>/dev/null \
+        | grep "\"name\":\"${LIMA_VM_NAME}\"" \
+        | sed -n 's/.*"status":"\([^"]*\)".*/\1/p' \
+        | head -n1)
 
     if [[ "$status" != "Running" ]]; then
         echo "Starting Lima VM '${LIMA_VM_NAME}'..." >&2
@@ -54,21 +50,34 @@ for line in sys.stdin:
     # from usermod -aG aren't loaded — docker ps would fail with permission denied.
     # Default to amd64 image builds — external clusters are x86_64 and the
     # arm64 Lima VM would otherwise produce arm64 images that can't run there.
-    local _archs="${ARCHS:-amd64}"
+
+    # Build the environment variable assignments with proper escaping via printf %q
+    # to handle values containing spaces or special characters.
+    local env_vars=""
+    local -A _forward_vars=(
+        [ARCHS]="${ARCHS:-amd64}"
+        [KUBEVIRT_PROVIDER]="${KUBEVIRT_PROVIDER:-}"
+        [KUBEVIRT_NUM_NODES]="${KUBEVIRT_NUM_NODES:-}"
+        [KUBEVIRT_NUM_SECONDARY_NICS]="${KUBEVIRT_NUM_SECONDARY_NICS:-}"
+        [KUBEVIRT_DEPLOY_PROMETHEUS]="${KUBEVIRT_DEPLOY_PROMETHEUS:-}"
+        [KUBEVIRT_DEPLOY_GRAFANA]="${KUBEVIRT_DEPLOY_GRAFANA:-}"
+        [KUBECONFIG]="${KUBECONFIG:-}"
+        [NM_VERSION]="${NM_VERSION:-}"
+        [NMSTATE_VERSION]="${NMSTATE_VERSION:-}"
+        [DEV_IMAGE_REGISTRY]="${DEV_IMAGE_REGISTRY:-}"
+        [IMAGE_REGISTRY]="${IMAGE_REGISTRY:-}"
+        [IMAGE_REPO]="${IMAGE_REPO:-}"
+    )
+    for key in "${!_forward_vars[@]}"; do
+        env_vars+="$key=$(printf '%q' "${_forward_vars[$key]}") "
+    done
+
+    # Escape script path and arguments
+    local escaped_args=""
+    for arg in "$@"; do
+        escaped_args+=" $(printf '%q' "$arg")"
+    done
 
     exec limactl shell --workdir "$(pwd)" "${LIMA_VM_NAME}" \
-        sg docker -c "\
-        ARCHS='${_archs}' \
-        KUBEVIRT_PROVIDER='${KUBEVIRT_PROVIDER:-}' \
-        KUBEVIRT_NUM_NODES='${KUBEVIRT_NUM_NODES:-}' \
-        KUBEVIRT_NUM_SECONDARY_NICS='${KUBEVIRT_NUM_SECONDARY_NICS:-}' \
-        KUBEVIRT_DEPLOY_PROMETHEUS='${KUBEVIRT_DEPLOY_PROMETHEUS:-}' \
-        KUBEVIRT_DEPLOY_GRAFANA='${KUBEVIRT_DEPLOY_GRAFANA:-}' \
-        KUBECONFIG='${KUBECONFIG:-}' \
-        NM_VERSION='${NM_VERSION:-}' \
-        NMSTATE_VERSION='${NMSTATE_VERSION:-}' \
-        DEV_IMAGE_REGISTRY='${DEV_IMAGE_REGISTRY:-}' \
-        IMAGE_REGISTRY='${IMAGE_REGISTRY:-}' \
-        IMAGE_REPO='${IMAGE_REPO:-}' \
-        bash $0 $@"
+        sg docker -c "${env_vars}bash $(printf '%q' "$0")${escaped_args}"
 }

--- a/cluster/lima.sh
+++ b/cluster/lima.sh
@@ -53,24 +53,22 @@ function lima::ensure_linux() {
 
     # Build the environment variable assignments with proper escaping via printf %q
     # to handle values containing spaces or special characters.
+    # Note: must be bash 3.2 compatible (no associative arrays) since macOS
+    # ships bash 3.2 and this function runs on the host before re-exec.
     local env_vars=""
-    local -A _forward_vars=(
-        [ARCHS]="${ARCHS:-amd64}"
-        [KUBEVIRT_PROVIDER]="${KUBEVIRT_PROVIDER:-}"
-        [KUBEVIRT_NUM_NODES]="${KUBEVIRT_NUM_NODES:-}"
-        [KUBEVIRT_NUM_SECONDARY_NICS]="${KUBEVIRT_NUM_SECONDARY_NICS:-}"
-        [KUBEVIRT_DEPLOY_PROMETHEUS]="${KUBEVIRT_DEPLOY_PROMETHEUS:-}"
-        [KUBEVIRT_DEPLOY_GRAFANA]="${KUBEVIRT_DEPLOY_GRAFANA:-}"
-        [KUBECONFIG]="${KUBECONFIG:-}"
-        [NM_VERSION]="${NM_VERSION:-}"
-        [NMSTATE_VERSION]="${NMSTATE_VERSION:-}"
-        [DEV_IMAGE_REGISTRY]="${DEV_IMAGE_REGISTRY:-}"
-        [IMAGE_REGISTRY]="${IMAGE_REGISTRY:-}"
-        [IMAGE_REPO]="${IMAGE_REPO:-}"
-    )
-    for key in "${!_forward_vars[@]}"; do
-        env_vars+="$key=$(printf '%q' "${_forward_vars[$key]}") "
-    done
+    _add_env() { env_vars+="$1=$(printf '%q' "$2") "; }
+    _add_env ARCHS               "${ARCHS:-amd64}"
+    _add_env KUBEVIRT_PROVIDER    "${KUBEVIRT_PROVIDER:-}"
+    _add_env KUBEVIRT_NUM_NODES   "${KUBEVIRT_NUM_NODES:-}"
+    _add_env KUBEVIRT_NUM_SECONDARY_NICS "${KUBEVIRT_NUM_SECONDARY_NICS:-}"
+    _add_env KUBEVIRT_DEPLOY_PROMETHEUS  "${KUBEVIRT_DEPLOY_PROMETHEUS:-}"
+    _add_env KUBEVIRT_DEPLOY_GRAFANA     "${KUBEVIRT_DEPLOY_GRAFANA:-}"
+    _add_env KUBECONFIG           "${KUBECONFIG:-}"
+    _add_env NM_VERSION           "${NM_VERSION:-}"
+    _add_env NMSTATE_VERSION      "${NMSTATE_VERSION:-}"
+    _add_env DEV_IMAGE_REGISTRY   "${DEV_IMAGE_REGISTRY:-}"
+    _add_env IMAGE_REGISTRY       "${IMAGE_REGISTRY:-}"
+    _add_env IMAGE_REPO           "${IMAGE_REPO:-}"
 
     # Escape script path and arguments
     local escaped_args=""

--- a/cluster/lima.sh
+++ b/cluster/lima.sh
@@ -30,7 +30,7 @@ function lima::ensure_linux() {
     fi
 
     local status
-    status=$(limactl list "${LIMA_VM_NAME}" --json 2>/dev/null | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+    status=$(limactl list "${LIMA_VM_NAME}" --format '{{.Status}}' 2>/dev/null)
 
     if [[ "$status" != "Running" ]]; then
         echo "Starting Lima VM '${LIMA_VM_NAME}'..." >&2
@@ -66,6 +66,9 @@ function lima::ensure_linux() {
     _add_env DEV_IMAGE_REGISTRY   "${DEV_IMAGE_REGISTRY:-}"
     _add_env IMAGE_REGISTRY       "${IMAGE_REGISTRY:-}"
     _add_env IMAGE_REPO           "${IMAGE_REPO:-}"
+    _add_env OPERATOR_NAMESPACE   "${OPERATOR_NAMESPACE:-}"
+    _add_env HANDLER_NAMESPACE    "${HANDLER_NAMESPACE:-}"
+    _add_env MANIFESTS_DIR        "${MANIFESTS_DIR:-}"
 
     # Escape script path and arguments
     local escaped_args=""

--- a/cluster/lima.sh
+++ b/cluster/lima.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+LIMA_VM_NAME="${LIMA_VM_NAME:-kubernetes-nmstate}"
+LIMA_TEMPLATE="$(dirname "$0")/../lima/kubernetes-nmstate.yaml"
+
+# Detect macOS and re-exec the calling script inside the Lima VM.
+# Call this at the top of each cluster script. On Linux it's a no-op.
+function lima::ensure_linux() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        return 0
+    fi
+
+    if ! command -v limactl &>/dev/null; then
+        echo "ERROR: Lima is required for macOS development." >&2
+        echo "Install it with: brew install lima" >&2
+        echo "Then create the VM: limactl start ./lima/kubernetes-nmstate.yaml --name ${LIMA_VM_NAME}" >&2
+        exit 1
+    fi
+
+    if ! limactl list --json 2>/dev/null | grep -q "\"name\":\"${LIMA_VM_NAME}\""; then
+        echo "Lima VM '${LIMA_VM_NAME}' not found. Creating it..." >&2
+        echo "This will download a VM image and install dependencies (Docker, Go, etc.)." >&2
+        echo "First-time setup — this is a one-time operation." >&2
+        if ! limactl start "${LIMA_TEMPLATE}" --name "${LIMA_VM_NAME}" --tty=false; then
+            echo "ERROR: Lima VM creation failed." >&2
+            echo "Serial log (last 50 lines):" >&2
+            tail -50 "${HOME}/.lima/${LIMA_VM_NAME}/serial.log" 2>/dev/null || true
+            exit 1
+        fi
+    fi
+
+    local status
+    status=$(limactl list --json 2>/dev/null | python3 -c "
+import sys, json
+for line in sys.stdin:
+    obj = json.loads(line)
+    if obj.get('name') == '${LIMA_VM_NAME}':
+        print(obj.get('status', ''))
+        break
+" 2>/dev/null || echo "")
+
+    if [[ "$status" != "Running" ]]; then
+        echo "Starting Lima VM '${LIMA_VM_NAME}'..." >&2
+        limactl start "${LIMA_VM_NAME}"
+    fi
+
+    # Unset SSH so Lima doesn't try to use ./cluster/ssh.sh (exported by the
+    # Makefile) as its SSH binary — Lima needs the real ssh to connect to the VM.
+    unset SSH
+
+    # Re-exec the original script inside the VM, forwarding env vars and args.
+    # Use sg to ensure the docker group is active in the session.
+    # limactl shell doesn't create a login shell, so supplementary groups
+    # from usermod -aG aren't loaded — docker ps would fail with permission denied.
+    # Default to amd64 image builds — external clusters are x86_64 and the
+    # arm64 Lima VM would otherwise produce arm64 images that can't run there.
+    local _archs="${ARCHS:-amd64}"
+
+    exec limactl shell --workdir "$(pwd)" "${LIMA_VM_NAME}" \
+        sg docker -c "\
+        ARCHS='${_archs}' \
+        KUBEVIRT_PROVIDER='${KUBEVIRT_PROVIDER:-}' \
+        KUBEVIRT_NUM_NODES='${KUBEVIRT_NUM_NODES:-}' \
+        KUBEVIRT_NUM_SECONDARY_NICS='${KUBEVIRT_NUM_SECONDARY_NICS:-}' \
+        KUBEVIRT_DEPLOY_PROMETHEUS='${KUBEVIRT_DEPLOY_PROMETHEUS:-}' \
+        KUBEVIRT_DEPLOY_GRAFANA='${KUBEVIRT_DEPLOY_GRAFANA:-}' \
+        KUBECONFIG='${KUBECONFIG:-}' \
+        NM_VERSION='${NM_VERSION:-}' \
+        NMSTATE_VERSION='${NMSTATE_VERSION:-}' \
+        DEV_IMAGE_REGISTRY='${DEV_IMAGE_REGISTRY:-}' \
+        IMAGE_REGISTRY='${IMAGE_REGISTRY:-}' \
+        IMAGE_REPO='${IMAGE_REPO:-}' \
+        bash $0 $@"
+}

--- a/cluster/sync-common.sh
+++ b/cluster/sync-common.sh
@@ -45,7 +45,7 @@ function digest {
 
 function push() {
     if isExternal; then
-        if [[ -z "${DEV_IMAGE_REGISTRY+x}" ]]; then
+        if [[ -z "${DEV_IMAGE_REGISTRY:-}" ]]; then
             echo "Missing DEV_IMAGE_REGISTRY variable"
             return 1
         fi

--- a/cluster/sync-common.sh
+++ b/cluster/sync-common.sh
@@ -45,7 +45,7 @@ function digest {
 
 function push() {
     if isExternal; then
-        if [[ ! -v DEV_IMAGE_REGISTRY ]]; then
+        if [[ -z "${DEV_IMAGE_REGISTRY+x}" ]]; then
             echo "Missing DEV_IMAGE_REGISTRY variable"
             return 1
         fi

--- a/cluster/sync-operator.sh
+++ b/cluster/sync-operator.sh
@@ -2,7 +2,13 @@
 
 set -ex
 
+source ./cluster/lima.sh
+lima::ensure_linux
+
 kubectl=./cluster/kubectl.sh
+MANIFESTS_DIR=${MANIFESTS_DIR:-build/_output/manifests}
+OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE:-nmstate}
+HANDLER_NAMESPACE=${HANDLER_NAMESPACE:-nmstate}
 
 source ./cluster/sync-common.sh
 

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+source ./cluster/lima.sh
+lima::ensure_linux
+
 source ./cluster/sync-common.sh
 source ./cluster/sync-operator.sh
 

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -2,6 +2,21 @@
 
 set -ex
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ERROR: make cluster-up is not supported on macOS." >&2
+    echo "" >&2
+    echo "kubevirtci requires x86_64 Linux and cannot run under arm64 emulation." >&2
+    echo "Set up a Kubernetes cluster on a remote x86_64 Linux machine, then use:" >&2
+    echo "" >&2
+    echo "  export KUBEVIRT_PROVIDER=external" >&2
+    echo "  export KUBECONFIG=/path/to/your/cluster/kubeconfig" >&2
+    echo "  export DEV_IMAGE_REGISTRY=<your-registry>" >&2
+    echo "  make cluster-sync" >&2
+    echo "" >&2
+    echo "See docs/content/developer-guide/106-macos-development.md for details." >&2
+    exit 1
+fi
+
 source ./cluster/kubevirtci.sh
 kubevirtci::install
 

--- a/docs/content/developer-guide/106-macos-development.md
+++ b/docs/content/developer-guide/106-macos-development.md
@@ -1,0 +1,160 @@
+---
+title: "macOS Development"
+weight: 60
+type: docs
+---
+
+This page covers developing kubernetes-nmstate on macOS using a [Lima](https://lima-vm.io/) virtual machine and an external Kubernetes cluster.
+
+## Overview
+
+On macOS (especially Apple Silicon), `make cluster-up` is **not supported** because kubevirtci is amd64-only and Go's runtime crashes under arm64 emulation (both Rosetta and QEMU user-static). Instead, the macOS workflow uses:
+
+1. An **external Kubernetes cluster** running on x86_64 Linux (remote machine, cloud VM, etc.)
+2. A **Lima VM** on your Mac for building images and running `make cluster-sync`
+
+Lima provides a lightweight Linux VM with automatic file sharing — you edit code on macOS and build inside the VM transparently.
+
+## Prerequisites
+
+Install Lima via Homebrew:
+
+```bash
+brew install lima
+```
+
+You also need an x86_64 Linux machine with a running Kubernetes cluster. See the [Local Development Cluster]({{< relref "/developer-guide/103-local-cluster" >}}) page for how to set one up with `make cluster-up` on Linux.
+
+## Quick Start
+
+Set up your environment:
+
+```bash
+export KUBEVIRT_PROVIDER=external
+export KUBECONFIG=/path/to/your/cluster/kubeconfig
+export DEV_IMAGE_REGISTRY=<your-registry>   # e.g., quay.io/yourusername
+```
+
+Then build and deploy:
+
+```bash
+make cluster-sync
+```
+
+On macOS, `cluster-sync` detects Darwin, ensures the Lima VM is running (creating it automatically on first use), and re-executes itself inside the VM. Inside the VM, it builds container images, pushes them to your registry, and deploys to the external cluster. This is completely transparent.
+
+## How It Works
+
+The cluster scripts that support macOS (`cluster/sync.sh`, `cluster/clean.sh`, etc.) source `cluster/lima.sh` and call `lima::ensure_linux` at the top. This function:
+
+1. Checks if running on macOS (on Linux, it returns immediately — zero overhead)
+2. Verifies Lima is installed
+3. Creates the VM from `lima/kubernetes-nmstate.yaml` if it doesn't exist
+4. Starts the VM if it's stopped
+5. Re-executes the same script inside the VM via `limactl shell`, forwarding all relevant environment variables (including `KUBEVIRT_PROVIDER`, `KUBECONFIG`, `DEV_IMAGE_REGISTRY`)
+
+Scripts that require kubevirtci (`cluster/up.sh`, `cluster/down.sh`) detect macOS and exit with a helpful error message instead.
+
+## Workflow
+
+- **Edit code** using your macOS editor or IDE — changes are immediately visible inside the VM via Lima's shared mount
+- **Run `make cluster-sync`** from your macOS terminal to build and deploy
+- **Run `make cluster-clean`** to clean up deployed resources
+- **Run unit tests** inside the VM: `limactl shell kubernetes-nmstate` then `make test/unit`
+- **Manage the external cluster** (up/down) directly on the Linux machine
+
+## Configuration
+
+### VM Name
+
+The default Lima VM name is `kubernetes-nmstate`. Override it with:
+
+```bash
+export LIMA_VM_NAME=my-custom-vm
+make cluster-sync
+```
+
+### Environment Variables
+
+All standard environment variables are forwarded into the VM automatically:
+
+- `KUBEVIRT_PROVIDER`, `KUBECONFIG`
+- `KUBEVIRT_NUM_NODES`, `KUBEVIRT_NUM_SECONDARY_NICS`
+- `KUBEVIRT_DEPLOY_PROMETHEUS`, `KUBEVIRT_DEPLOY_GRAFANA`
+- `NM_VERSION`, `NMSTATE_VERSION`
+- `DEV_IMAGE_REGISTRY`, `IMAGE_REGISTRY`, `IMAGE_REPO`
+
+**Important**: `KUBECONFIG` must point to a file under your home directory (`~`) since that's what Lima mounts into the VM.
+
+## Stopping and Restarting
+
+Stop the VM (preserves state):
+
+```bash
+limactl stop kubernetes-nmstate
+```
+
+Restart it later:
+
+```bash
+limactl start kubernetes-nmstate
+```
+
+Or just run a make target — the scripts will start the VM automatically if it's stopped.
+
+## Cleanup
+
+Delete the VM entirely:
+
+```bash
+limactl delete kubernetes-nmstate
+```
+
+## Troubleshooting
+
+### Docker socket permissions
+
+If you see `permission denied` errors when running Docker commands inside the VM, your user may not have picked up the `docker` group yet. Run:
+
+```bash
+limactl shell kubernetes-nmstate
+newgrp docker
+```
+
+### Registry authentication
+
+If `make cluster-sync` fails with `unauthorized: access to the requested resource is not authorized`, the Lima VM doesn't have your container registry credentials. macOS Docker Desktop stores credentials in the macOS Keychain via the `osxkeychain` helper, which isn't available inside the VM. Log in to your registry inside the VM:
+
+```bash
+limactl shell kubernetes-nmstate
+docker login quay.io
+```
+
+You only need to do this once — the credentials are stored in `~/.docker/config.json` which persists across VM restarts.
+
+### Disk space
+
+If you run out of space in the VM, delete unused Docker images:
+
+```bash
+limactl shell kubernetes-nmstate
+docker system prune -a
+```
+
+### Manual shell access
+
+For debugging or running commands not covered by the transparent integration:
+
+```bash
+limactl shell kubernetes-nmstate
+cd /Users/<your-user>/Developer/kubernetes-nmstate
+```
+
+## Why Not cluster-up on macOS?
+
+kubevirtci provisions Kubernetes nodes as Docker containers running x86_64 Linux. On Apple Silicon Macs, these containers need emulation:
+
+- **Rosetta / qemu-user-static** (user-mode emulation): Go's garbage collector crashes because its `lfstack` pointer packing assumes a 48-bit x86_64 address space, but arm64 emulation maps memory at addresses that overflow this packing.
+- **QEMU full system emulation**: Works correctly but is too slow — kubevirtci nodes take 30+ minutes to boot and are unusable for development.
+
+Until kubevirtci provides native arm64 images, an external x86_64 cluster is the recommended approach.

--- a/docs/content/developer-guide/_index.md
+++ b/docs/content/developer-guide/_index.md
@@ -11,3 +11,4 @@ This guide covers setting up a development environment and common development wo
 - [Local Development Cluster]({{< relref "/developer-guide/103-local-cluster" >}})
 - [Code Generation]({{< relref "/developer-guide/104-code-generation" >}})
 - [Advanced Topics]({{< relref "/developer-guide/105-advanced" >}})
+- [macOS Development]({{< relref "/developer-guide/106-macos-development" >}})

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -20,7 +20,8 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 # If there is no buildx let's install it
 if ! docker buildx > /dev/null 2>&1; then
     mkdir -p ~/.docker/cli-plugins
-    curl -L https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 --output ~/.docker/cli-plugins/docker-buildx
+    BUILDX_ARCH=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')
+    curl -L "https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-${BUILDX_ARCH}" --output ~/.docker/cli-plugins/docker-buildx
     chmod a+x ~/.docker/cli-plugins/docker-buildx
 fi
 

--- a/hack/qemu-user-static.sh
+++ b/hack/qemu-user-static.sh
@@ -2,11 +2,24 @@
 
 set -xe
 
+# Determine which foreign architectures we need QEMU for.
+# On amd64 hosts building arm64 images, we need qemu-aarch64.
+# On arm64 hosts building amd64 images, we need qemu-x86_64.
+HOST_ARCH=$(uname -m)
+
+case "$HOST_ARCH" in
+    x86_64)  QEMU_BINFMT="qemu-aarch64" ;;
+    aarch64) QEMU_BINFMT="qemu-x86_64" ;;
+    *)       QEMU_BINFMT="qemu-aarch64" ;;
+esac
+
 # If qemu-static has already been registered as a runner for foreign
 # binaries, for example by installing qemu-user and qemu-user-binfmt
 # packages on Fedora or by having already run this script earlier,
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
-if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
-    ${IMAGE_BUILDER} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/${QEMU_BINFMT} 2>/dev/null; then
+    # Use tonistiigi/binfmt which provides multi-arch images (works on both amd64 and arm64 hosts),
+    # unlike multiarch/qemu-user-static which is amd64-only.
+    ${IMAGE_BUILDER} run --rm --privileged tonistiigi/binfmt --install all
 fi

--- a/hack/qemu-user-static.sh
+++ b/hack/qemu-user-static.sh
@@ -19,7 +19,12 @@ esac
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
 if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/${QEMU_BINFMT} 2>/dev/null; then
-    # Use tonistiigi/binfmt which provides multi-arch images (works on both amd64 and arm64 hosts),
-    # unlike multiarch/qemu-user-static which is amd64-only.
-    ${IMAGE_BUILDER} run --rm --privileged tonistiigi/binfmt --install all
+    if [[ "$HOST_ARCH" == "aarch64" ]]; then
+        # On arm64 hosts, use tonistiigi/binfmt which provides multi-arch images,
+        # unlike multiarch/qemu-user-static which is amd64-only.
+        ${IMAGE_BUILDER} run --rm --privileged docker.io/tonistiigi/binfmt --install all
+    else
+        # On amd64 hosts, use the original multiarch/qemu-user-static.
+        ${IMAGE_BUILDER} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+    fi
 fi

--- a/lima/kubernetes-nmstate.yaml
+++ b/lima/kubernetes-nmstate.yaml
@@ -1,0 +1,54 @@
+# Lima VM for kubernetes-nmstate development on macOS
+#
+# Provides a Linux environment for building images and deploying to an
+# external Kubernetes cluster. On Apple Silicon, the VM runs arm64 natively
+# using Apple's Virtualization.framework for near-native performance.
+#
+# Note: `make cluster-up` (kubevirtci) is not supported on macOS because
+# kubevirtci is amd64-only and Go's runtime crashes under arm64 emulation.
+# Use KUBEVIRT_PROVIDER=external with a remote x86_64 cluster instead.
+#
+# See docs/content/developer-guide/106-macos-development.md for full instructions.
+
+vmType: "vz"
+rosetta:
+  enabled: true
+
+images:
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2"
+    arch: "aarch64"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
+    arch: "x86_64"
+
+cpus: 4
+memory: "8GiB"
+disk: "60GiB"
+
+mounts:
+  - location: "~"
+    writable: true
+
+containerd:
+  system: false
+  user: false
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      # Install Docker
+      dnf install -y dnf-plugins-core
+      dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+      dnf install -y docker-ce docker-ce-cli containerd.io
+      systemctl enable --now docker
+      usermod -aG docker "${LIMA_CIDATA_USER}"
+      # Install Go (match project version)
+      GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -1)
+      curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz" | tar -C /usr/local -xz
+      echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' > /etc/profile.d/go.sh
+      # Install kubectl
+      curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/kubectl" -o /usr/local/bin/kubectl
+      chmod +x /usr/local/bin/kubectl
+      # Build tools
+      dnf install -y make git gcc jq skopeo

--- a/lima/kubernetes-nmstate.yaml
+++ b/lima/kubernetes-nmstate.yaml
@@ -43,9 +43,9 @@ provision:
       dnf install -y docker-ce docker-ce-cli containerd.io
       systemctl enable --now docker
       usermod -aG docker "${LIMA_CIDATA_USER}"
-      # Install Go (match project version)
-      GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -1)
-      curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz" | tar -C /usr/local -xz
+      # Install Go — pinned to match the version in build/Dockerfile
+      GO_VERSION=1.25.0
+      curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz" | tar -C /usr/local -xz
       echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' > /etc/profile.d/go.sh
       # Install kubectl
       curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/kubectl" -o /usr/local/bin/kubectl

--- a/lima/kubernetes-nmstate.yaml
+++ b/lima/kubernetes-nmstate.yaml
@@ -15,9 +15,9 @@ rosetta:
   enabled: true
 
 images:
-  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-44-1.7.aarch64.qcow2"
     arch: "aarch64"
-  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
+  - location: "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
     arch: "x86_64"
 
 cpus: 4
@@ -44,7 +44,7 @@ provision:
       systemctl enable --now docker
       usermod -aG docker "${LIMA_CIDATA_USER}"
       # Install Go — pinned to match the version in build/Dockerfile
-      GO_VERSION=1.25.0
+      GO_VERSION=1.25
       curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/').tar.gz" | tar -C /usr/local -xz
       echo 'export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH' > /etc/profile.d/go.sh
       # Install kubectl


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
- Add macOS (Apple Silicon) development support using a Lima VM for builds and                  
  `KUBEVIRT_PROVIDER=external` for deployment to a remote x86_64 cluster                          
- Cluster scripts (`sync.sh`, `clean.sh`) transparently re-exec inside the Lima VM on macOS;    
  `up.sh`/`down.sh` exit with guidance since kubevirtci can't run under arm64 emulation           
- Enable Docker cross-compilation in Dockerfiles (`FROM --platform=$BUILDPLATFORM` +            
  `GOARCH=$TARGETARCH`) so Go compiles natively without QEMU                                      
- Fix `hack/qemu-user-static.sh` to work on arm64 hosts (switch to `tonistiigi/binfmt`, detect  
  correct binfmt handler)                                                                         
- Fix `hack/init-buildx.sh` to download the correct buildx binary for the host architecture

**Special notes for your reviewer**:
- [ ] On macOS: `make cluster-sync` with `KUBEVIRT_PROVIDER=external` and valid `KUBECONFIG` —  
  Lima VM should be created automatically, images built as amd64, pushed, and deployed            
- [ ] On macOS: `make cluster-up` should exit with a helpful error message                      
- [ ] On Linux (amd64): existing workflow unchanged — `make cluster-up` and `make cluster-sync` 
  work as before                                                                                  
- [ ] Verify built container images are `linux/amd64` architecture

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add macOS development support via Lima VM with automatic cross-compilation for external x86_64  
  clusters. 
```
