### PR TITLE
Add qeth VNICC handling for s390x NNCP.

### DIFF
--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	goruntime "runtime"
 	"sort"
 	"strconv"
 	"time"
@@ -59,6 +60,7 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/pkg/nmstatectl"
 	"github.com/nmstate/kubernetes-nmstate/pkg/node"
 	"github.com/nmstate/kubernetes-nmstate/pkg/policyconditions"
+	"github.com/nmstate/kubernetes-nmstate/pkg/qeth"
 	"github.com/nmstate/kubernetes-nmstate/pkg/selectors"
 )
 
@@ -184,6 +186,21 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	}
 	previousConditions := &enactmentInstance.Status.Conditions
 	enactmentConditions := enactmentconditions.New(r.APIClient, nmstateapi.EnactmentKey(nodeName, instance.Name))
+	if goruntime.GOARCH == "s390x" {
+		vniccHook := qeth.NewVniccHook(log)
+		cleanedState, err := vniccHook.ProcessAndStrip(enactmentInstance.Status.DesiredState)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("qeth vnicc pre-processing failed: %w", err)
+		}
+		enactmentInstance.Status.DesiredState = cleanedState
+		// Strip from policy spec (used by nmpolicy.GenerateState → nmstatectl policy)
+		// Modified in-memory only — NOT written back to Kubernetes
+		cleanedSpecState, err := vniccHook.ProcessAndStrip(instance.Spec.DesiredState)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("qeth vnicc pre-processing (spec) failed: %w", err)
+		}
+		instance.Spec.DesiredState = cleanedSpecState
+	}
 
 	err = r.fillInEnactmentStatus(ctx, instance, enactmentInstance, enactmentConditions)
 	if err != nil {

--- a/pkg/qeth/vnicc.go
+++ b/pkg/qeth/vnicc.go
@@ -1,0 +1,234 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qeth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	sysfsQethBase = "/sys/devices/qeth"
+	sysfsNetBase  = "/sys/class/net"
+	filePerm      = 0600
+)
+
+// VniccConfig holds the desired VNIC characteristics for a qeth device.
+type VniccConfig struct {
+	Flooding         *bool `json:"flooding,omitempty"         yaml:"flooding,omitempty"`
+	McastFlooding    *bool `json:"mcast-flooding,omitempty"   yaml:"mcast-flooding,omitempty"`
+	Learning         *bool `json:"learning,omitempty"         yaml:"learning,omitempty"`
+	LearningTimeout  *int  `json:"learning-timeout,omitempty" yaml:"learning-timeout,omitempty"`
+	RxBcast          *bool `json:"rx-bcast,omitempty"         yaml:"rx-bcast,omitempty"`
+	TakeoverSetvmac  *bool `json:"takeover-setvmac,omitempty" yaml:"takeover-setvmac,omitempty"`
+	TakeoverLearning *bool `json:"takeover-learning,omitempty" yaml:"takeover-learning,omitempty"`
+	BridgeInvisible  *bool `json:"bridge-invisible,omitempty" yaml:"bridge-invisible,omitempty"`
+}
+
+// Manager handles reading and writing qeth VNIC characteristics via sysfs.
+type Manager struct {
+	log logr.Logger
+}
+
+// NewManager creates a new qeth VNIC characteristics Manager.
+func NewManager(log logr.Logger) *Manager {
+	return &Manager{log: log.WithName("qeth-vnicc")}
+}
+
+// Apply writes VniccConfig to sysfs for the given interface using real sysfs paths.
+func (m *Manager) Apply(ifaceName string, cfg VniccConfig) error {
+	return m.applyWithPaths(sysfsQethBase, sysfsNetBase, ifaceName, cfg)
+}
+
+// ApplyWithBasePath writes VniccConfig using a custom base path.
+// Used in unit tests to point at a fake tmpdir sysfs.
+func (m *Manager) ApplyWithBasePath(basePath, ifaceName string, cfg VniccConfig) error {
+	qethBase := filepath.Join(basePath, "devices", "qeth")
+	netBase := filepath.Join(basePath, "class", "net")
+	return m.applyWithPaths(qethBase, netBase, ifaceName, cfg)
+}
+
+// Read returns the current VniccConfig from real sysfs for the given interface.
+func (m *Manager) Read(ifaceName string) (*VniccConfig, error) {
+	return m.readWithPaths(sysfsQethBase, sysfsNetBase, ifaceName)
+}
+
+// ReadWithBasePath reads VniccConfig from a custom base path (for unit tests).
+func (m *Manager) ReadWithBasePath(basePath, ifaceName string) (*VniccConfig, error) {
+	qethBase := filepath.Join(basePath, "devices", "qeth")
+	netBase := filepath.Join(basePath, "class", "net")
+	return m.readWithPaths(qethBase, netBase, ifaceName)
+}
+
+// IsQethInterface returns true if the interface is backed by a qeth device (real sysfs).
+func (m *Manager) IsQethInterface(ifaceName string) bool {
+	return m.isQethWithPaths(sysfsQethBase, sysfsNetBase, ifaceName)
+}
+
+// IsQethInterfaceWithBasePath checks qeth status using a custom base path (for unit tests).
+func (m *Manager) IsQethInterfaceWithBasePath(basePath, ifaceName string) bool {
+	qethBase := filepath.Join(basePath, "devices", "qeth")
+	netBase := filepath.Join(basePath, "class", "net")
+	return m.isQethWithPaths(qethBase, netBase, ifaceName)
+}
+
+func (m *Manager) applyWithPaths(qethBase, netBase, ifaceName string, cfg VniccConfig) error {
+	busID, err := m.resolveQethBusID(netBase, ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve qeth bus ID for interface %s: %w", ifaceName, err)
+	}
+
+	vniccPath := filepath.Join(qethBase, busID, "vnicc")
+	if _, err := os.Stat(vniccPath); os.IsNotExist(err) {
+		return fmt.Errorf("vnicc path does not exist for %s (%s): not a qeth device or not in layer2 mode", ifaceName, busID)
+	}
+
+	m.log.Info("Applying vnicc configuration", "interface", ifaceName, "busID", busID)
+
+	// IBM doc: learning_timeout MUST be set before enabling learning
+	if cfg.LearningTimeout != nil {
+		if err := writeAttr(vniccPath, "learning_timeout", strconv.Itoa(*cfg.LearningTimeout)); err != nil {
+			return fmt.Errorf("failed to set learning_timeout: %w", err)
+		}
+		m.log.Info("Set vnicc attribute", "interface", ifaceName, "attr", "learning_timeout", "value", *cfg.LearningTimeout)
+	}
+
+	// Apply all boolean attributes; learning goes last (after timeout is set)
+	attrs := []struct {
+		name    string
+		sysName string
+		val     *bool
+	}{
+		{"flooding", "flooding", cfg.Flooding},
+		{"mcast-flooding", "mcast_flooding", cfg.McastFlooding},
+		{"rx-bcast", "rx_bcast", cfg.RxBcast},
+		{"takeover-setvmac", "takeover_setvmac", cfg.TakeoverSetvmac},
+		{"takeover-learning", "takeover_learning", cfg.TakeoverLearning},
+		{"bridge-invisible", "bridge_invisible", cfg.BridgeInvisible},
+		{"learning", "learning", cfg.Learning},
+	}
+
+	for _, a := range attrs {
+		if a.val == nil {
+			continue
+		}
+		val := boolToSysfs(*a.val)
+		if err := writeAttr(vniccPath, a.sysName, val); err != nil {
+			return fmt.Errorf("failed to set vnicc/%s=%s for %s: %w", a.sysName, val, ifaceName, err)
+		}
+		m.log.Info("Set vnicc attribute", "interface", ifaceName, "attr", a.sysName, "value", val)
+	}
+
+	return nil
+}
+
+func (m *Manager) readWithPaths(qethBase, netBase, ifaceName string) (*VniccConfig, error) {
+	busID, err := m.resolveQethBusID(netBase, ifaceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve qeth bus ID for %s: %w", ifaceName, err)
+	}
+
+	vniccPath := filepath.Join(qethBase, busID, "vnicc")
+	if _, err := os.Stat(vniccPath); os.IsNotExist(err) {
+		return nil, nil // not a qeth device — silently skip
+	}
+
+	cfg := &VniccConfig{}
+
+	boolAttrs := []struct {
+		sysName string
+		target  **bool
+	}{
+		{"flooding", &cfg.Flooding},
+		{"mcast_flooding", &cfg.McastFlooding},
+		{"learning", &cfg.Learning},
+		{"rx_bcast", &cfg.RxBcast},
+		{"takeover_setvmac", &cfg.TakeoverSetvmac},
+		{"takeover_learning", &cfg.TakeoverLearning},
+		{"bridge_invisible", &cfg.BridgeInvisible},
+	}
+
+	for _, a := range boolAttrs {
+		raw, err := readAttr(vniccPath, a.sysName)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("reading vnicc/%s: %w", a.sysName, err)
+		}
+		v := raw == "1"
+		*a.target = &v
+	}
+
+	rawTimeout, err := readAttr(vniccPath, "learning_timeout")
+	if err == nil {
+		v, err := strconv.Atoi(rawTimeout)
+		if err == nil {
+			cfg.LearningTimeout = &v
+		}
+	}
+
+	return cfg, nil
+}
+
+func (m *Manager) isQethWithPaths(qethBase, netBase, ifaceName string) bool {
+	busID, err := m.resolveQethBusID(netBase, ifaceName)
+	if err != nil {
+		return false
+	}
+	vniccPath := filepath.Join(qethBase, busID, "vnicc")
+	_, err = os.Stat(vniccPath)
+	return err == nil
+}
+
+func (m *Manager) resolveQethBusID(netBase, ifaceName string) (string, error) {
+	devicePath := filepath.Join(netBase, ifaceName, "device")
+	resolved, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve device symlink for %s: %w", ifaceName, err)
+	}
+	busID := filepath.Base(resolved)
+	if busID == "" || busID == "." {
+		return "", fmt.Errorf("could not determine bus ID from path %s", resolved)
+	}
+	return busID, nil
+}
+
+func writeAttr(vniccPath, attr, value string) error {
+	return os.WriteFile(filepath.Join(vniccPath, attr), []byte(value), filePerm)
+}
+
+func readAttr(vniccPath, attr string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(vniccPath, attr))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func boolToSysfs(v bool) string {
+	if v {
+		return "1"
+	}
+	return "0"
+}

