### PR TITLE
build: gracefully handle missing Copr chroot for s390x

### DIFF
--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -2,9 +2,16 @@
 
 dnf install -b -y dnf-plugins-core
 
-# Specify the centos-stream-9 chroot explicitly because dnf copr auto-detection
-# picks epel-9-<arch> on CentOS Stream 9, which does not exist for aarch64 in
-# the nmstate/nmstate-git Copr project.
-dnf copr enable -y nmstate/nmstate-git "centos-stream-9-$(uname -m)"
+arch=$(uname -m)
+chroot="centos-stream-9-${arch}"
+
+# Try to enable the nmstate-git Copr for the current architecture.
+# Not all architectures have a build target in the Copr project (e.g. s390x),
+# so fall back to the distro-provided nmstate when the chroot is unavailable.
+if dnf copr enable -y nmstate/nmstate-git "${chroot}" 2>/dev/null; then
+    echo "Enabled Copr nmstate-git for ${chroot}"
+else
+    echo "WARNING: Copr nmstate-git not available for ${chroot}, installing distro nmstate"
+fi
 
 dnf install -b -y nmstate


### PR DESCRIPTION
The `nmstate/nmstate-git` Copr project does not have a
`centos-stream-9-s390x` build target, which causes the multi-arch
container build to fail for s390x when `NMSTATE_SOURCE=git`.

PR #1530 added s390x to the `ARCHS` list, but the runtime stage runs
`install-nmstate.git.sh` which unconditionally tries:

```
dnf copr enable -y nmstate/nmstate-git "centos-stream-9-$(uname -m)"
```

Inside the s390x container (qemu emulation), `uname -m` returns `s390x`,
and that Copr chroot does not exist → build fails.

**Fix:** Try to enable the Copr repo, and if the chroot is not available,
fall back to the distro-provided nmstate package. This keeps s390x images
building (with distro nmstate) while amd64 and arm64 continue using the
Copr git builds as before.

Failing job: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-latest/2064165606369792000

Once the Copr project adds `centos-stream-9-s390x`, that arch will
automatically start picking up the git builds with no further changes.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*