### PR TITLE
Add startup probes and DNS egress to network policies

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -122,6 +122,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: allow-webhook-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-metrics-egress-api-6443
   namespace: {{ .HandlerNamespace }}
 spec:
@@ -133,6 +152,43 @@ spec:
     - ports:
         - protocol: TCP
           port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-dns
+  namespace: {{ .OperatorNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
   policyTypes:
     - Egress
 ---

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -87,15 +87,19 @@ spec:
           - containerPort: 8443
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: metrics
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: metrics
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -200,6 +204,12 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: webhook-server
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
           readinessProbe:
             httpGet:
               path: /readyz
@@ -208,7 +218,6 @@ spec:
               httpHeaders:
               - name: Content-Type
                 value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
@@ -218,7 +227,6 @@ spec:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
## Problem

nmstate-webhook and nmstate-metrics pods can enter CrashLoopBackOff because liveness/readiness probes kill the containers before they finish initializing.

The root cause is a combination of:

1. **Missing DNS egress in network policies**: The default-deny network policies block all egress except TCP 6443 (API server). DNS (UDP/TCP 53) is not allowed. Various libraries may attempt DNS lookups during startup. With DNS blocked, each lookup hangs for ~5s (Go resolver timeout), compounding startup delay.

2. **No startupProbe**: Without a startupProbe, the liveness probe (`initialDelaySeconds: 10`, `failureThreshold: 3`, `periodSeconds: 10`) gives containers only ~30s to start, which can be exceeded on loaded nodes.

## Fix

1. Add `startupProbe` (TCP socket, `failureThreshold: 18`, `periodSeconds: 10` = up to 3 minutes) to nmstate-webhook and nmstate-metrics containers.
2. Remove `initialDelaySeconds` from liveness/readiness probes (redundant with startupProbe).
3. Add DNS egress network policies (UDP/TCP 53) for webhook, metrics, and operator pods.

OpenShift downstream: [openshift/kubernetes-nmstate#759](https://github.com/openshift/kubernetes-nmstate/pull/759)

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*