### PR TITLE
test(tls): add unit tests for pkg/tls

### DIFF
--- a/pkg/tls/ciphers_test.go
+++ b/pkg/tls/ciphers_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("tlsVersion", func() {
+	DescribeTable("returns the right TLS code for a known version name",
+		func(name string, expected uint16) {
+			v, err := tlsVersion(name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(Equal(expected))
+		},
+		Entry("TLS 1.0", "VersionTLS10", uint16(tls.VersionTLS10)),
+		Entry("TLS 1.1", "VersionTLS11", uint16(tls.VersionTLS11)),
+		Entry("TLS 1.2", "VersionTLS12", uint16(tls.VersionTLS12)),
+		Entry("TLS 1.3", "VersionTLS13", uint16(tls.VersionTLS13)),
+	)
+
+	It("defaults to TLS 1.2 when the version name is empty", func() {
+		v, err := tlsVersion("")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v).To(Equal(uint16(tls.VersionTLS12)))
+	})
+
+	It("returns an error for an unknown version name", func() {
+		_, err := tlsVersion("VersionTLS99")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unknown tls version"))
+	})
+})
+
+var _ = Describe("tlsVersionOrDie", func() {
+	It("returns the resolved code for a known version", func() {
+		Expect(tlsVersionOrDie("VersionTLS12")).To(Equal(uint16(tls.VersionTLS12)))
+	})
+
+	It("returns the default for an empty version name", func() {
+		Expect(tlsVersionOrDie("")).To(Equal(uint16(tls.VersionTLS12)))
+	})
+
+	It("panics on an unknown version name", func() {
+		Expect(func() { tlsVersionOrDie("VersionTLS99") }).To(Panic())
+	})
+})
+
+var _ = Describe("cipherSuite", func() {
+	It("returns the code for a known IANA cipher name", func() {
+		code, err := cipherSuite("TLS_AES_128_GCM_SHA256")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(code).To(Equal(uint16(tls.TLS_AES_128_GCM_SHA256)))
+	})
+
+	It("returns an error for an unknown cipher name", func() {
+		_, err := cipherSuite("NOPE")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unknown cipher name"))
+	})
+
+	It("returns an error for an OpenSSL-style cipher name (not in IANA map)", func() {
+		_, err := cipherSuite("ECDHE-RSA-AES128-GCM-SHA256")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("openSSLToIANACipherSuites", func() {
+	It("maps every known OpenSSL name to its IANA name, in order", func() {
+		input := []string{
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-AES256-GCM-SHA384",
+			"AES128-SHA",
+		}
+		Expect(openSSLToIANACipherSuites(input)).To(Equal([]string{
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			"TLS_RSA_WITH_AES_128_CBC_SHA",
+		}))
+	})
+
+	It("silently drops unknown OpenSSL names", func() {
+		input := []string{"ECDHE-RSA-AES128-GCM-SHA256", "NOT-A-CIPHER"}
+		Expect(openSSLToIANACipherSuites(input)).To(Equal([]string{
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		}))
+	})
+
+	It("returns an empty slice for an empty input", func() {
+		Expect(openSSLToIANACipherSuites(nil)).To(BeEmpty())
+		Expect(openSSLToIANACipherSuites([]string{})).To(BeEmpty())
+	})
+
+	It("does not pass through an IANA name directly (only OpenSSL names are in the table)", func() {
+		// Sanity check: the table is OpenSSL-keyed, so feeding an IANA-style
+		// name yields no output. cipherCode() compensates by trying IANA first.
+		input := []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+		Expect(openSSLToIANACipherSuites(input)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("cipherCode", func() {
+	It("resolves an IANA cipher name", func() {
+		Expect(cipherCode("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")).
+			To(Equal(uint16(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)))
+	})
+
+	It("resolves an OpenSSL cipher name via the translation table", func() {
+		Expect(cipherCode("ECDHE-RSA-AES128-GCM-SHA256")).
+			To(Equal(uint16(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)))
+	})
+
+	It("resolves a TLS 1.3 cipher name (shared between IANA and OpenSSL)", func() {
+		Expect(cipherCode("TLS_AES_128_GCM_SHA256")).
+			To(Equal(uint16(tls.TLS_AES_128_GCM_SHA256)))
+	})
+
+	It("returns 0 for an unknown cipher name", func() {
+		Expect(cipherCode("DEFINITELY-NOT-A-CIPHER")).To(BeZero())
+	})
+
+	It("returns 0 for an empty cipher name", func() {
+		Expect(cipherCode("")).To(BeZero())
+	})
+})
+
+var _ = Describe("cipherCodes", func() {
+	It("returns codes for all-known inputs and no unsupported list", func() {
+		codes, unsupported := cipherCodes([]string{
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"TLS_AES_128_GCM_SHA256",
+		})
+		Expect(unsupported).To(BeEmpty())
+		Expect(codes).To(Equal([]uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_AES_128_GCM_SHA256,
+		}))
+	})
+
+	It("returns empty codes and the full input as unsupported when nothing is known", func() {
+		codes, unsupported := cipherCodes([]string{"BOGUS-1", "BOGUS-2"})
+		Expect(codes).To(BeEmpty())
+		Expect(unsupported).To(Equal([]string{"BOGUS-1", "BOGUS-2"}))
+	})
+
+	It("partitions a mixed input while preserving input order", func() {
+		codes, unsupported := cipherCodes([]string{
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"BOGUS-1",
+			"TLS_AES_128_GCM_SHA256",
+			"BOGUS-2",
+		})
+		Expect(codes).To(Equal([]uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_AES_128_GCM_SHA256,
+		}))
+		Expect(unsupported).To(Equal([]string{"BOGUS-1", "BOGUS-2"}))
+	})
+
+	It("returns empty results for an empty or nil input", func() {
+		codes, unsupported := cipherCodes(nil)
+		Expect(codes).To(BeEmpty())
+		Expect(unsupported).To(BeEmpty())
+
+		codes, unsupported = cipherCodes([]string{})
+		Expect(codes).To(BeEmpty())
+		Expect(unsupported).To(BeEmpty())
+	})
+})

--- a/pkg/tls/controller_test.go
+++ b/pkg/tls/controller_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// callbackRecorder captures invocations of SecurityProfileWatcher.OnProfileChange.
+type callbackRecorder struct {
+	calls []callbackCall
+}
+
+type callbackCall struct {
+	oldProfile   TLSProfileSpec
+	newProfile   TLSProfileSpec
+	oldAdherence TLSAdherencePolicy
+	newAdherence TLSAdherencePolicy
+}
+
+func (r *callbackRecorder) fn() func(ctx context.Context, oldProfile, newProfile TLSProfileSpec, oldAdherence, newAdherence TLSAdherencePolicy) {
+	return func(_ context.Context, oldProfile, newProfile TLSProfileSpec, oldAdherence, newAdherence TLSAdherencePolicy) {
+		r.calls = append(r.calls, callbackCall{
+			oldProfile:   oldProfile,
+			newProfile:   newProfile,
+			oldAdherence: oldAdherence,
+			newAdherence: newAdherence,
+		})
+	}
+}
+
+func reconcileRequest() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: apiServerName}}
+}
+
+var _ = Describe("SecurityProfileWatcher.Reconcile", func() {
+	ctx := context.Background()
+
+	It("returns no error and does not call the callback when the APIServer is absent", func() {
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:          newFakeClient(),
+			OnProfileChange: rec.fn(),
+		}
+		res, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+		Expect(rec.calls).To(BeEmpty())
+	})
+
+	It("fires the callback on the first reconcile when initial state differs from current", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Modern"})
+		setTLSAdherence(obj, "StrictAllComponents")
+
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:                    newFakeClient(obj),
+			InitialTLSProfileSpec:     *TLSProfiles[TLSProfileIntermediateType],
+			InitialTLSAdherencePolicy: TLSAdherenceLegacyAdheringComponentsOnly,
+			OnProfileChange:           rec.fn(),
+		}
+
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(HaveLen(1))
+		Expect(rec.calls[0].oldProfile).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+		Expect(rec.calls[0].newProfile).To(Equal(*TLSProfiles[TLSProfileModernType]))
+		Expect(rec.calls[0].oldAdherence).To(Equal(TLSAdherenceLegacyAdheringComponentsOnly))
+		Expect(rec.calls[0].newAdherence).To(Equal(TLSAdherenceStrictAllComponents))
+
+		// And the watcher updates its internal state so that a second
+		// reconcile against the same cluster state is a no-op.
+		_, err = w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(HaveLen(1))
+	})
+
+	It("does not fire the callback when current state already matches initial state", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Intermediate"})
+
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:                    newFakeClient(obj),
+			InitialTLSProfileSpec:     *TLSProfiles[TLSProfileIntermediateType],
+			InitialTLSAdherencePolicy: TLSAdherencePolicy(""),
+			OnProfileChange:           rec.fn(),
+		}
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(BeEmpty())
+	})
+
+	It("fires the callback when only the profile changes", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Modern"})
+		setTLSAdherence(obj, "StrictAllComponents")
+
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:                    newFakeClient(obj),
+			InitialTLSProfileSpec:     *TLSProfiles[TLSProfileIntermediateType],
+			InitialTLSAdherencePolicy: TLSAdherenceStrictAllComponents,
+			OnProfileChange:           rec.fn(),
+		}
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(HaveLen(1))
+		Expect(rec.calls[0].oldAdherence).To(Equal(rec.calls[0].newAdherence))
+		Expect(rec.calls[0].oldProfile).NotTo(Equal(rec.calls[0].newProfile))
+	})
+
+	It("fires the callback when only the adherence changes", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Intermediate"})
+		setTLSAdherence(obj, "StrictAllComponents")
+
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:                    newFakeClient(obj),
+			InitialTLSProfileSpec:     *TLSProfiles[TLSProfileIntermediateType],
+			InitialTLSAdherencePolicy: TLSAdherenceLegacyAdheringComponentsOnly,
+			OnProfileChange:           rec.fn(),
+		}
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(HaveLen(1))
+		Expect(rec.calls[0].oldProfile).To(Equal(rec.calls[0].newProfile))
+		Expect(rec.calls[0].oldAdherence).To(Equal(TLSAdherenceLegacyAdheringComponentsOnly))
+		Expect(rec.calls[0].newAdherence).To(Equal(TLSAdherenceStrictAllComponents))
+	})
+
+	It("fires the callback when both profile and adherence change", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Old"})
+		setTLSAdherence(obj, "StrictAllComponents")
+
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:                    newFakeClient(obj),
+			InitialTLSProfileSpec:     *TLSProfiles[TLSProfileIntermediateType],
+			InitialTLSAdherencePolicy: TLSAdherenceLegacyAdheringComponentsOnly,
+			OnProfileChange:           rec.fn(),
+		}
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.calls).To(HaveLen(1))
+		Expect(rec.calls[0].newProfile).To(Equal(*TLSProfiles[TLSProfileOldType]))
+		Expect(rec.calls[0].newAdherence).To(Equal(TLSAdherenceStrictAllComponents))
+	})
+
+	It("does not panic when OnProfileChange is nil and still updates internal state", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Modern"})
+
+		w := &SecurityProfileWatcher{
+			Client:                newFakeClient(obj),
+			InitialTLSProfileSpec: *TLSProfiles[TLSProfileIntermediateType],
+		}
+		Expect(func() {
+			_, err := w.Reconcile(ctx, reconcileRequest())
+			Expect(err).NotTo(HaveOccurred())
+		}).NotTo(Panic())
+		Expect(w.InitialTLSProfileSpec).To(Equal(*TLSProfiles[TLSProfileModernType]))
+	})
+
+	It("returns an error when spec.tlsSecurityProfile cannot be parsed", func() {
+		obj := newAPIServerUnstructured()
+		obj.Object["spec"] = map[string]interface{}{
+			"tlsSecurityProfile": "not-a-map",
+		}
+		rec := &callbackRecorder{}
+		w := &SecurityProfileWatcher{
+			Client:          newFakeClient(obj),
+			OnProfileChange: rec.fn(),
+		}
+		_, err := w.Reconcile(ctx, reconcileRequest())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse TLS profile"))
+		Expect(rec.calls).To(BeEmpty())
+	})
+})

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newAPIServerUnstructured returns an *unstructured.Unstructured representing
+// a config.openshift.io/v1 APIServer object named "cluster". The caller can
+// further mutate obj.Object["spec"] before seeding into the fake client.
+func newAPIServerUnstructured() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(apiServerGVK)
+	obj.SetName(apiServerName)
+	obj.Object["spec"] = map[string]interface{}{}
+	return obj
+}
+
+// setTLSSecurityProfile installs spec.tlsSecurityProfile on obj.
+func setTLSSecurityProfile(obj *unstructured.Unstructured, profile map[string]interface{}) {
+	spec, _ := obj.Object["spec"].(map[string]interface{})
+	if spec == nil {
+		spec = map[string]interface{}{}
+		obj.Object["spec"] = spec
+	}
+	spec["tlsSecurityProfile"] = profile
+}
+
+// setTLSAdherence installs spec.tlsAdherence on obj.
+func setTLSAdherence(obj *unstructured.Unstructured, adherence string) {
+	spec, _ := obj.Object["spec"].(map[string]interface{})
+	if spec == nil {
+		spec = map[string]interface{}{}
+		obj.Object["spec"] = spec
+	}
+	spec["tlsAdherence"] = adherence
+}
+
+// newFakeClient builds a controller-runtime fake client seeded with the
+// provided unstructured objects.
+func newFakeClient(objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder()
+	if len(objs) > 0 {
+		builder = builder.WithObjects(objs...)
+	}
+	return builder.Build()
+}
+
+var _ = Describe("parseTLSSecurityProfile", func() {
+	It("returns (nil, nil) when spec.tlsSecurityProfile is absent", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{},
+		}
+		profile, err := parseTLSSecurityProfile(obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile).To(BeNil())
+	})
+
+	It("returns (nil, nil) when spec is missing entirely", func() {
+		profile, err := parseTLSSecurityProfile(map[string]interface{}{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile).To(BeNil())
+	})
+
+	It("returns a profile with empty profileType when type is missing", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{},
+			},
+		}
+		profile, err := parseTLSSecurityProfile(obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile).NotTo(BeNil())
+		Expect(profile.profileType).To(Equal(TLSProfileType("")))
+		Expect(profile.customSpec).To(BeNil())
+	})
+
+	DescribeTable("returns the right non-custom profile type",
+		func(profileType TLSProfileType) {
+			obj := map[string]interface{}{
+				"spec": map[string]interface{}{
+					"tlsSecurityProfile": map[string]interface{}{
+						"type": string(profileType),
+					},
+				},
+			}
+			profile, err := parseTLSSecurityProfile(obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(profile).NotTo(BeNil())
+			Expect(profile.profileType).To(Equal(profileType))
+			Expect(profile.customSpec).To(BeNil())
+		},
+		Entry("Old", TLSProfileOldType),
+		Entry("Intermediate", TLSProfileIntermediateType),
+		Entry("Modern", TLSProfileModernType),
+	)
+
+	It("returns a populated customSpec for Custom type with custom block", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+					"custom": map[string]interface{}{
+						"minTLSVersion": "VersionTLS12",
+						"ciphers":       []interface{}{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+					},
+				},
+			},
+		}
+		profile, err := parseTLSSecurityProfile(obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile).NotTo(BeNil())
+		Expect(profile.profileType).To(Equal(TLSProfileCustomType))
+		Expect(profile.customSpec).NotTo(BeNil())
+		Expect(profile.customSpec.MinTLSVersion).To(Equal(VersionTLS12))
+		Expect(profile.customSpec.Ciphers).To(Equal([]string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"}))
+	})
+
+	It("returns Custom type with nil customSpec when custom block is absent", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+				},
+			},
+		}
+		profile, err := parseTLSSecurityProfile(obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile).NotTo(BeNil())
+		Expect(profile.profileType).To(Equal(TLSProfileCustomType))
+		Expect(profile.customSpec).To(BeNil())
+	})
+
+	It("returns an error when spec.tlsSecurityProfile is the wrong type", func() {
+		obj := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"tlsSecurityProfile": "not-a-map",
+			},
+		}
+		_, err := parseTLSSecurityProfile(obj)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("GetTLSProfileSpec", func() {
+	It("returns the default Intermediate profile when profile is nil", func() {
+		spec, err := GetTLSProfileSpec(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+	})
+
+	It("returns the default Intermediate profile when profileType is empty", func() {
+		spec, err := GetTLSProfileSpec(&tlsSecurityProfile{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+	})
+
+	DescribeTable("returns the canned profile for a known non-custom type",
+		func(profileType TLSProfileType) {
+			spec, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: profileType})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec).To(Equal(*TLSProfiles[profileType]))
+		},
+		Entry("Old", TLSProfileOldType),
+		Entry("Intermediate", TLSProfileIntermediateType),
+		Entry("Modern", TLSProfileModernType),
+	)
+
+	It("falls back to Intermediate when the non-custom type is unknown", func() {
+		spec, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: "ImaginaryProfile"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+	})
+
+	It("returns the customSpec verbatim for Custom type", func() {
+		custom := TLSProfileSpec{
+			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+			MinTLSVersion: VersionTLS13,
+		}
+		spec, err := GetTLSProfileSpec(&tlsSecurityProfile{
+			profileType: TLSProfileCustomType,
+			customSpec:  &custom,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).To(Equal(custom))
+	})
+
+	It("returns ErrCustomProfileNil when Custom type lacks customSpec", func() {
+		_, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: TLSProfileCustomType})
+		Expect(errors.Is(err, ErrCustomProfileNil)).To(BeTrue())
+	})
+})
+
+var _ = Describe("FetchAPIServerTLSConfig", func() {
+	ctx := context.Background()
+
+	It("returns a wrapped error when the APIServer is not found", func() {
+		c := newFakeClient()
+		_, err := FetchAPIServerTLSConfig(ctx, c)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get APIServer"))
+		Expect(err.Error()).To(ContainSubstring(apiServerName))
+	})
+
+	It("returns the default Intermediate profile and empty adherence when spec is empty", func() {
+		obj := newAPIServerUnstructured()
+		cfg, err := FetchAPIServerTLSConfig(ctx, newFakeClient(obj))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Profile).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+		Expect(cfg.Adherence).To(Equal(TLSAdherencePolicy("")))
+	})
+
+	It("returns the configured non-custom profile and adherence", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Intermediate"})
+		setTLSAdherence(obj, "StrictAllComponents")
+		cfg, err := FetchAPIServerTLSConfig(ctx, newFakeClient(obj))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Profile).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+		Expect(cfg.Adherence).To(Equal(TLSAdherenceStrictAllComponents))
+	})
+
+	It("returns the custom profile spec verbatim", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{
+			"type": "Custom",
+			"custom": map[string]interface{}{
+				"minTLSVersion": "VersionTLS13",
+				"ciphers":       []interface{}{"TLS_AES_128_GCM_SHA256"},
+			},
+		})
+		cfg, err := FetchAPIServerTLSConfig(ctx, newFakeClient(obj))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Profile.MinTLSVersion).To(Equal(VersionTLS13))
+		Expect(cfg.Profile.Ciphers).To(Equal([]string{"TLS_AES_128_GCM_SHA256"}))
+	})
+
+	It("returns ErrCustomProfileNil when Custom type lacks the custom block", func() {
+		obj := newAPIServerUnstructured()
+		setTLSSecurityProfile(obj, map[string]interface{}{"type": "Custom"})
+		_, err := FetchAPIServerTLSConfig(ctx, newFakeClient(obj))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrCustomProfileNil)).To(BeTrue())
+	})
+})
+
+var _ = Describe("NewTLSConfigFromProfile", func() {
+	It("applies MinVersion and CipherSuites for a non-TLS-1.3 profile (Intermediate)", func() {
+		fn, unsupported := NewTLSConfigFromProfile(*TLSProfiles[TLSProfileIntermediateType])
+		Expect(unsupported).To(BeEmpty())
+
+		conf := &tls.Config{}
+		fn(conf)
+		Expect(conf.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(conf.CipherSuites).NotTo(BeEmpty())
+	})
+
+	It("applies MinVersion for the Old profile and resolves all its ciphers", func() {
+		fn, unsupported := NewTLSConfigFromProfile(*TLSProfiles[TLSProfileOldType])
+		Expect(unsupported).To(BeEmpty())
+
+		conf := &tls.Config{}
+		fn(conf)
+		Expect(conf.MinVersion).To(Equal(uint16(tls.VersionTLS10)))
+		Expect(conf.CipherSuites).NotTo(BeEmpty())
+	})
+
+	It("leaves CipherSuites untouched for a TLS-1.3 profile (Modern)", func() {
+		fn, _ := NewTLSConfigFromProfile(*TLSProfiles[TLSProfileModernType])
+
+		sentinel := []uint16{tls.TLS_RSA_WITH_RC4_128_SHA}
+		conf := &tls.Config{CipherSuites: sentinel}
+		fn(conf)
+
+		Expect(conf.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+		// Per the documented contract: TLS 1.3 cipher suites are not
+		// configurable in Go, so the pre-populated CipherSuites slice
+		// must remain untouched.
+		Expect(conf.CipherSuites).To(Equal(sentinel))
+	})
+
+	It("partitions supported and unsupported ciphers in input order", func() {
+		profile := TLSProfileSpec{
+			Ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256", // supported (OpenSSL)
+				"BOGUS-CIPHER",                // unsupported
+				"TLS_AES_128_GCM_SHA256",      // supported (IANA)
+				"ALSO-BOGUS",                  // unsupported
+			},
+			MinTLSVersion: VersionTLS12,
+		}
+		fn, unsupported := NewTLSConfigFromProfile(profile)
+		Expect(unsupported).To(Equal([]string{"BOGUS-CIPHER", "ALSO-BOGUS"}))
+
+		conf := &tls.Config{}
+		fn(conf)
+		Expect(conf.CipherSuites).To(HaveLen(2))
+		Expect(conf.CipherSuites[0]).To(Equal(uint16(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)))
+		Expect(conf.CipherSuites[1]).To(Equal(uint16(tls.TLS_AES_128_GCM_SHA256)))
+	})
+
+	It("handles an empty cipher list", func() {
+		profile := TLSProfileSpec{Ciphers: []string{}, MinTLSVersion: VersionTLS12}
+		fn, unsupported := NewTLSConfigFromProfile(profile)
+		Expect(unsupported).To(BeEmpty())
+
+		conf := &tls.Config{}
+		fn(conf)
+		Expect(conf.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(conf.CipherSuites).To(BeEmpty())
+	})
+})
+
+var _ = Describe("TLSProfiles map", func() {
+	// These pinned assertions intentionally catch any change to the canned
+	// Mozilla-derived profiles. If the project deliberately rebases the
+	// profiles against a newer Mozilla guideline, these expectations must
+	// be updated in the same change.
+
+	It("pins the Old profile to its exact cipher list and min version", func() {
+		Expect(TLSProfiles[TLSProfileOldType]).NotTo(BeNil())
+		Expect(TLSProfiles[TLSProfileOldType].MinTLSVersion).To(Equal(VersionTLS10))
+		Expect(TLSProfiles[TLSProfileOldType].Ciphers).To(Equal([]string{
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-AES256-GCM-SHA384",
+			"ECDHE-RSA-AES256-GCM-SHA384",
+			"ECDHE-ECDSA-CHACHA20-POLY1305",
+			"ECDHE-RSA-CHACHA20-POLY1305",
+			"ECDHE-ECDSA-AES128-SHA256",
+			"ECDHE-RSA-AES128-SHA256",
+			"ECDHE-ECDSA-AES128-SHA",
+			"ECDHE-RSA-AES128-SHA",
+			"ECDHE-ECDSA-AES256-SHA",
+			"ECDHE-RSA-AES256-SHA",
+			"AES128-GCM-SHA256",
+			"AES256-GCM-SHA384",
+			"AES128-SHA256",
+			"AES128-SHA",
+			"AES256-SHA",
+			"DES-CBC3-SHA",
+		}))
+	})
+
+	It("pins the Intermediate profile to its exact cipher list and min version", func() {
+		Expect(TLSProfiles[TLSProfileIntermediateType]).NotTo(BeNil())
+		Expect(TLSProfiles[TLSProfileIntermediateType].MinTLSVersion).To(Equal(VersionTLS12))
+		Expect(TLSProfiles[TLSProfileIntermediateType].Ciphers).To(Equal([]string{
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-AES256-GCM-SHA384",
+			"ECDHE-RSA-AES256-GCM-SHA384",
+			"ECDHE-ECDSA-CHACHA20-POLY1305",
+			"ECDHE-RSA-CHACHA20-POLY1305",
+		}))
+	})
+
+	It("pins the Modern profile to its exact cipher list and min version", func() {
+		Expect(TLSProfiles[TLSProfileModernType]).NotTo(BeNil())
+		Expect(TLSProfiles[TLSProfileModernType].MinTLSVersion).To(Equal(VersionTLS13))
+		Expect(TLSProfiles[TLSProfileModernType].Ciphers).To(Equal([]string{
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+		}))
+	})
+
+	DescribeTable("every cipher in every canned profile resolves to a non-zero TLS code",
+		func(profileType TLSProfileType) {
+			profile := TLSProfiles[profileType]
+			Expect(profile).NotTo(BeNil())
+			for _, cipher := range profile.Ciphers {
+				Expect(cipherCode(cipher)).NotTo(BeZero(), "cipher %q in profile %q must resolve", cipher, profileType)
+			}
+		},
+		Entry("Old", TLSProfileOldType),
+		Entry("Intermediate", TLSProfileIntermediateType),
+		Entry("Modern", TLSProfileModernType),
+	)
+})


### PR DESCRIPTION
## Summary
- Adds Ginkgo v2 + Gomega unit tests for the `pkg/tls` package: `parseTLSSecurityProfile`, `GetTLSProfileSpec`, `FetchAPIServerTLSConfig`, `NewTLSConfigFromProfile` (including the documented TLS-1.3 `CipherSuites` sentinel-untouched contract), and exact pinning of `TLSProfiles[Old|Intermediate|Modern]` cipher lists + `MinTLSVersion`.
- Covers the cipher helpers (`tlsVersion`, `tlsVersionOrDie`, `cipherSuite`, `openSSLToIANACipherSuites`, `cipherCode`, `cipherCodes`) and `SecurityProfileWatcher.Reconcile` across APIServer-absent, profile-only-change, adherence-only-change, both-change, steady-state, nil-callback, and parse-error paths.
- No production code changes; uses a `controller-runtime` fake client.

## Note
This PR depends on the `tlsAdherence` production-code work (introducing `TLSAdherencePolicy`, `parseTLSAdherence`, `FetchAPIServerTLSConfig`, and `SecurityProfileWatcher.InitialTLSAdherencePolicy`). It will compile and pass once that change lands; opened now to keep the test coverage ready for review alongside it.

76 specs, all passing locally against the adherence branch.