### PR TITLE
docs: update kubevirtci default version references to k8s-1.34

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ make cluster-clean
 ```
 
 Cluster configuration via environment variables:
-- `KUBEVIRT_PROVIDER`: Kubernetes version (default: k8s-1.32)
+- `KUBEVIRT_PROVIDER`: Kubernetes version (default: k8s-1.34)
 - `KUBEVIRT_NUM_NODES`: Number of nodes (default: 3)
 - `KUBEVIRT_NUM_SECONDARY_NICS`: Secondary NICs per node (default: 2)
 - `KUBECONFIG`: Path to kubeconfig (auto-detected via ./cluster/kubeconfig.sh)

--- a/docs/content/developer-guide/103-local-cluster.md
+++ b/docs/content/developer-guide/103-local-cluster.md
@@ -37,7 +37,7 @@ make cluster-clean
 
 Configure the local cluster via environment variables:
 
-- `KUBEVIRT_PROVIDER`: Kubernetes version (default: k8s-1.32)
+- `KUBEVIRT_PROVIDER`: Kubernetes version (default: k8s-1.34)
 - `KUBEVIRT_NUM_NODES`: Number of nodes (default: 3)
 - `KUBEVIRT_NUM_SECONDARY_NICS`: Secondary NICs per node (default: 2)
 - `KUBECONFIG`: Path to kubeconfig (auto-detected via ./cluster/kubeconfig.sh)


### PR DESCRIPTION

**Is this a BUG FIX or a FEATURE?**:

> Uncomment only one, leave it on its own line:
>
> /kind enhancement

**What this PR does / why we need it**:
follow-up documentation update after the kubevirtci provider bump introduced in pr-https://github.com/nmstate/kubernetes-nmstate/pull/1521

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
