### PR TITLE
cluster: blacklist igb module to prevent RTNL deadlock

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -28,6 +28,14 @@ fi
 
 echo 'Upgrading NetworkManager and enabling and starting up openvswitch'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
+    # Blacklist the igb kernel module to prevent RTNL lock contention.
+    # kubevirtci VMs include an emulated Intel 82576 (igb) NIC for SRIOV
+    # testing that kubernetes-nmstate does not use. The igb watchdog task
+    # can stall on emulated register reads, holding a spinlock that blocks
+    # igb_get_stats64 under the RTNL mutex and deadlocking all netlink
+    # operations (including nmstatectl).
+    ./cluster/cli.sh ssh ${node} -- 'for dev in /sys/class/net/*; do [ -L "$dev/device/driver" ] && [ "$(basename "$(readlink "$dev/device/driver")")" = "igb" ] && sudo ip link set dev "${dev##*/}" down; done; sudo modprobe -r igb' || true
+    ./cluster/cli.sh ssh ${node} -- 'echo "blacklist igb" | sudo tee /etc/modprobe.d/blacklist-igb.conf > /dev/null'
     if [[ "$NM_VERSION" == "latest" ]]; then
         echo "Installing NetworkManager from copr networkmanager/NetworkManager-main"
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y dnf-plugins-core

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -28,12 +28,15 @@ fi
 
 echo 'Upgrading NetworkManager and enabling and starting up openvswitch'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-    # Blacklist the igb kernel module to prevent RTNL lock contention.
-    # kubevirtci VMs include an emulated Intel 82576 (igb) NIC for SRIOV
-    # testing that kubernetes-nmstate does not use. The igb watchdog task
-    # can stall on emulated register reads, holding a spinlock that blocks
-    # igb_get_stats64 under the RTNL mutex and deadlocking all netlink
-    # operations (including nmstatectl).
+    # Unload and blacklist the igb kernel module to prevent RTNL lock
+    # contention. kubevirtci VMs include an emulated Intel 82576 (igb)
+    # NIC for SRIOV testing that kubernetes-nmstate does not use. The igb
+    # watchdog task can stall on emulated register reads, holding a
+    # spinlock that blocks igb_get_stats64 under the RTNL mutex and
+    # deadlocking all netlink operations (including nmstatectl).
+    # Remove the systemd-modules-load entry so igb is not reloaded on
+    # node reboots during tests.
+    ./cluster/cli.sh ssh ${node} -- sudo rm -f /etc/modules-load.d/igb.conf
     ./cluster/cli.sh ssh ${node} -- 'for dev in /sys/class/net/*; do [ -L "$dev/device/driver" ] && [ "$(basename "$(readlink "$dev/device/driver")")" = "igb" ] && sudo ip link set dev "${dev##*/}" down; done; sudo modprobe -r igb' || true
     ./cluster/cli.sh ssh ${node} -- 'echo "blacklist igb" | sudo tee /etc/modprobe.d/blacklist-igb.conf > /dev/null'
     if [[ "$NM_VERSION" == "latest" ]]; then


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

Blacklists the igb kernel module on kubevirtci VM nodes during `cluster-up` to prevent an RTNL mutex deadlock that causes nmstatectl to hang indefinitely.

kubevirtci VMs include an emulated Intel 82576 (igb) NIC at PCI `0000:01:00.0` for KubeVirt SRIOV testing. kubernetes-nmstate does not use this device (`eth3`), but the igb kernel driver auto-loads and runs background tasks (`igb_watchdog_task`) that read emulated hardware registers via MMIO traps into QEMU.

When the QEMU host is under load, `igb_rd32` stalls holding a spinlock. This blocks `igb_get_stats64`, which is called under the **RTNL mutex** during netlink interface dumps. The RTNL deadlock then blocks ALL netlink operations system-wide, causing nmstatectl to hang after a successful NM apply.

**Evidence from CI logs** (`node02-journalctl.log`):

```
kernel: INFO: task nmstatectl:4183 blocked for more than 122 seconds.
  -> stuck in nl80211_dump_interface -> __mutex_lock (RTNL lock)

kernel: BUG: soft lockup - CPU#0 stuck for 21s! [kubelet:1294]
  -> stuck in igb_get_stats64 -> igb_rd32 (emulated register read)
```

The deadlock chain:
```
igb_watchdog_task -> igb_rd32 (QEMU MMIO stall) -> holds igb spinlock
  -> igb_get_stats64 blocked on igb spinlock
    -> called under RTNL mutex (netlink dump)
      -> nmstatectl blocked on RTNL mutex
        -> ALL netlink operations blocked system-wide
```

This was observed as **persistent failures** (7 consecutive days, May 25-31) in the `periodic-knmstate-e2e-handler-k8s-latest` CI job. The `linux bridge with disabled VLAN` test timed out every run because one node's nmstatectl got stuck waiting on the RTNL lock held by igb.

**Special notes for your reviewer**:

Closes: https://github.com/nmstate/kubernetes-nmstate/issues/1523

- The igb NIC (`eth3`) is never used by kubernetes-nmstate tests — only `eth0` (primary), `eth1`, `eth2` (secondary) are used, all virtio-net
- `modprobe -r igb` unloads the module at runtime; the blacklist file prevents reload after reboots
- QEMU does not require the guest to load a driver for emulated devices — the PCI device stays on the bus unclaimed

```release-note
Fix persistent CI failures caused by igb kernel module RTNL deadlock on kubevirtci VMs by blacklisting the unused igb module during cluster-up.
```