### PR TITLE
build: add s390x support to lint and Go installation scripts

### DIFF
--- a/build/install-go.sh
+++ b/build/install-go.sh
@@ -1,21 +1,17 @@
 #!/bin/bash -xe
 
 version=$1
-arch=""
+arch=$(uname -m)
 os=linux
-go_mod_version=$1
 
 dnf install -y jq
 
-case $(uname -m) in
-    x86_64)  arch="amd64";;
+case $arch in
+    x86_64)  arch="amd64" ;;
     aarch64) arch="arm64" ;;
 esac
 
-if [ "$arch" == "" ]; then
-    echo "Unknown architecture $(uname -m)"
-    exit 1
-fi
+echo "Installing Go ${version} for architecture: ${arch}"
 
 tarball_url="https://go.dev/dl/go${version}.${os}-${arch}.tar.gz"
 

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,11 +1,10 @@
 #!/bin/bash -xe
-architecture=""
-case $(uname -m) in
-    x86_64)           architecture="amd64" ;;
-    aarch64|arm64)    architecture="arm64" ;;
-    *)
-                      echo "Unsupported architecture: $(uname -m), must be (x86_64|aarch64|arm64)."
-                      exit 1;
+
+architecture=$(uname -m)
+
+case $architecture in
+    x86_64)        architecture="amd64" ;;
+    aarch64|arm64) architecture="arm64" ;;
 esac
 
 path_combined="$(uname -s | tr '[:upper:]' '[:lower:]')-${architecture}"


### PR DESCRIPTION
support building kubernetes-nmstate on IBM Z / s390x environments.
Add explicit support for s390x architecture in:

- hack/lint.sh: Allow linting to run on s390x instead of failing
- build/install-go.sh: Map s390x architecture correctly when downloading and installing Go

This enables building kubernetes-nmstate on s390x-based systems.

**Is this a BUG FIX or a FEATURE?**:
> /kind enhancement

**What this PR does / why we need it**:
Add support for the s390x (IBM Z) architecture in the build and lint scripts.

Previously, running make lint or make handler on s390x systems would fail due to missing architecture mappings. This change adds the necessary cases so that:
- **hack/lint.sh** recognizes s390x and proceeds with linting.
- **build/install-go.sh** correctly maps s390x and downloads the appropriate Go binary (go${VERSION}.linux-s390x.tar.gz).


**Special notes for your reviewer**:
- Tested on s390x: make lint and make handler  now succeed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add s390x  support to lint and container build scripts.
```
