### PR TITLE
build: fix nmstate-git Copr install on non-x86_64 multi-arch builds

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -12,6 +12,11 @@ main() {
     cd ${TMP_PROJECT_PATH}
     export ARCHS="amd64 arm64"
     make all
+    # Also build the handler with nmstate from the git Copr (NMSTATE_SOURCE=git),
+    # the same code path exercised by periodic-knmstate-e2e-handler-k8s-latest.
+    # This shifts-left multi-arch Copr/chroot regressions to per-PR CI instead of
+    # only catching them in the nightly periodic job.
+    make NMSTATE_VERSION=latest handler
     make test-reporter
     make UNIT_TEST_ARGS="--output-dir=$ARTIFACTS --no-color --compilers=2" test/unit
 }

--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -1,5 +1,28 @@
 #!/bin/bash -xe
 
 dnf install -b -y dnf-plugins-core
-dnf copr enable -y nmstate/nmstate-git
-dnf install -b -y nmstate
+
+# The nmstate/nmstate-git Copr project publishes its builds under
+# "centos-stream-9-<arch>" chroots. We must pass the chroot name explicitly
+# because "dnf copr enable" auto-detects "epel-9-<arch>" on CentOS Stream 9,
+# and the project only ships an "epel-9-x86_64" chroot (there is no
+# "epel-9-aarch64"). Relying on auto-detection therefore breaks the arm64
+# multi-arch image build with:
+#   Error: It wasn't possible to enable this project.
+#   Repository 'epel-9-aarch64' does not exist in project 'nmstate/nmstate-git'.
+#
+# The Copr project currently provides x86_64 and aarch64 builds only. For any
+# other architecture (e.g. s390x, which is part of the multi-arch image build)
+# there is no nmstate-git build available, so fall back to the distro nmstate
+# package to keep the image build working across all architectures.
+arch="$(uname -m)"
+case "${arch}" in
+    x86_64 | aarch64)
+        dnf copr enable -y nmstate/nmstate-git "centos-stream-9-${arch}"
+        dnf install -b -y nmstate
+        ;;
+    *)
+        echo "nmstate/nmstate-git Copr has no ${arch} build; installing distro nmstate instead"
+        dnf install -b -y -x "*alpha*" -x "*beta*" nmstate
+        ;;
+esac


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

Fixes #1531.

The arm64 multi-arch handler image build fails when `NMSTATE_SOURCE=git` (the
code path used by the `periodic-knmstate-e2e-handler-k8s-latest` job) because
`build/install-nmstate.git.sh` runs `dnf copr enable -y nmstate/nmstate-git`
and relies on dnf auto-detecting the Copr chroot.

On CentOS Stream 9 arm64, dnf resolves the chroot to `epel-9-aarch64`, but the
`nmstate/nmstate-git` Copr project only ships `epel-9-x86_64` and
`centos-stream-9-<arch>` chroots. So the build fails deterministically with:

```
Error: It wasn't possible to enable this project.
Repository 'epel-9-aarch64' does not exist in project 'nmstate/nmstate-git'.
```

The amd64 build works only by luck: dnf auto-detects `epel-9-x86_64`, which
happens to exist.

This PR passes the chroot name explicitly as `centos-stream-9-<arch>` so both
x86_64 and aarch64 resolve to a repository that actually exists.

**Special notes for your reviewer**:

The `nmstate/nmstate-git` Copr project currently provides **x86_64 and aarch64
builds only** (verified via the Copr API — there is no `*-s390x` chroot). Since
`s390x` was added to the multi-arch image build in afa089939 (#1530), a fix that
blindly used `centos-stream-9-$(uname -m)` would simply move the failure from
arm64 to s390x. To keep the whole multi-arch build green, this PR falls back to
the **distro** nmstate package for any architecture that has no nmstate-git Copr
build.

I verified the fix end-to-end by emulating an arm64 CentOS Stream 9 container:

- Before (auto-detect): `dnf copr enable -y nmstate/nmstate-git` →
  `Repository 'epel-9-aarch64' does not exist` (exit 1) — reproduces the CI
  failure.
- After (explicit chroot): `dnf copr enable -y nmstate/nmstate-git
  centos-stream-9-aarch64` → `Repository successfully enabled.` and `nmstate`
  then resolves from `copr:...:nmstate:nmstate-git` (2.2.61) instead of the
  distro appstream build.

I also added a `make NMSTATE_VERSION=latest handler` step to the unit-test CI
job (`automation/check-patch.unit-test.sh`) so this multi-arch Copr/chroot
class of regression is caught on every PR, instead of only in the nightly
periodic job. That job already exports `ARCHS="amd64 arm64"`, so it exercises
the arm64 git build path directly.

Note: this overlaps with the auto-generated PR #1533, which only changes
`centos-stream-9-$(uname -m)` and would still fail the s390x leg of the
multi-arch build. This PR additionally handles the s390x (and any future
non-Copr) architecture.

**Release note**:

```release-note
Fix the arm64 (and other non-x86_64) handler image build failing when using nmstate from git (NMSTATE_SOURCE=git) by explicitly enabling the centos-stream-9-<arch> Copr chroot, and fall back to the distro nmstate package on architectures without an nmstate-git Copr build.
```
