### PR TITLE
automation: force archs just for publish/release

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -23,5 +23,4 @@ export E2E_LOGS=${TMP_PROJECT_PATH}/test_logs/e2e
 export ARTIFACTS=${ARTIFACTS-$tmp_dir/artifacts}
 mkdir -p $ARTIFACTS
 
-export ARCHS="${ARCHS:-amd64 arm64 s390x}"
 rsync -rt --links $(pwd)/ $TMP_PROJECT_PATH

--- a/automation/publish-release.env
+++ b/automation/publish-release.env
@@ -1,0 +1,1 @@
+export ARCHS="${ARCHS:-amd64 arm64 s390x}"

--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -12,6 +12,8 @@ image_registry=${IMAGE_REGISTRY:-quay.io}
 image_repo=${IMAGE_REPO:-nmstate}
 
 source automation/check-patch.setup.sh
+source automation/publish-release.env
+
 cd ${TMP_PROJECT_PATH}
 
 push_knmstate_containers() {

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -10,6 +10,8 @@
 git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
 
 source automation/check-patch.setup.sh
+source automation/publish-release.env
+
 cd ${TMP_PROJECT_PATH}
 make \
     IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}  \


### PR DESCRIPTION
**What this PR does / why we need it**:
After [1] now all the automation e2e where trying to build for all the archs, that's  wrong since for e2e we just need the image for the arch kuberntes is going to run on.

[1] https://github.com/nmstate/kubernetes-nmstate/pull/1530

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
