### PR TITLE
rbac: grant update on nmstates/finalizers to the operator

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -260,6 +260,12 @@ spec:
         - apiGroups:
           - nmstate.io
           resources:
+          - nmstates/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - nmstate.io
+          resources:
           - nmstates/status
           - nodenetworkconfigurationenactments/status
           - nodenetworkconfigurationpolicies/status

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -92,6 +92,7 @@ type NMStateReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // nmstate.io: explicit resources instead of wildcard; includes /status subresources.
 // +kubebuilder:rbac:groups=nmstate.io,resources=nmstates;nodenetworkstates;nodenetworkconfigurationpolicies;nodenetworkconfigurationenactments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=nmstate.io,resources=nmstates/finalizers,verbs=update
 // +kubebuilder:rbac:groups=nmstate.io,resources=nmstates/status;nodenetworkstates/status;nodenetworkconfigurationpolicies/status;nodenetworkconfigurationenactments/status,verbs=get;update;patch
 // CRDs: operator manages the 3 nmstate CRDs — no need for wildcard over all apiextensions resources.
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -158,6 +158,12 @@ rules:
 - apiGroups:
   - nmstate.io
   resources:
+  - nmstates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - nmstate.io
+  resources:
   - nmstates/status
   - nodenetworkconfigurationenactments/status
   - nodenetworkconfigurationpolicies/status


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

After #1520 hardened the operator RBAC by replacing wildcard permissions
with explicit least-privilege rules, the operator lost the implicit
ability to set `blockOwnerDeletion` on owner references.

`controllerutil.SetControllerReference` sets `blockOwnerDeletion: true`
by default, and Kubernetes requires `update` permission on the owner's
`finalizers` subresource for this to succeed.

Every reconcile fails with:

```
clusterroles.rbac.authorization.k8s.io "nmstate-cluster-reader" is forbidden:
cannot set blockOwnerDeletion if an ownerReference refers to a resource you
can't set finalizers on
```

The operator never gets past `applyRBAC`, so handler DaemonSets are
never created and the NMState operand is completely broken.

This adds the missing `nmstates/finalizers` `update` permission to the
operator ClusterRole and the OLM CSV.

**How to reproduce**:

1. Deploy the operator with the hardened RBAC from #1520
2. Create an NMState CR
3. Operator enters infinite reconcile loop, handler pods are never created

**Special notes for your reviewer**:

The root cause was found by inspecting the operator pod logs from a
failed CI run of [openshift/kubernetes-nmstate#751](https://github.com/openshift/kubernetes-nmstate/pull/751)
(`e2e-handler-ovn-ipv4`). The operator logs showed the
`blockOwnerDeletion` error repeating every reconcile cycle.

**Release note**:

```release-note
Fix operator reconcile failure caused by missing nmstates/finalizers
RBAC permission after security hardening in #1520.
```

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*