### PR TITLE
operator: remove unused kube-rbac-proxy image plumbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,6 @@ OPERATOR_IMAGE_TAG ?= latest
 OPERATOR_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_FULL_NAME)
 
-KUBE_RBAC_PROXY_NAME ?= origin-kube-rbac-proxy
-KUBE_RBAC_PROXY_TAG ?= 4.10.0
-KUBE_RBAC_PROXY_IMAGE_REGISTRY ?= quay.io
-KUBE_RBAC_PROXY_IMAGE_REPO ?= openshift
-KUBE_RBAC_PROXY_FULL_NAME ?= $(KUBE_RBAC_PROXY_IMAGE_REPO)/$(KUBE_RBAC_PROXY_NAME):$(KUBE_RBAC_PROXY_TAG)
-KUBE_RBAC_PROXY_IMAGE ?= $(KUBE_RBAC_PROXY_IMAGE_REGISTRY)/$(KUBE_RBAC_PROXY_FULL_NAME)
-
 export HANDLER_NAMESPACE ?= nmstate
 export OPERATOR_NAMESPACE ?= $(HANDLER_NAMESPACE)
 export MONITORING_NAMESPACE ?= monitoring
@@ -175,7 +168,7 @@ check-bundle: bundle
 generate: gen-k8s gen-crds gen-rbac
 
 manifests:
-	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -monitoring-namespace=$(MONITORING_NAMESPACE) -kube-rbac-proxy-image=$(KUBE_RBAC_PROXY_IMAGE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
+	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -monitoring-namespace=$(MONITORING_NAMESPACE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 require-image-builder:
 	@test -n "$(IMAGE_BUILDER)" || { echo "Error: IMAGE_BUILDER is not set and could not be auto-detected (neither podman nor docker is running/available)." >&2; exit 1; }

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -378,8 +378,6 @@ spec:
                   value: monitoring
                 - name: OPERATOR_NAMESPACE
                   value: nmstate
-                - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -385,7 +385,6 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["HandlerPullPolicy"] = environment.GetEnvVar("HANDLER_IMAGE_PULL_POLICY", "")
 	data.Data["HandlerPrefix"] = environment.GetEnvVar("HANDLER_PREFIX", "")
 	data.Data["MonitoringNamespace"] = environment.GetEnvVar("MONITORING_NAMESPACE", "")
-	data.Data["KubeRBACProxyImage"] = environment.GetEnvVar("KUBE_RBAC_PROXY_IMAGE", "")
 	data.Data["InfraNodeSelector"] = infraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations
 	data.Data["WebhookAffinity"] = infraAffinity

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -120,7 +120,6 @@ var _ = Describe("NMState controller reconcile", func() {
 		webhookKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
 		handlerImage        = "quay.io/some_image"
 		monitoringNamespace = "monitoring"
-		kubeRBACProxyImage  = "quay.io/some_kube_rbac_proxy_image"
 		imagePullPolicy     = "Always"
 		manifestsDir        = ""
 		newNMState          = func() *nmstatev1.NMState {
@@ -183,7 +182,6 @@ var _ = Describe("NMState controller reconcile", func() {
 		os.Setenv("HANDLER_IMAGE_PULL_POLICY", imagePullPolicy)
 		os.Setenv("HANDLER_PREFIX", handlerPrefix)
 		os.Setenv("MONITORING_NAMESPACE", monitoringNamespace)
-		os.Setenv("KUBE_RBAC_PROXY_IMAGE", kubeRBACProxyImage)
 	})
 	AfterEach(func() {
 		err := os.RemoveAll(manifestsDir)

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -105,5 +105,3 @@ spec:
               value: {{ .MonitoringNamespace }}
             - name: OPERATOR_NAMESPACE
               value: {{ .OperatorNamespace }}
-            - name: KUBE_RBAC_PROXY_IMAGE
-              value: {{ .KubeRBACProxyImage }}

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -42,7 +42,6 @@ func main() {
 		OperatorImage       string
 		OperatorPullPolicy  string
 		MonitoringNamespace string
-		KubeRBACProxyImage  string
 	}
 
 	handlerNamespace := flag.String("handler-namespace", "nmstate", "Namespace for the NMState handler")
@@ -53,7 +52,6 @@ func main() {
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
 	operatorPullPolicy := flag.String("operator-pull-policy", "IfNotPresent", "Pull policy for the NMState operator image")
 	monitoringNamespace := flag.String("monitoring-namespace", "monitoring", "Namespace for the cluster monitoring")
-	kubeRBACProxyImage := flag.String("kube-rbac-proxy-image", "", "Image for the kube RBAC proxy needed for metrics")
 	inputDir := flag.String("input-dir", "", "Input directory")
 	outputDir := flag.String("output-dir", "", "Output directory")
 	flag.Parse()
@@ -67,7 +65,6 @@ func main() {
 		OperatorImage:       *operatorImage,
 		OperatorPullPolicy:  *operatorPullPolicy,
 		MonitoringNamespace: *monitoringNamespace,
-		KubeRBACProxyImage:  *kubeRBACProxyImage,
 	}
 
 	// Clean up output dir so we don't have old files.


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind cleanup

**What this PR does / why we need it**:

The `nmstate-metrics` deployment no longer runs a `kube-rbac-proxy` sidecar — metrics are served directly by the manager on `:8443` with TLS. This removes the leftover, now-unused `KUBE_RBAC_PROXY_IMAGE` plumbing: Makefile variables, the `render-manifests.go` flag, the operator deployment env var and its render data, the regenerated CSV value, and the unit-test wiring.

No runtime behavior change. Bundle regenerated with `make bundle`.

**Release note**:

```release-note
NONE
```
