### PR TITLE
e2e, cluster: emulate a LLDP switch on the cluster network

### DIFF
--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -12,4 +12,6 @@ fi
 source ./cluster/kubevirtci.sh
 kubevirtci::install
 
+./cluster/lldpd-switch.sh down
+
 $(kubevirtci::path)/cluster-up/down.sh

--- a/cluster/lldpd-switch.Dockerfile
+++ b/cluster/lldpd-switch.Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/alpine:latest
+
+RUN apk add --no-cache lldpd

--- a/cluster/lldpd-switch.Dockerfile
+++ b/cluster/lldpd-switch.Dockerfile
@@ -1,3 +1,6 @@
-FROM docker.io/library/alpine:latest
+# The kubevirt CI DNS only resolves an allowlist of domains: Fedora
+# repositories are resolvable there (quay.io + fedoraproject.org), while e.g.
+# the Alpine CDN is not, so stick to a Fedora based image.
+FROM quay.io/fedora/fedora:latest
 
-RUN apk add --no-cache lldpd
+RUN dnf install -y lldpd procps-ng && dnf clean all

--- a/cluster/lldpd-switch.sh
+++ b/cluster/lldpd-switch.sh
@@ -22,7 +22,7 @@ source ./cluster/kubevirtci.sh
 
 DNSMASQ_CONTAINER="${KUBEVIRT_PROVIDER}-dnsmasq"
 LLDPD_SWITCH_CONTAINER="${KUBEVIRT_PROVIDER}-lldpd-switch"
-LLDPD_SWITCH_IMAGE="${LLDPD_SWITCH_IMAGE:-docker.io/library/alpine:latest}"
+LLDPD_SWITCH_IMAGE="localhost/kubernetes-nmstate-lldpd-switch:latest"
 
 # Same container runtime detection kubevirtci cluster-up uses, so we talk to
 # the runtime that owns the cluster containers.
@@ -45,18 +45,18 @@ function up() {
         return 0
     fi
     down
+
+    # Install lldpd at image build time: containers joining another container
+    # network namespace do not get working DNS in every environment (e.g.
+    # CI), so the switch container must not do any network I/O at runtime.
+    ${CRI} build -t "${LLDPD_SWITCH_IMAGE}" -f cluster/lldpd-switch.Dockerfile cluster/
+
     ${CRI} run -d --name "${LLDPD_SWITCH_CONTAINER}" \
         --cap-add=NET_ADMIN --cap-add=NET_RAW \
         --network "container:${DNSMASQ_CONTAINER}" \
         "${LLDPD_SWITCH_IMAGE}" \
         sh -c '
             set -ex
-            # podman does not wire up working DNS for containers joining
-            # another container network namespace in every environment
-            # (e.g. CI); use the kubevirtci dnsmasq listening on br0, the
-            # same resolver the cluster VMs use.
-            echo "nameserver 192.168.66.2" > /etc/resolv.conf
-            apk add --no-cache lldpd
             echo "configure lldp tx-interval 5" > /etc/lldpd.conf
             echo "configure system hostname lldp-switch" >> /etc/lldpd.conf
             # Transmit on the bridge ports attached to the node VM NICs,

--- a/cluster/lldpd-switch.sh
+++ b/cluster/lldpd-switch.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Emulate a production top-of-rack switch for the kubevirtci cluster.
+#
+# Production nodes receive LLDPDUs from the switch they are cabled to: the
+# frames arrive inbound on the NIC with the switch port as source MAC. The
+# kubevirtci cluster network has no LLDP-speaking switch, so nodes never see
+# any LLDP neighbor (the bridges also do not forward the link-local scoped
+# LLDP group address between nodes, just like a compliant switch).
+#
+# To reproduce the production behavior without changing kubevirtci, run
+# lldpd in an extra container that joins the cluster network namespace
+# (owned by the ${KUBEVIRT_PROVIDER}-dnsmasq container) bound to the tap
+# devices that connect the node VM NICs (tapXX -> primary NIC, stapX-Y ->
+# secondary NICs). lldpd then transmits LLDPDUs on every "switch port" and
+# each node receives them inbound on its NICs, exactly like from a real
+# switch.
+
+set -ex
+
+source ./cluster/kubevirtci.sh
+
+DNSMASQ_CONTAINER="${KUBEVIRT_PROVIDER}-dnsmasq"
+LLDPD_SWITCH_CONTAINER="${KUBEVIRT_PROVIDER}-lldpd-switch"
+LLDPD_SWITCH_IMAGE="${LLDPD_SWITCH_IMAGE:-quay.io/fedora/fedora:latest}"
+
+# Same container runtime detection kubevirtci cluster-up uses, so we talk to
+# the runtime that owns the cluster containers.
+function detect_cri() {
+    local podman_socket=${KUBEVIRTCI_PODMAN_SOCKET:-/run/podman/podman.sock}
+    if [ "${KUBEVIRTCI_RUNTIME:-}" = "podman" ]; then
+        echo "podman --remote --url=unix://${podman_socket}"
+    elif [ "${KUBEVIRTCI_RUNTIME:-}" = "docker" ]; then
+        echo "docker"
+    elif curl --unix-socket "${podman_socket}" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+        echo "podman --remote --url=unix://${podman_socket}"
+    elif docker ps >/dev/null 2>&1; then
+        echo "docker"
+    fi
+}
+
+function up() {
+    if ! ${CRI} inspect "${DNSMASQ_CONTAINER}" >/dev/null 2>&1; then
+        echo "no ${DNSMASQ_CONTAINER} container found, skipping LLDP switch emulation"
+        return 0
+    fi
+    down
+    ${CRI} run -d --name "${LLDPD_SWITCH_CONTAINER}" \
+        --privileged \
+        --network "container:${DNSMASQ_CONTAINER}" \
+        "${LLDPD_SWITCH_IMAGE}" \
+        bash -c '
+            set -ex
+            dnf install -y lldpd
+            echo "configure lldp tx-interval 5" > /etc/lldpd.conf
+            echo "configure system hostname lldp-switch" >> /etc/lldpd.conf
+            # Transmit on the bridge ports attached to the node VM NICs,
+            # like a real switch does on each of its ports. Exact interface
+            # names make lldpd accept the tap devices unconditionally.
+            ports=$(ls /sys/class/net | grep -E "^(tap[0-9]+|stap[0-9]+-[0-9]+)$" | paste -sd, -)
+            exec lldpd -d -I "${ports}"
+        '
+}
+
+function down() {
+    ${CRI} rm -f "${LLDPD_SWITCH_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+CRI=$(detect_cri)
+if [ -z "${CRI}" ]; then
+    echo "no working container runtime found, skipping LLDP switch emulation"
+    exit 0
+fi
+
+case "${1:-up}" in
+up)
+    up
+    ;;
+down)
+    down
+    ;;
+*)
+    echo "usage: $0 up|down" >&2
+    exit 1
+    ;;
+esac

