### PR TITLE
tls: propagate cluster TLS adherence policy

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -68,12 +68,14 @@ import (
 	nmstatelog "github.com/nmstate/kubernetes-nmstate/pkg/log"
 	"github.com/nmstate/kubernetes-nmstate/pkg/monitoring"
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
+	nmstatetls "github.com/nmstate/kubernetes-nmstate/pkg/tls"
 	"github.com/nmstate/kubernetes-nmstate/pkg/webhook"
 )
 
 const (
-	generalExitStatus    int    = 1
-	tlsProfileConfigPath string = "/etc/nmstate/tls/profile.json"
+	generalExitStatus      int    = 1
+	tlsProfileConfigPath   string = "/etc/nmstate/tls/profile.json"
+	tlsAdherenceConfigPath string = "/etc/nmstate/tls/adherence"
 )
 
 const (
@@ -163,6 +165,24 @@ func mainHandler() int {
 			return generalExitStatus
 		}
 		platformTLSOpts = opts
+
+		// Read the cluster-wide tlsAdherence policy from the same
+		// ConfigMap. A missing file or empty value means "no opinion"
+		// (currently equivalent to LegacyAdheringComponentsOnly).
+		// kubernetes-nmstate already honors the cluster TLS profile
+		// regardless of the adherence policy, so this is logged for
+		// observability only — but the value is also exposed via
+		// ShouldHonorClusterTLSProfile for any future code path that
+		// needs to gate behavior on it.
+		adherence, err := cluster.FetchTLSAdherenceFromFile(tlsAdherenceConfigPath)
+		if err != nil {
+			setupLog.Error(err, "unable to load TLS adherence from file")
+			return generalExitStatus
+		}
+		setupLog.Info("Loaded cluster TLS configuration",
+			"adherence", string(adherence),
+			"shouldHonorClusterTLSProfile", nmstatetls.ShouldHonorClusterTLSProfile(adherence),
+		)
 	}
 
 	// Compose the TLS opts applied to all TLS-enabled servers.

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -392,18 +392,24 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	// On OpenShift, fetch and serialize the TLS profile so handler-deployed
 	// pods can read it from a ConfigMap instead of calling the API server.
 	// A hash annotation on the pod templates triggers a rolling restart
-	// when the TLS profile changes.
+	// when the TLS profile or the tlsAdherence policy changes.
 	if r.IsOpenShift {
-		tlsProfileSpec, err := nmstatetls.FetchAPIServerTLSProfile(ctx, r.APIClient)
+		tlsConfig, err := nmstatetls.FetchAPIServerTLSConfig(ctx, r.APIClient)
 		if err != nil {
 			return fmt.Errorf("failed fetching TLS profile for ConfigMap: %w", err)
 		}
-		tlsJSON, err := json.Marshal(tlsProfileSpec)
+		tlsJSON, err := json.Marshal(tlsConfig.Profile)
 		if err != nil {
 			return fmt.Errorf("failed serializing TLS profile: %w", err)
 		}
 		data.Data["TLSProfileJSON"] = string(tlsJSON)
-		data.Data["TLSProfileHash"] = fmt.Sprintf("%x", sha256.Sum256(tlsJSON))
+		data.Data["TLSAdherencePolicy"] = string(tlsConfig.Adherence)
+		// Hash both the profile and the adherence policy so that a change
+		// to either field rolls the dependent Deployments.
+		hashInput := append([]byte{}, tlsJSON...)
+		hashInput = append(hashInput, '|')
+		hashInput = append(hashInput, []byte(tlsConfig.Adherence)...)
+		data.Data["TLSProfileHash"] = fmt.Sprintf("%x", sha256.Sum256(hashInput))
 	}
 
 	return r.renderAndApply(ctx, instance, data, "handler", true)

--- a/deploy/handler/tls_config.yaml
+++ b/deploy/handler/tls_config.yaml
@@ -7,4 +7,5 @@ metadata:
   namespace: {{ .HandlerNamespace }}
 data:
   profile.json: '{{ .TLSProfileJSON }}'
