### PR TITLE
Harden RBAC security configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,9 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - lll
+        source: "\\+kubebuilder:rbac:"
+      - linters:
           - dupl
           - gocritic
           - mnd

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/nmstate/kubernetes-nmstate-operator:latest
-    createdAt: "2026-03-25T12:36:37Z"
+    createdAt: "2026-05-29T12:19:37Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
@@ -112,14 +112,27 @@ spec:
           - configmaps
           - endpoints
           - events
-          - namespaces
-          - persistentvolumeclaims
-          - pods
-          - secrets
           - serviceaccounts
           - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -128,20 +141,48 @@ spec:
           - get
           - list
         - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - mutatingwebhookconfigurations
           - validatingadmissionpolicies
           - validatingadmissionpolicybindings
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - apiextensions.k8s.io
-          - nmstate.io
           resources:
-          - '*'
+          - customresourcedefinitions
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - apps
           resources:
@@ -150,7 +191,13 @@ spec:
           - replicasets
           - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -164,7 +211,13 @@ spec:
           resources:
           - consoleplugins
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -182,7 +235,39 @@ spec:
           resources:
           - networkpolicies
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - nmstate.io
+          resources:
+          - nmstates
+          - nodenetworkconfigurationenactments
+          - nodenetworkconfigurationpolicies
+          - nodenetworkstates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - nmstate.io
+          resources:
+          - nmstates/status
+          - nodenetworkconfigurationenactments/status
+          - nodenetworkconfigurationpolicies/status
+          - nodenetworkstates/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - operator.openshift.io
           resources:
@@ -193,14 +278,45 @@ spec:
           - update
           - watch
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
-          - clusterroles
           - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
           - roles
           verbs:
-          - '*'
+          - bind
+          - create
+          - delete
+          - escalate
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: nmstate-operator
       deployments:
       - label:
@@ -308,24 +424,6 @@ spec:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
                 operator: Exists
-      permissions:
-      - rules:
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - policy
-          resources:
-          - poddisruptionbudgets
-          verbs:
-          - '*'
-        serviceAccountName: nmstate-operator
     strategy: deployment
   installModes:
   - supported: false

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -257,6 +257,10 @@ func createManager(cfg *rest.Config, tlsOpts func(*tls.Config), isOpenShift bool
 
 	if environment.IsHandler() {
 		cacheResourcesOnNodes(&ctrlOptions)
+	} else if environment.IsCertManager() {
+		if err := restrictCertManagerCache(&ctrlOptions); err != nil {
+			return nil, err
+		}
 	}
 
 	setupLog.Info("Creating manager")
@@ -441,6 +445,29 @@ func cacheResourcesOnNodes(ctrlOptions *ctrl.Options) {
 			},
 		},
 	}
