### PR TITLE
cluster: blacklist igb module to prevent RTNL deadlock

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -28,6 +28,25 @@ fi
 
 echo 'Upgrading NetworkManager and enabling and starting up openvswitch'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
+    # Unload the unused emulated igb NIC. kubevirtci VMs ship an emulated
+    # Intel 82576 (igb) NIC for SRIOV testing that kubernetes-nmstate does
+    # not use (eth3). Reading its interface stats (igb_get_stats64 ->
+    # igb_update_stats -> igb_rd32) traps into an emulated MMIO register
+    # read that stalls for seconds under host load while holding the
+    # adapter stats spinlock. Every stats reader then piles onto that lock:
+    # kubelet/cadvisor via /proc/net/dev and nmstatectl/node_exporter via
+    # RTM_GETLINK dumps, producing CPU soft lockups and 120s+ hangs that
+    # fail the e2e handler suite.
+    #
+    # modprobe.d blacklisting cannot fix this across reboots: kubevirtci
+    # boots each node from an immutable external kernel+initrd (qemu
+    # -kernel/-initrd) and that initrd loads igb before the rootfs
+    # modprobe.d is read, so igb reappears after every reboot performed by
+    # the e2e suite. The node rootfs does persist, so install a systemd
+    # oneshot unit there that unloads igb on every boot.
+    ./cluster/cli.sh ssh ${node} -- sudo rm -f /etc/modules-load.d/igb.conf
+    ./cluster/cli.sh ssh ${node} -- 'printf "[Unit]\nDescription=Unload unused emulated igb NIC (avoids stats-spinlock soft lockups)\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=-/usr/sbin/modprobe -r igb\n\n[Install]\nWantedBy=multi-user.target\n" | sudo tee /etc/systemd/system/disable-igb.service > /dev/null'
+    ./cluster/cli.sh ssh ${node} -- 'sudo systemctl enable --now disable-igb.service || true'
     if [[ "$NM_VERSION" == "latest" ]]; then
         echo "Installing NetworkManager from copr networkmanager/NetworkManager-main"
         ./cluster/cli.sh ssh ${node} -- sudo dnf install -y dnf-plugins-core


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

kubevirtci VMs ship an emulated Intel 82576 (igb) NIC (eth3) for KubeVirt SRIOV testing that kubernetes-nmstate does not use. Under host load, `igb_watchdog_task` stalls in `igb_rd32` holding a spinlock, blocking `igb_get_stats64` under the RTNL mutex. This deadlocks all netlink ops, hanging `nmstatectl` after a successful NM apply.

Seen as persistent failures in `periodic-knmstate-e2e-handler-k8s-latest` (May 25-31): the disabled-VLAN bridge test timed out every run.

This PR unloads and blacklists igb during cluster-up (knmstate only uses virtio-net eth0/eth1/eth2), and removes the `/etc/modules-load.d/igb.conf` entry so it stays unloaded across node reboots.

**Special notes for your reviewer**:

Closes: #1523


**Release note**:

```release-note
NONE
```