--- a/cluster/lldpd-switch.sh
+++ b/cluster/lldpd-switch.sh
@@ -51,6 +51,11 @@ function up() {
         "${LLDPD_SWITCH_IMAGE}" \
         sh -c '
             set -ex
+            # podman does not wire up working DNS for containers joining
+            # another container network namespace in every environment
+            # (e.g. CI); use the kubevirtci dnsmasq listening on br0, the
+            # same resolver the cluster VMs use.
+            echo "nameserver 192.168.66.2" > /etc/resolv.conf
             apk add --no-cache lldpd
             echo "configure lldp tx-interval 5" > /etc/lldpd.conf
             echo "configure system hostname lldp-switch" >> /etc/lldpd.conf

--- a/cluster/lldpd-switch.sh
+++ b/cluster/lldpd-switch.sh
@@ -22,7 +22,7 @@ source ./cluster/kubevirtci.sh
 
 DNSMASQ_CONTAINER="${KUBEVIRT_PROVIDER}-dnsmasq"
 LLDPD_SWITCH_CONTAINER="${KUBEVIRT_PROVIDER}-lldpd-switch"
-LLDPD_SWITCH_IMAGE="${LLDPD_SWITCH_IMAGE:-quay.io/fedora/fedora:latest}"
+LLDPD_SWITCH_IMAGE="${LLDPD_SWITCH_IMAGE:-docker.io/library/alpine:latest}"
 
 # Same container runtime detection kubevirtci cluster-up uses, so we talk to
 # the runtime that owns the cluster containers.
@@ -46,20 +46,39 @@ function up() {
     fi
     down
     ${CRI} run -d --name "${LLDPD_SWITCH_CONTAINER}" \
-        --privileged \
+        --cap-add=NET_ADMIN --cap-add=NET_RAW \
         --network "container:${DNSMASQ_CONTAINER}" \
         "${LLDPD_SWITCH_IMAGE}" \
-        bash -c '
+        sh -c '
             set -ex
-            dnf install -y lldpd
+            apk add --no-cache lldpd
             echo "configure lldp tx-interval 5" > /etc/lldpd.conf
             echo "configure system hostname lldp-switch" >> /etc/lldpd.conf
             # Transmit on the bridge ports attached to the node VM NICs,
             # like a real switch does on each of its ports. Exact interface
             # names make lldpd accept the tap devices unconditionally.
-            ports=$(ls /sys/class/net | grep -E "^(tap[0-9]+|stap[0-9]+-[0-9]+)$" | paste -sd, -)
+            ports=$(ls /sys/class/net | grep -E "^(tap[0-9]+|stap[0-9]+-[0-9]+)$" | tr "\n" "," | sed "s/,$//")
+            if [ -z "${ports}" ]; then
+                echo "no tap/stap bridge ports found in the cluster network namespace" >&2
+                exit 1
+            fi
             exec lldpd -d -I "${ports}"
         '
+
+    # lldpd starts in the background; fail cluster-up right away instead of
+    # timing out later in the LLDP e2e tests if it did not come up.
+    for _ in $(seq 1 30); do
+        if [ "$(${CRI} inspect -f '{{.State.Running}}' "${LLDPD_SWITCH_CONTAINER}" 2>/dev/null)" != "true" ]; then
+            break
+        fi
+        if ${CRI} exec "${LLDPD_SWITCH_CONTAINER}" pgrep lldpd >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    ${CRI} logs "${LLDPD_SWITCH_CONTAINER}" || true
+    echo "the LLDP switch emulation container failed to start lldpd" >&2
+    exit 1
 }
 
 function down() {

--- a/cluster/lldpd-switch.sh
+++ b/cluster/lldpd-switch.sh
@@ -49,7 +49,10 @@ function up() {
     # Install lldpd at image build time: containers joining another container
     # network namespace do not get working DNS in every environment (e.g.
     # CI), so the switch container must not do any network I/O at runtime.
-    ${CRI} build -t "${LLDPD_SWITCH_IMAGE}" -f cluster/lldpd-switch.Dockerfile cluster/
+    # Build with the host network so the build container resolves names with
+    # the host resolver (the CI package proxy hostname is only resolvable
+    # there).
+    ${CRI} build --network host -t "${LLDPD_SWITCH_IMAGE}" -f cluster/lldpd-switch.Dockerfile cluster/
 
     ${CRI} run -d --name "${LLDPD_SWITCH_CONTAINER}" \
         --cap-add=NET_ADMIN --cap-add=NET_RAW \

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -64,3 +64,7 @@ for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); d
     ./cluster/cli.sh ssh ${node} -- sudo mkdir -p /var/log/journal
     ./cluster/cli.sh ssh ${node} -- sudo systemctl restart systemd-journald
 done
+
+# Emulate a production LLDP-speaking switch on the cluster network so nodes
+# receive LLDP neighbors on their NICs (consumed by the LLDP e2e tests)
+./cluster/lldpd-switch.sh up

--- a/test/e2e/handler/lldp_with_nmpolicy_test.go
+++ b/test/e2e/handler/lldp_with_nmpolicy_test.go
@@ -31,7 +31,8 @@ import (
 // by cluster/lldpd-switch.sh at cluster-up: it joins the kubevirtci cluster
 // network namespace and runs lldpd on the bridge ports attached to the node
 // NICs, so nodes receive LLDPDUs inbound exactly like from a production
-// top-of-rack switch.
+// top-of-rack switch. The emulated switch advertises "lldp-switch" as its
+// system name.
 var _ = Describe("LLDP configuration with nmpolicy", func() {
 	lldpEnabledPolicyName := "lldp-enabled"
 	lldpDisabledPolicyName := "lldp-disabled"
@@ -73,13 +74,11 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 		}
 
 		Byf("Check %s has the emulated switch as neighbor", primaryNic)
-		for _, node := range nodes {
-			Eventually(
-				func() string {
-					return lldpNeighbors(node, primaryNic)
-				},
-				5*time.Minute, time.Second,
-			).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s at node %s should have lldp neighbors", primaryNic, node))
-		}
+		Eventually(func(g Gomega) {
+			for _, node := range nodes {
+				g.Expect(lldpNeighbors(node, primaryNic)).To(ContainSubstring("lldp-switch"),
+					fmt.Sprintf("Interface %s at node %s should have the emulated switch as lldp neighbor", primaryNic, node))
+			}
+		}, 5*time.Minute, time.Second).Should(Succeed())
 	})
 })

