### PR TITLE
CI Failure: periodic-knmstate-e2e-handler-k8s-latest / The arm64 multi-arch image build for the handler fails

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -12,6 +12,9 @@ main() {
     cd ${TMP_PROJECT_PATH}
     export ARCHS="amd64 arm64"
     make all
+    # Verify handler also builds with nmstate from git copr (NMSTATE_SOURCE=git),
+    # the same code path used by periodic-knmstate-e2e-handler-k8s-latest.
+    make NMSTATE_VERSION=latest handler
     make test-reporter
     make UNIT_TEST_ARGS="--output-dir=$ARTIFACTS --no-color --compilers=2" test/unit
 }

--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -xe
 
 dnf install -b -y dnf-plugins-core
-dnf copr enable -y nmstate/nmstate-git
+
+# Specify the centos-stream-9 chroot explicitly because dnf copr auto-detection
+# picks epel-9-<arch> on CentOS Stream 9, which does not exist for aarch64 in
+# the nmstate/nmstate-git Copr project.
+dnf copr enable -y nmstate/nmstate-git "centos-stream-9-$(uname -m)"
+
 dnf install -b -y nmstate


### PR DESCRIPTION
Fixes #1531

**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

Fixes the arm64 multi-arch handler image build when `NMSTATE_SOURCE=git`.

The `dnf copr enable` command auto-detects the chroot as `epel-9-aarch64` on
CentOS Stream 9 arm64, but the `nmstate/nmstate-git` Copr project uses
`centos-stream-9-aarch64` as the chroot name. This mismatch causes the build
to fail deterministically on arm64.

The fix explicitly specifies the correct `centos-stream-9-<arch>` chroot name
instead of relying on dnf's auto-detection, which resolves the mismatch for
both x86_64 and aarch64 architectures.

**Special notes for your reviewer**:

The `nmstate/nmstate-git` Copr project currently only provides repositories for
`centos-stream-9-x86_64` and `centos-stream-9-aarch64` (along with
`epel-9-x86_64`). The s390x architecture is not available in the Copr project,
so the script will fail with a clear error message for unsupported architectures
rather than a confusing Copr resolution error.

**Release note**:

```release-note
Fix arm64 handler image build failure when using nmstate-git from Copr by explicitly specifying the centos-stream-9 chroot name instead of relying on dnf auto-detection.
```

<!-- oompa-bot v:93e4587 -->