--- a/pkg/qeth/vnicc_hook.go
+++ b/pkg/qeth/vnicc_hook.go
@@ -1,0 +1,187 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qeth
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+
+	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+type vniccApplier interface {
+	Apply(ifaceName string, cfg VniccConfig) error
+}
+
+// VniccHook processes the NNCP desiredState:
+//  1. Parses any qeth.vnicc config from interface entries
+//  2. Applies it via sysfs (qeth driver, not NetworkManager)
+//  3. Returns a cleaned desiredState with qeth.vnicc stripped
+//     so nmstatectl receives clean input with no unknown fields
+type VniccHook struct {
+	log     logr.Logger
+	manager *Manager     // real sysfs manager
+	applier vniccApplier // overridden in tests via hookWithFake
+}
+
+// NewVniccHook creates a VniccHook backed by a real sysfs Manager.
+func NewVniccHook(log logr.Logger) *VniccHook {
+	mgr := NewManager(log)
+	return &VniccHook{
+		log:     log.WithName("qeth-vnicc-hook"),
+		manager: mgr,
+		applier: mgr,
+	}
+}
+
+// ProcessAndStrip is the main entry point called from the controller Reconcile.
+//
+// On non-s390x platforms this is a no-op (returns state unchanged).
+// On s390x:
+//   - Parses state.Raw as JSON
+//   - Finds interfaces with qeth.vnicc, applies via sysfs
+//   - Strips qeth.vnicc from the JSON
+//   - Rebuilds shared.State from cleaned JSON
+func (h *VniccHook) ProcessAndStrip(state shared.State) (shared.State, error) {
+	if runtime.GOARCH != "s390x" {
+		return state, nil
+	}
+
+	if len(state.Raw) == 0 {
+		return state, nil
+	}
+
+	// state.Raw is YAML. MarshalJSON() converts YAML→JSON.
+	rawJSON, err := state.MarshalJSON()
+	if err != nil {
+		return state, fmt.Errorf("failed to marshal desiredState to JSON: %w", err)
+	}
+
+	cleanedJSON, err := h.processJSON(rawJSON)
+	if err != nil {
+		return state, err
+	}
+
+	// Rebuild shared.State from cleaned JSON
+	var cleaned shared.State
+	if err := json.Unmarshal(cleanedJSON, &cleaned); err != nil {
+		return state, fmt.Errorf("failed to rebuild shared.State after vnicc processing: %w", err)
+	}
+
+	return cleaned, nil
+}
+
+// processJSON contains the core JSON-level logic.
+// Exported-friendly in tests via internal package access.
+func (h *VniccHook) processJSON(rawJSON []byte) ([]byte, error) {
+	var stateMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawJSON, &stateMap); err != nil {
+		return nil, fmt.Errorf("failed to parse desiredState JSON: %w", err)
+	}
+
+	rawIfaces, ok := stateMap["interfaces"]
+	if !ok {
+		return rawJSON, nil
+	}
+
+	var ifaces []json.RawMessage
+	if err := json.Unmarshal(rawIfaces, &ifaces); err != nil {
+		return nil, fmt.Errorf("failed to parse interfaces array: %w", err)
+	}
+
+	cleaned := make([]json.RawMessage, 0, len(ifaces))
+	for _, rawIface := range ifaces {
+		c, err := h.processIface(rawIface)
+		if err != nil {
+			return nil, err
+		}
+		cleaned = append(cleaned, c)
+	}
+
+	cleanedIfacesJSON, err := json.Marshal(cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-encode interfaces: %w", err)
+	}
+	stateMap["interfaces"] = cleanedIfacesJSON
+
+	return json.Marshal(stateMap)
+}
+
+// processIface handles one interface entry:
+// applies vnicc via the applier if present, strips the qeth.vnicc key.
+func (h *VniccHook) processIface(rawIface json.RawMessage) (json.RawMessage, error) {
+	var ifaceMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawIface, &ifaceMap); err != nil {
+		return rawIface, fmt.Errorf("failed to parse interface entry: %w", err)
+	}
+
+	rawQeth, hasQeth := ifaceMap["qeth"]
+	if !hasQeth {
+		return rawIface, nil
+	}
+
+	var qethCfg struct {
+		Vnicc *VniccConfig `json:"vnicc,omitempty"`
+	}
+	if err := json.Unmarshal(rawQeth, &qethCfg); err != nil {
+		return rawIface, fmt.Errorf("failed to parse qeth config: %w", err)
+	}
+
+	if qethCfg.Vnicc == nil {
+		return rawIface, nil // qeth present but no vnicc — pass through unchanged
+	}
+
+	// Resolve interface name
+	nameRaw, ok := ifaceMap["name"]
+	if !ok {
+		return rawIface, fmt.Errorf("interface entry missing 'name' field")
+	}
+	var ifaceName string
+	if err := json.Unmarshal(nameRaw, &ifaceName); err != nil {
+		return rawIface, fmt.Errorf("failed to parse interface name: %w", err)
+	}
+
+	h.log.Info("Applying qeth vnicc configuration", "interface", ifaceName)
+
+	// Use applier (real Manager in production, fakeManager in tests)
+	if err := h.applier.Apply(ifaceName, *qethCfg.Vnicc); err != nil {
+		return rawIface, fmt.Errorf("vnicc apply failed for %s: %w", ifaceName, err)
+	}
+
+	// Strip vnicc from the qeth map — nmstate rejects unknown keys
+	var qethMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawQeth, &qethMap); err != nil {
+		return rawIface, err
+	}
+	delete(qethMap, "vnicc")
+
+	if len(qethMap) == 0 {
+		delete(ifaceMap, "qeth") // remove entire qeth block if nothing remains
+	} else {
+		cleanedQeth, err := json.Marshal(qethMap)
+		if err != nil {
+			return rawIface, err
+		}
+		ifaceMap["qeth"] = cleanedQeth
+	}
+
+	return json.Marshal(ifaceMap)
+}