--- a/test/e2e/handler/lldp_with_nmpolicy_test.go
+++ b/test/e2e/handler/lldp_with_nmpolicy_test.go
@@ -18,23 +18,21 @@ limitations under the License.
 package handler
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
-	testenv "github.com/nmstate/kubernetes-nmstate/test/env"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// The LLDP neighbors are transmitted by the lldpd "switch" container started
+// by cluster/lldpd-switch.sh at cluster-up: it joins the kubevirtci cluster
+// network namespace and runs lldpd on the bridge ports attached to the node
+// NICs, so nodes receive LLDPDUs inbound exactly like from a production
+// top-of-rack switch.
 var _ = Describe("LLDP configuration with nmpolicy", func() {
-	var lldpdPod *corev1.Pod
-
 	lldpEnabledPolicyName := "lldp-enabled"
 	lldpDisabledPolicyName := "lldp-disabled"
 
@@ -49,33 +47,6 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 	interfacesWithLldpEnabledState := nmstate.NewState(`interfaces: "{{ capture.ethernets-lldp.interfaces }}"`)
 
 	BeforeEach(func() {
-		By("Starting lldpd at one node")
-		lldpdPod = &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "lldpd",
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:    "lldpd",
-					Image:   "quay.io/fedora/fedora-toolbox",
-					Command: []string{"/bin/bash"},
-					Args:    []string{"-c", "dnf install -y lldpd && lldpd -d"},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: new(true),
-					},
-				}},
-				HostNetwork: true,
-			},
-		}
-		Expect(testenv.Client.Create(context.Background(), lldpdPod)).To(Succeed())
-		Eventually(func() (corev1.PodPhase, error) {
-			if err := testenv.Client.Get(context.Background(), client.ObjectKeyFromObject(lldpdPod), lldpdPod); err != nil {
-				return "", err
-			}
-			return lldpdPod.Status.Phase, nil
-		}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Equal(corev1.PodRunning))
-
 		By("Enabling LLDP on up ethernet interfaces")
 		setDesiredStateWithPolicyAndCapture(lldpEnabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("true"))
 		policy.WaitForAvailablePolicy(lldpEnabledPolicyName)
