### PR TITLE
Revert "build: add s390x to multi-arch image builds (#1530)"

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -23,5 +23,5 @@ export E2E_LOGS=${TMP_PROJECT_PATH}/test_logs/e2e
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
 
-export ARCHS="${ARCHS:-amd64 arm64 s390x}"
+
 rsync -rt --links $(pwd)/ $TMP_PROJECT_PATH

--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -12,6 +12,7 @@ image_registry=${IMAGE_REGISTRY:-quay.io}
 image_repo=${IMAGE_REPO:-nmstate}
 
 source automation/check-patch.setup.sh
+export ARCHS="amd64 arm64"
 cd ${TMP_PROJECT_PATH}
 
 push_knmstate_containers() {

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -10,6 +10,7 @@
 git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
 
 source automation/check-patch.setup.sh
+export ARCHS="amd64 arm64"
 cd ${TMP_PROJECT_PATH}
 make \
     IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}  \

--- a/hack/build-push-container.docker.linux.sh
+++ b/hack/build-push-container.docker.linux.sh
@@ -7,6 +7,8 @@ if [ "$SKIP_IMAGE_BUILD" == "true" ]; then
     exit 0
 fi
 
+hack/init-buildx.sh
+
 ARCHS=${ARCHS:-$(go env GOARCH)}
 
 if [ "${ARCHS}" != "$(go env GOARCH)" ]; then

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# If there is no buildx let's install it
+if ! docker buildx > /dev/null 2>&1; then
+    mkdir -p ~/.docker/cli-plugins
+    BUILDX_ARCH=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')
+    curl -L "https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-${BUILDX_ARCH}" --output ~/.docker/cli-plugins/docker-buildx
+    chmod a+x ~/.docker/cli-plugins/docker-buildx
+fi
+
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the docker driver, which doesn't work
+current_builder="$(docker buildx inspect)"
+# linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+if ! grep -q "^Driver: docker$"  <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}"; then
+  exit 0
+fi
+
+
+if ! docker buildx ls | grep -q kubernetes-nmstate-builder; then
+    docker buildx create --driver-opt network=host --use --name=kubernetes-nmstate-builder
+fi


### PR DESCRIPTION
This reverts commit afa0899391fc9b681d458e8b2258aeb0209a80bd (PR #1530).

## Reason

PR #1530 added `s390x` to the multi-arch build matrix (`ARCHS`), but the
`nmstate/nmstate-git` Copr project does not have a `centos-stream-9-s390x`
chroot.  The runtime stage of the Dockerfile runs `install-nmstate.git.sh`,
which calls:

```
dnf copr enable -y nmstate/nmstate-git "centos-stream-9-$(uname -m)"
```

Inside the s390x container (via qemu emulation) `uname -m` returns `s390x`,
so it tries to enable `centos-stream-9-s390x` — a repo that does not exist.

This breaks the `periodic-knmstate-e2e-handler-k8s-latest` job:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-latest/2064165606369792000

Available CentOS Stream 9 chroots in the Copr project are only `x86_64` and
`aarch64`.

The s390x support can be re-added once the Copr project has the
`centos-stream-9-s390x` build target enabled.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*