--- a/pkg/qeth/vnicc_hook_test.go
+++ b/pkg/qeth/vnicc_hook_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qeth
+
+import (
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	shared "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+type fakeVniccManager struct {
+	applyCalled bool
+	lastIface   string
+	lastCfg     VniccConfig
+}
+
+func (f *fakeVniccManager) Apply(
+	ifaceName string,
+	cfg VniccConfig,
+) error {
+	f.applyCalled = true
+	f.lastIface = ifaceName
+	f.lastCfg = cfg
+	return nil
+}
+
+var _ = Describe("VniccHook", func() {
+	var (
+		manager *fakeVniccManager
+		hook    *VniccHook
+	)
+
+	BeforeEach(func() {
+		manager = &fakeVniccManager{}
+
+		hook = NewVniccHook(logr.Discard())
+
+		// override real sysfs applier with fake
+		hook.applier = manager
+	})
+
+	It("should apply and strip qeth.vnicc config", func() {
+		rawJSON := []byte(`{
+			"interfaces": [
+				{
+					"name": "enc220",
+					"type": "ethernet",
+					"qeth": {
+						"vnicc": {
+							"flooding": true
+						}
+					}
+				}
+			]
+		}`)
+
+		cleanedJSON, err := hook.processJSON(rawJSON)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(manager.applyCalled).To(BeTrue())
+		Expect(manager.lastIface).To(Equal("enc220"))
+
+		var cleaned map[string]any
+
+		Expect(json.Unmarshal(cleanedJSON, &cleaned)).To(Succeed())
+
+		ifaces := cleaned["interfaces"].([]any)
+		iface := ifaces[0].(map[string]any)
+
+		qethMap, ok := iface["qeth"].(map[string]any)
+
+		if ok {
+			_, exists := qethMap["vnicc"]
+			Expect(exists).To(BeFalse())
+		}
+	})
+
+	It("should leave interfaces without qeth unchanged", func() {
+		rawJSON := []byte(`{
+			"interfaces": [
+				{
+					"name": "eth0",
+					"type": "ethernet"
+				}
+			]
+		}`)
+
+		cleanedJSON, err := hook.processJSON(rawJSON)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleanedJSON).To(MatchJSON(rawJSON))
+		Expect(manager.applyCalled).To(BeFalse())
+	})
+
+	It("should fail when interface name is missing", func() {
+		rawJSON := []byte(`{
+			"interfaces": [
+				{
+					"type": "ethernet",
+					"qeth": {
+						"vnicc": {
+							"flooding": true
+						}
+					}
+				}
+			]
+		}`)
+
+		_, err := hook.processJSON(rawJSON)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(
+			ContainSubstring("missing 'name' field"),
+		)
+	})
+
+	It("should process shared.State safely", func() {
+		stateJSON := `{
+			"interfaces": [
+				{
+					"name": "eth0",
+					"type": "ethernet"
+				}
+			]
+		}`
+
+		state := shared.State{
+			Raw: []byte(stateJSON),
+		}
+
+		_, err := hook.ProcessAndStrip(state)
+
+		// On non-s390x this is no-op
+		// On s390x this still succeeds
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/qeth/vnicc_test.go
+++ b/pkg/qeth/vnicc_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qeth_test
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nmstate/kubernetes-nmstate/pkg/qeth"
+)
+
+const (
+	filePerm = 0600
+)
+
+func TestQeth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "qeth vnicc Suite")
+}
+
+// tHelper is the minimal interface satisfied by both *testing.T and GinkgoT().
+// GinkgoT() returns FullGinkgoTInterface which does NOT implement *testing.T directly,
+// so we define a common interface with only the methods we need.
+type tHelper interface {
+	TempDir() string
+	Fatal(args ...any)
+}
+
+// fakeQethEnv sets up a fake sysfs structure for testing without real hardware.
+func fakeQethEnv(t tHelper, busID, ifaceName string, attrs map[string]string) string {
+	tmpDir := t.TempDir()
+
+	// Create fake vnicc sysfs path: <tmpDir>/devices/qeth/<busID>/vnicc/
+	vniccPath := filepath.Join(tmpDir, "devices", "qeth", busID, "vnicc")
+	if err := os.MkdirAll(vniccPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write default attribute files then override with provided attrs
+	defaults := map[string]string{
+		"flooding":          "0",
+		"mcast_flooding":    "0",
+		"learning":          "0",
+		"learning_timeout":  "600",
+		"rx_bcast":          "1",
+		"takeover_setvmac":  "0",
+		"takeover_learning": "0",
+		"bridge_invisible":  "0",
+	}
+	maps.Copy(defaults, attrs)
+	for k, v := range defaults {
+		if err := os.WriteFile(filepath.Join(vniccPath, k), []byte(v), filePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create fake net symlink: <tmpDir>/class/net/<ifaceName>/device -> <tmpDir>/devices/qeth/<busID>
+	netPath := filepath.Join(tmpDir, "class", "net", ifaceName)
+	if err := os.MkdirAll(netPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	qethDevicePath := filepath.Join(tmpDir, "devices", "qeth", busID)
+	linkPath := filepath.Join(netPath, "device")
+	if err := os.Symlink(qethDevicePath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpDir
+}
+
+var _ = Describe("VniccManager", func() {
+	var manager *qeth.Manager
+
+	BeforeEach(func() {
+		manager = qeth.NewManager(logr.Discard())
+	})
+
+	Describe("Apply", func() {
+		Context("when applying flooding, mcast_flooding and learning", func() {
+			It("should write correct sysfs values in correct order", func() {
+				tmpDir := fakeQethEnv(GinkgoT(), "0.0.0220", "enc220", nil)
+
+				trueVal := true
+				timeout := 300
+				cfg := qeth.VniccConfig{
+					Flooding:        &trueVal,
+					McastFlooding:   &trueVal,
+					Learning:        &trueVal,
+					LearningTimeout: &timeout,
+				}
+
+				err := manager.ApplyWithBasePath(tmpDir, "enc220", cfg)
+				Expect(err).NotTo(HaveOccurred())
+
+				vniccBase := filepath.Join(tmpDir, "devices", "qeth", "0.0.0220", "vnicc")
+				Expect(readSysfs(vniccBase, "flooding")).To(Equal("1"))
+				Expect(readSysfs(vniccBase, "mcast_flooding")).To(Equal("1"))
+				Expect(readSysfs(vniccBase, "learning")).To(Equal("1"))
+				Expect(readSysfs(vniccBase, "learning_timeout")).To(Equal("300"))
+			})
+		})
+
+		Context("when interface is not a qeth device", func() {
+			It("should return an error", func() {
+				trueVal := true
+				cfg := qeth.VniccConfig{Flooding: &trueVal}
+				err := manager.ApplyWithBasePath("/nonexistent", "eth0", cfg)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Read", func() {
+		It("should read vnicc attributes correctly from sysfs", func() {
+			tmpDir := fakeQethEnv(GinkgoT(), "0.0.0420", "enc420", map[string]string{
+				"flooding":       "1",
+				"mcast_flooding": "1",
+				"learning":       "0",
+			})
+
+			cfg, err := manager.ReadWithBasePath(tmpDir, "enc420")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).NotTo(BeNil())
+			Expect(*cfg.Flooding).To(BeTrue())
+			Expect(*cfg.McastFlooding).To(BeTrue())
+			Expect(*cfg.Learning).To(BeFalse())
+		})
+
+		It("should return an error for non-qeth interfaces", func() {
+			tmpDir := GinkgoT().TempDir()
+			// Create interface dir without qeth device symlink
+			netPath := filepath.Join(tmpDir, "class", "net", "eth0")
+			Expect(os.MkdirAll(netPath, 0755)).To(Succeed())
+
+			cfg, err := manager.ReadWithBasePath(tmpDir, "eth0")
+			Expect(err).To(HaveOccurred()) // symlink missing → bus ID resolution fails
+			Expect(cfg).To(BeNil())
+		})
+	})
+
+	Describe("IsQethInterface", func() {
+		It("should return true for qeth interfaces", func() {
+			tmpDir := fakeQethEnv(GinkgoT(), "0.0.0220", "enc220", nil)
+			Expect(manager.IsQethInterfaceWithBasePath(tmpDir, "enc220")).To(BeTrue())
+		})
+
+		It("should return false for non-qeth interfaces", func() {
+			Expect(manager.IsQethInterfaceWithBasePath("/nonexistent", "eth0")).To(BeFalse())
+		})
+	})
+})
+
+func readSysfs(base, attr string) string {
+	data, err := os.ReadFile(filepath.Join(base, attr))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}


### PR DESCRIPTION
On s390x architecture, the qeth driver (OSA/HiperSockets) disables flooding, mcast_flooding and learning by default. Without these enabled, the driver silently drops packets destined for VM MAC addresses — including ARP replies — breaking kubevirt/OpenShift Virtualization VM network communication over OVS/Linux bridges.

This commit adds declarative qeth VNIC characteristics management via NodeNetworkConfigurationPolicy. Users can now enable/disable vnicc settings with standard NNCP syntax:

```apiVersion: nmstate.io/v1
kind: NodeNetworkConfigurationPolicy
metadata:
  name: qeth-vnicc-enc7100
spec:
  desiredState:
    interfaces:
    - name: enc7100
      type: ethernet
      state: up
      qeth:
        vnicc:
          flooding: true
          mcast-flooding: true
          learning-timeout: 600
          learning: true
```

Implementation approach:
- New pkg/qeth/vnicc.go: Manager reads/writes vnicc sysfs attributes, resolves interface → qeth bus ID via sysfs symlink.
- New pkg/qeth/vnicc_hook.go: VniccHook.ProcessAndStrip() extracts qeth.vnicc from desiredState, applies via sysfs, strips the key before nmstatectl sees it.
- controllers/handler: hook runs early in Reconcile(), before both fillInEnactmentStatus() (nmstatectl policy) and ApplyDesiredState() (nmstatectl apply) — both reject unknown fields.
- No changes to nmstate or NetworkManager upstream required.
- No-op on non-s390x platforms.

**Is this a BUG FIX or a FEATURE?**:

> Uncomment only one, leave it on its own line:
>
> /kind enhancement

**What this PR does / why we need it**:

Fixes issue https://github.com/nmstate/nmstate/issues/3148
This PR adds declarative management of qeth VNIC characteristics (`vnicc`) on
I390x arch via NodeNetworkConfigurationPolicy. 

please note that on s390x when using interfaces as bridge interface for linuc/ovs bridge, interface will not forward traffic 
from unknowm mac, so need to enabled vnicc setting of card, currently there is not declarative way to manage this via nncp policy.

On s390x, qeth network devices expose VNIC characteristics through sysfs under: /sys/devices/qeth/<bus-id>/vnicc/
These settings are not currently managed by NetworkManager or nmstate directly.


The implementation introduces a preprocessing hook that:

- Detects qeth.vnicc configuration in NNCP desired state
- Applies VNICC settings directly through qeth sysfs
- Removes unsupported qeth.vnicc fields before passing the configuration to nmstatectl

This enables NMState users to configure IBM Z qeth VNIC characteristics while maintaining compatibility with existing nmstate validation and apply workflows.

**Below is workflow:**

NNCP with qeth.vnicc applied
         ↓
Reconcile() [controllers/handler/nodenetworkconfigurationpolicy_controller.go]
         ↓
VniccHook.ProcessAndStrip(enactmentInstance.Status.DesiredState)  → apply vnicc via sysfs
VniccHook.ProcessAndStrip(instance.Spec.DesiredState)             → strip qeth key
         ↓
fillInEnactmentStatus() → nmstatectl policy  (clean state, no qeth)  
ApplyDesiredState()     → nmstatectl apply   (clean state, no qeth)  
         ↓
NNCE Available=True, NNCP SetPolicySuccess 

Example of NNCP policy:
```apiVersion: nmstate.io/v1
kind: NodeNetworkConfigurationPolicy
metadata:
  name: qeth-vnicc-enc7100
spec:
  desiredState:
    interfaces:
    - name: enc7100
      type: ethernet
      state: up
      qeth:
        vnicc:
          flooding: true
          mcast-flooding: true
          learning-timeout: 600
          learning: true
```
**Special notes for your reviewer**:
-Verified this changes on kubernetes cluster running on s390x arch.
- qeth VNICC is handled outside NetworkManager, configuration is applied directly through sysfs
- logic is isolated to s390x only, it will not break existing arch workflow.
- please note that nmstate/network manager does not understand vnicc config
only the Linux qeth driver/sysfs supports them.

With this change, we can automate current manual workaround which we need on s390x node
when using interface as bridge interface,
currently we need to do following on node -
echo 1 > /sys/devices/qeth/0.0.0220/vnicc/flooding
echo 1 > /sys/devices/qeth/0.0.0220/vnicc/mcast_flooding
echo 1 > /sys/devices/qeth/0.0.0220/vnicc/learningAlternatively, MAC learning can be enabled using chzdev:
 or 

chzdev 0.0.0220 vnicc/learning=1

Ref- doc refrence-https://www.ibm.com/docs/en/linux-on-systems?topic=bridge-packet-handling#taskqeth_wrk_vnicc__context__1



**Release note**:

```release-note
Added support for configuring qeth VNIC characteristics (VNICC) on s390x systems through Kubernetes NMState NodeNetworkConfigurationPolicy (NNCP).
```