+  adherence: '{{ .TLSAdherencePolicy }}'
 {{- end }}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -78,4 +79,23 @@ func FetchTLSProfileFromFile(path string) (func(*tls.Config), nmstatetls.TLSProf
 	}
 
 	return tlsOpts, spec, nil
+}
+
+// FetchTLSAdherenceFromFile reads the cluster-wide tlsAdherence policy from a
+// plain text file (mounted from a ConfigMap) and returns it. A missing file
+// or empty content is returned as the zero value ("") with no error: that is
+// the documented "no opinion" state, and matches clusters where the
+// TLSAdherence feature gate is disabled or the field has not yet been set.
+//
+// Any leading/trailing whitespace (notably the trailing newline that some
+// editors add) is trimmed before returning.
+func FetchTLSAdherenceFromFile(path string) (nmstatetls.TLSAdherencePolicy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed reading TLS adherence from %s: %w", path, err)
+	}
+	return nmstatetls.TLSAdherencePolicy(strings.TrimSpace(string(data))), nil
 }

--- a/pkg/tls/adherence_test.go
+++ b/pkg/tls/adherence_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ShouldHonorClusterTLSProfile", func() {
+	DescribeTable("returns the correct decision for each adherence value",
+		func(adherence TLSAdherencePolicy, expected bool) {
+			Expect(ShouldHonorClusterTLSProfile(adherence)).To(Equal(expected))
+		},
+		Entry("empty (no opinion) returns false", TLSAdherencePolicy(""), false),
+		Entry("LegacyAdheringComponentsOnly returns false",
+			TLSAdherenceLegacyAdheringComponentsOnly, false),
+		Entry("StrictAllComponents returns true",
+			TLSAdherenceStrictAllComponents, true),
+		Entry("unknown future value returns true (forward compatibility)",
+			TLSAdherencePolicy("SomeFutureValue"), true),
+		Entry("arbitrary mixed-case unknown value returns true",
+			TLSAdherencePolicy("strictallcomponents"), true),
+	)
+})
+
+var _ = Describe("parseTLSAdherence", func() {
+	It("returns empty when spec.tlsAdherence is missing", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{},
+		}
+		Expect(parseTLSAdherence(obj)).To(Equal(TLSAdherencePolicy("")))
+	})
+
+	It("returns empty when spec is entirely missing", func() {
+		obj := map[string]interface{}{}
+		Expect(parseTLSAdherence(obj)).To(Equal(TLSAdherencePolicy("")))
+	})
+
+	It("returns the value when spec.tlsAdherence is set", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsAdherence": "StrictAllComponents",
+			},
+		}
+		Expect(parseTLSAdherence(obj)).To(Equal(TLSAdherenceStrictAllComponents))
+	})
+
+	It("returns empty when spec.tlsAdherence is not a string", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsAdherence": 42,
+			},
+		}
+		// unstructured.NestedString reports an error in this case; we treat
+		// it as the zero value to keep the operator resilient against
+		// unexpected cluster state.
+		Expect(parseTLSAdherence(obj)).To(Equal(TLSAdherencePolicy("")))
+	})
+
+	It("preserves an unknown adherence value verbatim", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsAdherence": "SomeFutureValue",
+			},
+		}
+		Expect(parseTLSAdherence(obj)).To(Equal(TLSAdherencePolicy("SomeFutureValue")))
+	})
+})

--- a/pkg/tls/controller.go
+++ b/pkg/tls/controller.go
@@ -35,15 +35,22 @@ import (
 )
 
 // SecurityProfileWatcher watches the APIServer object for TLS profile changes
