### PR TITLE
fix(handler): disable unused metrics server on non-metrics components

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -221,22 +221,33 @@ func composeTLSOpts(tlsOpts func(*tls.Config)) func(*tls.Config) {
 }
 
 // createManager creates and configures the controller manager.
-// The metrics server always uses TLS (SecureServing). On non-OpenShift clusters
-// controller-runtime auto-generates a self-signed certificate.
-// When isOpenShift is true, authentication and authorization are enforced on the
-// metrics endpoint via TokenReview/SubjectAccessReview.
+//
+// Only the nmstate-metrics Deployment enables the metrics server: it is the
+// sole component that populates custom metrics and is wired to the
+// ServiceMonitor. All other components (handler, webhook, cert-manager)
+// disable it to avoid exposing unused HTTPS ports.
+//
+// When the metrics server is enabled, it always uses TLS (SecureServing).
+// On non-OpenShift clusters controller-runtime auto-generates a self-signed
+// certificate. When isOpenShift is true, authentication and authorization
+// are enforced on the metrics endpoint via TokenReview/SubjectAccessReview.
 func createManager(cfg *rest.Config, tlsOpts func(*tls.Config), isOpenShift bool) (manager.Manager, error) {
-	// Get metrics bind address from environment variable, with default fallback
-	metricsBindAddress := environment.GetEnvVar("METRICS_BIND_ADDRESS", ":8089")
+	var metricsOpts metricsserver.Options
 
-	metricsOpts := metricsserver.Options{
-		BindAddress:   metricsBindAddress,
-		SecureServing: true,
-		TLSOpts:       []func(*tls.Config){tlsOpts},
-	}
-
-	if isOpenShift {
-		metricsOpts.FilterProvider = filters.WithAuthenticationAndAuthorization
+	if environment.IsMetricsManager() {
+		metricsBindAddress := environment.GetEnvVar("METRICS_BIND_ADDRESS", ":8089")
+		metricsOpts = metricsserver.Options{
+			BindAddress:   metricsBindAddress,
+			SecureServing: true,
+			TLSOpts:       []func(*tls.Config){tlsOpts},
+		}
+		if isOpenShift {
+			metricsOpts.FilterProvider = filters.WithAuthenticationAndAuthorization
+		}
+	} else {
+		metricsOpts = metricsserver.Options{
+			BindAddress: "0",
+		}
 	}
 
 	ctrlOptions := ctrl.Options{

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -437,8 +437,6 @@ spec:
               value: "/var/k8s_nmstate/handler_lock"
             - name: PROBE_DNS_HOST
               value: "{{ .ProbeConfiguration.DNS.Host }}"
-            - name: METRICS_BIND_ADDRESS
-              value: "{{ .MetricsConfiguration.BindAddress }}"
             - name: NNCP_MAX_RETRIES
               value: "{{ .NNCPMaxRetries }}"
             - name: NNCP_MAX_BACKOFF_SECONDS


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Only the `nmstate-metrics` Deployment needs the metrics server — it is the sole component that populates custom metrics (`kubernetes_nmstate_*`) and is wired to the ServiceMonitor. All other components (handler, webhook, cert-manager) were running a TLS metrics server that:

- Registered custom gauges in `init()` but never populated them (no controllers write to `monitoring.*`)
- Was not targeted by any Service, ServiceMonitor, or PodMonitor
- Had no declared `containerPort` for the metrics port
- Was not referenced by any probe or NetworkPolicy

This PR flips the logic: only enable the metrics server when `IsMetricsManager()`, disable it (`BindAddress: "0"`) for everything else. This avoids exposing unused HTTPS ports — especially on `hostNetwork` handler nodes — and eliminates the need to configure the OpenShift TLS security profile on components that don't serve metrics.

**Special notes for your reviewer**:

- The `init()` function still registers the custom gauges unconditionally — this is harmless (no server to expose them) and keeps the diff minimal
- The `MetricsConfiguration` field in the NMState CR API is not removed — that would be an API change best handled separately
- The operator binary (`cmd/operator/main.go`) already uses `BindAddress: "0"` to disable its metrics server, so this is an established pattern
- E2E metrics tests (`test/e2e/handler/metrics_test.go`) exec into the `nmstate-metrics` Deployment pod and curl `:8443`, not any other component — they are unaffected

**Release note**:

```release-note
Disable unused metrics server on handler, webhook, and cert-manager components to avoid exposing unnecessary HTTPS ports.
```