@@ -87,9 +58,6 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 			setDesiredStateWithPolicyAndCapture(lldpDisabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("false"))
 			policy.WaitForAvailablePolicy(lldpDisabledPolicyName)
 			deletePolicy(lldpDisabledPolicyName)
-
-			By("Delete lldpd pod")
-			Expect(testenv.Client.Delete(context.Background(), lldpdPod)).To(Succeed())
 		})
 	})
 
@@ -104,12 +72,14 @@ var _ = Describe("LLDP configuration with nmpolicy", func() {
 			).Should(Equal("true"), fmt.Sprintf("Interface %s should have enabled lldp", primaryNic))
 		}
 
-		Byf("Check %s has neighbors", primaryNic)
-		Eventually(
-			func() string {
-				return lldpNeighbors(lldpdPod.Spec.NodeName, primaryNic)
-			},
-			5*time.Minute, time.Second,
-		).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s should have lldp neighbors", primaryNic))
+		Byf("Check %s has the emulated switch as neighbor", primaryNic)
+		for _, node := range nodes {
+			Eventually(
+				func() string {
+					return lldpNeighbors(node, primaryNic)
+				},
+				5*time.Minute, time.Second,
+			).ShouldNot(BeEmpty(), fmt.Sprintf("Interface %s at node %s should have lldp neighbors", primaryNic, node))
+		}
 	})
 })


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

The `periodic-knmstate-e2e-handler-k8s-latest` lanes fail since 2026-07-07 on the LLDP e2e test: NetworkManager main merged NetworkManager/NetworkManager@9a79eba502 ("lldp: filter out frames sourced by the local interface"), so NM no longer reports a host as its own LLDP neighbor. The test relied on exactly that behavior: it ran lldpd on one node and expected the same node to see neighbors, because the kubevirtci cluster network has no LLDP-speaking switch (and, like a compliant switch, its bridges do not forward the link-local scoped LLDP group address between nodes).

This PR reproduces the production topology instead of relying on the removed NM quirk:

- New `cluster/lldpd-switch.sh` (invoked from `cluster/up.sh`/`cluster/down.sh`): runs lldpd in a container that joins the kubevirtci cluster network namespace (the `${KUBEVIRT_PROVIDER}-dnsmasq` container), bound to the tap devices that connect the node VM NICs (`tapXX` -> primary NIC, `stapX-Y` -> secondary NICs). Nodes receive LLDPDUs inbound with a foreign source MAC, exactly like from a real, per-port LLDP-speaking top-of-rack switch. Works on any NetworkManager version and requires no kubevirtci changes.
- The LLDP e2e test drops the privileged hostNetwork lldpd pod and now verifies that every handler node reports the emulated switch as neighbor on the primary NIC (stronger than before, which only checked one node).

Fixes #1548

**Special notes for your reviewer**:

Root cause analysis with the pass/fail bisect between NM copr builds 34717/34726 is in #1548. The nmstate RPM was identical between the last passing and first failing nightly runs, so this is purely a NetworkManager behavior change (an intentional fix); the product itself is unaffected in production, where LLDP neighbors arrive inbound from real switches with foreign source MACs.

The lldpd switch container is a no-op when the dnsmasq container does not exist (e.g. `KUBEVIRT_PROVIDER=external`).

**Release note**:

```release-note
NONE
```