-// and triggers a callback when the profile changes.
+// and triggers a callback when the profile or the cluster-wide tlsAdherence
+// policy changes.
 type SecurityProfileWatcher struct {
 	client.Client
 
 	// InitialTLSProfileSpec is the TLS profile spec that was configured when the operator started.
 	InitialTLSProfileSpec TLSProfileSpec
 
-	// OnProfileChange is called when the TLS profile changes.
-	OnProfileChange func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec TLSProfileSpec)
+	// InitialTLSAdherencePolicy is the tlsAdherence policy that was observed
+	// when the operator started. An empty value is valid and means "no
+	// opinion" (currently equivalent to LegacyAdheringComponentsOnly).
+	InitialTLSAdherencePolicy TLSAdherencePolicy
+
+	// OnProfileChange is called when the TLS profile or the tlsAdherence
+	// policy changes. Both old and new values are passed for each.
+	OnProfileChange func(ctx context.Context, oldProfile, newProfile TLSProfileSpec, oldAdherence, newAdherence TLSAdherencePolicy)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -108,11 +115,17 @@ func (r *SecurityProfileWatcher) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to get TLS profile from APIServer %s: %w", req.String(), err)
 	}
 
-	if !reflect.DeepEqual(r.InitialTLSProfileSpec, currentTLSProfileSpec) {
+	currentAdherence := parseTLSAdherence(obj.Object)
+
+	profileChanged := !reflect.DeepEqual(r.InitialTLSProfileSpec, currentTLSProfileSpec)
+	adherenceChanged := r.InitialTLSAdherencePolicy != currentAdherence
+
+	if profileChanged || adherenceChanged {
 		if r.OnProfileChange != nil {
-			r.OnProfileChange(ctx, r.InitialTLSProfileSpec, currentTLSProfileSpec)
+			r.OnProfileChange(ctx, r.InitialTLSProfileSpec, currentTLSProfileSpec, r.InitialTLSAdherencePolicy, currentAdherence)
 		}
 		r.InitialTLSProfileSpec = currentTLSProfileSpec
+		r.InitialTLSAdherencePolicy = currentAdherence
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -43,27 +43,61 @@ var (
 	}
 )
 
-// FetchAPIServerTLSProfile fetches the TLS profile spec from the cluster's APIServer resource.
-func FetchAPIServerTLSProfile(ctx context.Context, k8sClient client.Client) (TLSProfileSpec, error) {
+// APIServerTLSConfig bundles the TLS profile spec and the cluster-wide
+// TLS adherence policy as observed from the cluster's APIServer resource.
+type APIServerTLSConfig struct {
+	Profile   TLSProfileSpec
+	Adherence TLSAdherencePolicy
+}
+
+// FetchAPIServerTLSConfig fetches both the TLS profile spec and the
+// tlsAdherence policy from the cluster's APIServer resource. A missing
+// or empty tlsAdherence field is returned as the zero value ("").
+func FetchAPIServerTLSConfig(ctx context.Context, k8sClient client.Client) (APIServerTLSConfig, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(apiServerGVK)
 
 	key := client.ObjectKey{Name: apiServerName}
 	if err := k8sClient.Get(ctx, key, obj); err != nil {
-		return TLSProfileSpec{}, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+		return APIServerTLSConfig{}, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
 	}
 
 	profile, err := parseTLSSecurityProfile(obj.Object)
 	if err != nil {
-		return TLSProfileSpec{}, fmt.Errorf("failed to parse TLS profile from APIServer %q: %w", key.String(), err)
+		return APIServerTLSConfig{}, fmt.Errorf("failed to parse TLS profile from APIServer %q: %w", key.String(), err)
 	}
 
 	spec, err := GetTLSProfileSpec(profile)
 	if err != nil {
-		return TLSProfileSpec{}, fmt.Errorf("failed to get TLS profile from APIServer %q: %w", key.String(), err)
+		return APIServerTLSConfig{}, fmt.Errorf("failed to get TLS profile from APIServer %q: %w", key.String(), err)
 	}
 
-	return spec, nil
+	adherence := parseTLSAdherence(obj.Object)
+
+	return APIServerTLSConfig{Profile: spec, Adherence: adherence}, nil
+}
+
+// ShouldHonorClusterTLSProfile returns true when the caller must honor the
+// cluster-wide TLS profile. It mirrors the semantics of the library-go helper
+// of the same name (openshift/library-go #2114): "" and
+// LegacyAdheringComponentsOnly return false; any other value (including
+// StrictAllComponents and any unknown future value) returns true for
+// forward compatibility.
+//
+// kubernetes-nmstate is already a legacy-adhering component: it honors the
+// cluster TLS profile in all observed adherence states. This helper exists so
+// any future code path that needs to gate behavior on adherence has a single,
+// consistent definition to call.
+func ShouldHonorClusterTLSProfile(adherence TLSAdherencePolicy) bool {
+	switch adherence {
+	case "", TLSAdherenceLegacyAdheringComponentsOnly:
+		return false
+	case TLSAdherenceStrictAllComponents:
+		return true
+	default:
+		// Any unknown future value: assume strict for forward compatibility.
+		return true
+	}
 }
 
 // parseTLSSecurityProfile extracts the TLS profile type and custom spec from an unstructured APIServer object.
@@ -105,6 +139,18 @@ func parseTLSSecurityProfile(obj map[string]interface{}) (*tlsSecurityProfile, e
 type tlsSecurityProfile struct {
 	profileType TLSProfileType
 	customSpec  *TLSProfileSpec
+}
+
+// parseTLSAdherence extracts spec.tlsAdherence from an unstructured APIServer
+// object. A missing field, non-string value, or read error is treated as
+// "" (no opinion) — this keeps callers safe on clusters where the feature
+// gate is disabled or the field is not yet present.
+func parseTLSAdherence(obj map[string]interface{}) TLSAdherencePolicy {
+	value, found, err := unstructured.NestedString(obj, "spec", "tlsAdherence")
+	if err != nil || !found {
+		return ""
+	}
+	return TLSAdherencePolicy(value)
 }
 
 // GetTLSProfileSpec returns a TLSProfileSpec for the given profile.

--- a/pkg/tls/tls_suite_test.go
+++ b/pkg/tls/tls_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Package Test Suite")
+}

--- a/pkg/tls/types.go
+++ b/pkg/tls/types.go
@@ -27,6 +27,31 @@ const (
 	TLSProfileCustomType       TLSProfileType = "Custom"
 )
 
+// TLSAdherencePolicy mirrors apiserver.config.openshift.io/v1 TLSAdherencePolicy.
+// It controls how strictly cluster components must honor the cluster-wide TLS profile.
+// See: https://github.com/openshift/api PR #2680.
+//
+// Behavior of the documented values:
+//   - "" (unset): no opinion, currently treated as LegacyAdheringComponentsOnly.
+//     Subject to change.
+//   - LegacyAdheringComponentsOnly: existing behavior; components that already
+//     honor the profile continue to do so.
+//   - StrictAllComponents: all components must honor the cluster TLS profile.
+//
+// The TLSAdherence feature gate (DevPreviewNoUpgrade, TechPreviewNoUpgrade)
+// guards this field on the cluster side; kubernetes-nmstate reads it
+// opportunistically and tolerates an absent or empty value.
+type TLSAdherencePolicy string
+
+const (
+	// TLSAdherenceLegacyAdheringComponentsOnly means existing behavior:
+	// only components that already honor the cluster TLS profile continue to do so.
+	TLSAdherenceLegacyAdheringComponentsOnly TLSAdherencePolicy = "LegacyAdheringComponentsOnly"
+
+	// TLSAdherenceStrictAllComponents means all components must honor the cluster TLS profile.
+	TLSAdherenceStrictAllComponents TLSAdherencePolicy = "StrictAllComponents"
+)
+
 // TLSProtocolVersion is a way to specify the protocol version used for TLS connections.
 type TLSProtocolVersion string
 


### PR DESCRIPTION
Read spec.tlsAdherence from the OpenShift APIServer resource alongside the TLS security profile.

Propagate the adherence policy through the generated TLS ConfigMap, include it in the rollout hash, and watch it for changes so dependent deployments are restarted when either the profile or adherence policy changes.

Missing or empty tlsAdherence is tolerated as the zero value to support clusters where the TLSAdherence feature gate is disabled or the field is absent.

AI-Model: Claude Opus 4.7

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
For OpenShift clusters we now parse TLSAdherencePolicy and include it in the nmstate-tls-config configmap
```
