### PR TITLE
automation: detach emulated igb before handler e2e

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -62,6 +62,8 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
 
+    ./hack/detach-igb-workers.sh
+
     make E2E_TEST_TIMEOUT=2h E2E_TEST_ARGS="--no-color --output-dir=$ARTIFACTS --junit-report=junit.functest.xml" test-e2e-handler
 }
 

--- a/hack/detach-igb-workers.sh
+++ b/hack/detach-igb-workers.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+workers="$(./cluster/kubectl.sh get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].metadata.name}')"
+if [ -z "${workers// }" ]; then
+    echo "No worker nodes found via label node-role.kubernetes.io/worker"
+    exit 1
+fi
+
+read -r -d '' remote_script <<'EOF' || true
+set -euo pipefail
+
+matches="$(
+for ifpath in /sys/class/net/*; do
+    dev=${ifpath##*/}
+    [ "$dev" = "lo" ] && continue
+    [ -L "$ifpath/device/driver" ] || continue
+    [ "$(basename "$(readlink -f "$ifpath/device/driver")")" = "igb" ] || continue
+    pci=$(basename "$(readlink -f "$ifpath/device")")
+    lspci -nns "$pci" | grep -qi "\[8086:10c9\]" || continue
+    echo "$dev $pci"
+done
+)"
+
+count=$(printf "%s\n" "$matches" | sed "/^$/d" | wc -l)
+if [ "$count" -eq 0 ]; then
+    echo "SKIP: no bound igb [8086:10c9] device found"
+    exit 0
+fi
+if [ "$count" -ne 1 ]; then
+    echo "ERROR: multiple bound igb [8086:10c9] devices found"
+    printf "%s\n" "$matches" | sed "/^$/d" | sed "s/^/  /"
+    exit 1
+fi
+
+read -r dev pci <<<"$(printf "%s\n" "$matches" | sed "/^$/d")"
+echo "Target: $dev ($pci)"
+
+nmcli device set "$dev" managed no || true
+ip link set dev "$dev" down || true
+
+echo "$pci" >"/sys/bus/pci/devices/$pci/driver/unbind"
+
+if [ -L "/sys/bus/pci/devices/$pci/driver" ]; then
+    echo "ERROR: still bound"
+    exit 1
+fi
+
+if ip -o link show "$dev" >/dev/null 2>&1; then
+    echo "ERROR: $dev still exists"
+    exit 1
+fi
+
+if nmcli -t -f DEVICE device status | grep -qx "$dev"; then
+    echo "ERROR: NetworkManager still lists $dev"
+    exit 1
+fi
+
+if lspci -nnk -s "$pci" 2>/dev/null | grep -q 'Kernel driver in use:'; then
+    echo "ERROR: lspci still reports a bound kernel driver"
+    exit 1
+fi
+
+echo "OK: detached $dev ($pci)"
+EOF
+
+remote_quoted="$(printf '%q' "$remote_script")"
+
+for node in $workers; do
+    echo "===== ${node} ====="
+    ./cluster/ssh.sh "$node" "sudo bash -lc $remote_quoted"
+done


### PR DESCRIPTION



<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:
Prevent handler e2e runs from interacting with the emulated igb NIC by detaching only worker devices that match the expected igb PCI ID before tests start. This keeps the CI path aligned with the manual mitigation and fails fast if the target device detection is ambiguous.

See https://github.com/nmstate/kubernetes-nmstate/issues/1523#issuecomment-4590140581 seems there is kernel bug that cause spin lock we saw only here. Until we fix it from the root, lets dettach the igb.

cc @qinqon 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