+}
+
+// restrictCertManagerCache scopes the Secret informer to the handler namespace.
+// The cert-manager only reads and writes Secrets in its own namespace (POD_NAMESPACE),
+// so a cluster-wide cache is unnecessary and would require cluster-wide RBAC.
+func restrictCertManagerCache(ctrlOptions *ctrl.Options) error {
+	handlerNamespace := environment.GetEnvVar("POD_NAMESPACE", "")
+	if handlerNamespace == "" {
+		handlerNamespace = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	}
+	if handlerNamespace == "" {
+		return fmt.Errorf("failed to restrict cert-manager cache: neither POD_NAMESPACE nor HANDLER_NAMESPACE is set")
+	}
+	ctrlOptions.Cache = cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Namespaces: map[string]cache.Config{
+					handlerNamespace: {},
+				},
+			},
+		},
+	}
+	return nil
 }
 
 func setupHandlerControllers(mgr manager.Manager) error {

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -71,22 +71,36 @@ type NMStateReconciler struct {
 	daemonSets  []client.ObjectKey
 }
 
-// +kubebuilder:rbac:groups="",resources=services;endpoints;persistentvolumeclaims;events;configmaps;secrets;pods,verbs="*"
-// ,namespace="{{ .OperatorNamespace }}"
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs="*",namespace="{{ .OperatorNamespace }}"
-// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs="*",namespace="{{ .OperatorNamespace }}"
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs="*"
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies;validatingadmissionpolicybindings,verbs="*"
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings;roles,verbs="*"
-// +kubebuilder:rbac:groups=nmstate.io,resources="*",verbs="*"
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources="*",verbs="*"
-// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs="*"
-// +kubebuilder:rbac:groups="",resources=serviceaccounts;configmaps;namespaces,verbs="*"
+// Core resources: services, endpoints, events, configmaps need full CRUD for handler deployment manifests.
+// +kubebuilder:rbac:groups="",resources=services;endpoints;events;configmaps,verbs=get;list;watch;create;update;patch;delete
+// Pods are created indirectly via Deployments/DaemonSets — operator only needs read access.
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// Secrets: operator only deletes one obsolete webhook secret during cleanup; cert-manager (handler SA) handles creation.
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
+// ServiceAccounts: operator creates handler SA.
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// Namespaces: operator creates handler namespace but never deletes it.
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list;get
-// +kubebuilder:rbac:groups="console.openshift.io",resources=consoleplugins,verbs="*"
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+// Admission webhooks: operator manages webhook configurations for the handler.
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingadmissionpolicies;validatingadmissionpolicybindings,verbs=get;list;watch;create;update;patch;delete
+// RBAC: operator creates handler ClusterRoles/Roles and bindings.
+// escalate is required because the handler ClusterRole contains permissions the operator itself does not hold.
+// bind is required on roles/clusterroles to create bindings referencing those roles.
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles,verbs=get;list;watch;create;update;patch;delete;escalate;bind
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// nmstate.io: explicit resources instead of wildcard; includes /status subresources.
+// +kubebuilder:rbac:groups=nmstate.io,resources=nmstates;nodenetworkstates;nodenetworkconfigurationpolicies;nodenetworkconfigurationenactments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nmstate.io,resources=nmstates/status;nodenetworkstates/status;nodenetworkconfigurationpolicies/status;nodenetworkconfigurationenactments/status,verbs=get;update;patch
+// CRDs: operator manages the 3 nmstate CRDs — no need for wildcard over all apiextensions resources.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+// Apps: cluster-scoped for handler DaemonSet and Deployments.
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="console.openshift.io",resources=consoleplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;get;watch;update
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors;prometheusrules,verbs=list;get;watch;update;create;patch
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs="*"
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers,verbs=get;list;watch
 
 func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -425,6 +425,10 @@ spec:
                   fieldPath: metadata.labels['app.kubernetes.io/managed-by']
             - name: OPERATOR_NAME
               value: "{{template "handlerPrefix" .}}nmstate"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -49,7 +49,9 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resourceNames:
@@ -91,43 +93,97 @@ metadata:
   name: {{template "handlerPrefix" .}}nmstate-handler
   namespace: {{ .HandlerNamespace }}
 rules:
+# Webhooks: cert-manager reads and updates CA bundles on mutating webhooks.
+# Validating webhooks are only watched, never written.
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+# nmstate.io: explicit resources with minimum required verbs.
+# NodeNetworkState: handler creates and updates state reports.
 - apiGroups:
   - nmstate.io
   resources:
-  - '*'
+  - nodenetworkstates
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - namespaces
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
   - get
+  - list
+  - watch
   - create
   - update
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkstates/status
+  verbs:
+  - get
+  - update
+# NodeNetworkConfigurationPolicy: handler reads policies and updates status.
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationpolicies
+  verbs:
+  - get
+  - list
   - watch
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationpolicies/status
+  verbs:
+  - get
+  - update
+# NodeNetworkConfigurationEnactment: handler creates, deletes, and updates status.
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationenactments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationenactments/status
+  verbs:
+  - get
+  - update
+# Nodes: handler only reads node objects for selectors and state reporting.
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - nodes
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+# Namespaces: handler only reads the default namespace as an API connectivity probe.
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - default
+  verbs:
+  - get
+# Auth delegation for the webhook server.
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -10,14 +10,27 @@ rules:
   - configmaps
   - endpoints
   - events
-  - namespaces
-  - persistentvolumeclaims
-  - pods
-  - secrets
   - serviceaccounts
   - services
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -26,20 +39,48 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingadmissionpolicies
   - validatingadmissionpolicybindings
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
-  - nmstate.io
   resources:
-  - '*'
+  - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -48,7 +89,13 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -62,7 +109,13 @@ rules:
   resources:
   - consoleplugins
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -80,7 +133,39 @@ rules:
   resources:
   - networkpolicies
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nmstates
+  - nodenetworkconfigurationenactments
+  - nodenetworkconfigurationpolicies
+  - nodenetworkstates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nmstates/status
+  - nodenetworkconfigurationenactments/status
+  - nodenetworkconfigurationpolicies/status
+  - nodenetworkstates/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -91,33 +176,42 @@ rules:
   - update
   - watch
 - apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: nmstate-operator
-  namespace: '{{ .OperatorNamespace }}'
-rules:
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy/operator/role_binding.yaml
+++ b/deploy/operator/role_binding.yaml
@@ -1,18 +1,4 @@
 ---
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nmstate-operator
-  namespace: {{ .OperatorNamespace }}
-subjects:
-- kind: ServiceAccount
-  name: nmstate-operator
-  namespace: {{ .OperatorNamespace }}
-roleRef:
-  kind: Role
-  name: nmstate-operator
-  apiGroup: rbac.authorization.k8s.io
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -52,7 +52,14 @@ func NodesRunningNmstate(ctx context.Context, cli client.Reader, nodeSelector ma
 
 	pods := corev1.PodList{}
 	byComponent := client.MatchingLabels{"component": "kubernetes-nmstate-handler"}
-	err = cli.List(ctx, &pods, byComponent)
+	handlerNamespace := environment.GetEnvVar("POD_NAMESPACE", "")
+	if handlerNamespace == "" {
+		handlerNamespace = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	}
+	if handlerNamespace == "" {
+		return []corev1.Node{}, errors.New("failed to get nodes running nmstate: neither POD_NAMESPACE nor HANDLER_NAMESPACE is set")
+	}
+	err = cli.List(ctx, &pods, byComponent, client.InNamespace(handlerNamespace))
 	if err != nil {
 		return []corev1.Node{}, errors.Wrap(err, "getting pods failed")
 	}


### PR DESCRIPTION
Replace wildcard verbs and resources with explicit, least-privilege permissions in operator and handler ClusterRoles.