### PR TITLE
e2e: ignore cni0 in handler initial-state checks

### DIFF
--- a/test/e2e/handler/main_test.go
+++ b/test/e2e/handler/main_test.go
@@ -53,7 +53,7 @@ var (
 	portFieldName               string
 	miimonFormat                string
 	nodesInitialInterfacesState = make(map[string]map[string]string)
-	interfacesToIgnore          = []string{"flannel.1", "dummy0", "tunl0"}
+	interfacesToIgnore          = []string{"flannel.1", "dummy0", "tunl0", "cni0"}
 	knmstateReporter            *knmstatereporter.KubernetesNMStateReporter
 )
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Adds `cni0` to `interfacesToIgnore` in the handler e2e suite.

The flannel `cni0` bridge is ephemeral: it is created when the first non-hostNetwork pod sandbox is scheduled on a node, torn down on node reboot, and recreated only once a pod is rescheduled. The `AfterEach` initial-state check (`test/e2e/handler/main_test.go`) compares the live state against a baseline captured in `BeforeSuite`. When `cni0` is present at baseline-capture time but absent post-reboot (or vice-versa), the check fails with a `len` mismatch after the 120s timeout.

This was masked by the igb emulated-NIC soft lockups (#1523), which killed handler runs before this check could surface. Now that #1525 disabled igb, the `cni0` reboot race is observable.

Closes #1527

**Special notes for your reviewer**:

No test asserts on `cni0`; the only reference is a doc comment in `utils.go`. This is the same treatment already applied to the CNI-managed `flannel.1`, `dummy0` and `tunl0` interfaces.

**Release note**:

```release-note
NONE
```