### PR TITLE
OCPBUGS-98067: Validate maxUnavailable via CRD CEL rule

### DIFF
--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -46,7 +46,7 @@ type NodeNetworkConfigurationPolicySpec struct {
 
 	// MaxUnavailable specifies percentage or number
 	// of machines that can be updating at a time. Default is "50%".
-	// The computed value must result in at least 1 node being available for updates.
+	// The computed value must result in at least 1 node being allowed to undergo updates at a time.
 	// If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -46,6 +46,8 @@ type NodeNetworkConfigurationPolicySpec struct {
 
 	// MaxUnavailable specifies percentage or number
 	// of machines that can be updating at a time. Default is "50%".
+	// The computed value must result in at least 1 node being available for updates.
+	// If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 }

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -46,7 +46,10 @@ type NodeNetworkConfigurationPolicySpec struct {
 
 	// MaxUnavailable specifies percentage or number
 	// of machines that can be updating at a time. Default is "50%".
+	// Must be greater than 0. When set as a percentage, it must be a positive percentage.
 	// +optional
+	//nolint:lll
+	// +kubebuilder:validation:XValidation:rule="(type(self) == int && self > 0) || (type(self) == string && self != '0' && self != '0%')",message="maxUnavailable must be greater than 0"
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 }
 

--- a/api/shared/nodenetworkconfigurationpolicy_types.go
+++ b/api/shared/nodenetworkconfigurationpolicy_types.go
@@ -46,10 +46,10 @@ type NodeNetworkConfigurationPolicySpec struct {
 
 	// MaxUnavailable specifies percentage or number
 	// of machines that can be updating at a time. Default is "50%".
-	// Must be greater than 0. When set as a percentage, it must be a positive percentage.
+	// Must be greater than 0. When set as a percentage, it must be between 1% and 100%.
 	// +optional
 	//nolint:lll
-	// +kubebuilder:validation:XValidation:rule="(type(self) == int && self > 0) || (type(self) == string && self != '0' && self != '0%')",message="maxUnavailable must be greater than 0"
+	// +kubebuilder:validation:XValidation:rule="(type(self) == int && self > 0) || (type(self) == string && self.matches('^([1-9][0-9]*|([1-9]|[1-9][0-9]|100)%)$'))",message="maxUnavailable must be a positive integer or a percentage between 1% and 100%"
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 }
 

--- a/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,6 +70,8 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  The computed value must result in at least 1 node being allowed to undergo updates at a time.
+                  If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 additionalProperties:
@@ -190,6 +192,8 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  The computed value must result in at least 1 node being allowed to undergo updates at a time.
+                  If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 additionalProperties:

--- a/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,7 +70,12 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: maxUnavailable must be greater than 0
+                  rule: (type(self) == int && self > 0) || (type(self) == string &&
+                    self != '0' && self != '0%')
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -190,7 +195,12 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: maxUnavailable must be greater than 0
+                  rule: (type(self) == int && self > 0) || (type(self) == string &&
+                    self != '0' && self != '0%')
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/bundle/manifests/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,12 +70,13 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
-                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
+                  Must be greater than 0. When set as a percentage, it must be between 1% and 100%.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:
-                - message: maxUnavailable must be greater than 0
+                - message: maxUnavailable must be a positive integer or a percentage
+                    between 1% and 100%
                   rule: (type(self) == int && self > 0) || (type(self) == string &&
-                    self != '0' && self != '0%')
+                    self.matches('^([1-9][0-9]*|([1-9]|[1-9][0-9]|100)%)$'))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -195,12 +196,13 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
-                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
+                  Must be greater than 0. When set as a percentage, it must be between 1% and 100%.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:
-                - message: maxUnavailable must be greater than 0
+                - message: maxUnavailable must be a positive integer or a percentage
+                    between 1% and 100%
                   rule: (type(self) == int && self > 0) || (type(self) == string &&
-                    self != '0' && self != '0%')
+                    self.matches('^([1-9][0-9]*|([1-9]|[1-9][0-9]|100)%)$'))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -231,11 +231,20 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	if r.shouldIncrementUnavailableNodeCount(previousConditions) {
 		err = r.incrementUnavailableNodeCount(ctx, instance, generationKey)
 		if err != nil {
+			if errors.Is(err, node.InvalidMaxUnavailableError{}) {
+				// Policy status already set to FailedToConfigure in incrementUnavailableNodeCount
+				log.Error(err, "Invalid maxUnavailable configuration, stopping reconciliation")
+				return ctrl.Result{}, nil
+			}
 			if apierrors.IsConflict(err) || errors.Is(err, node.MaxUnavailableLimitReachedError{}) {
 				enactmentConditions.NotifyPending(ctx)
 				log.Info(err.Error())
 				shouldAbortEnactment, err := r.shouldAbortReconcile(ctx, instance)
 				if err != nil {
+					if errors.Is(err, node.InvalidMaxUnavailableError{}) {
+						// Policy status already set, stop reconciliation
+						return ctrl.Result{}, nil
+					}
 					return ctrl.Result{}, err
 				}
 				if shouldAbortEnactment {
@@ -579,7 +588,9 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 	policy *nmstatev1.NodeNetworkConfigurationPolicy,
 	generationKey string) error {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
-	return retry.OnError(retry.DefaultRetry, func(error) bool { return true }, func() error {
+	return retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return !errors.Is(err, node.InvalidMaxUnavailableError{})
+	}, func() error {
 		err := r.Get(ctx, policyKey, policy)
 		if err != nil {
 			return err
@@ -592,14 +603,18 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 		}
 
 		if maxUnavailable < 1 {
-			errMsg := fmt.Sprintf("invalid maxUnavailable configuration: computed value is %d. The maxUnavailable field must result in at least 1 node. Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")", maxUnavailable)
-			r.Log.Error(errors.New(errMsg), "Invalid maxUnavailable configuration")
+			errMsg := fmt.Sprintf(
+				"invalid maxUnavailable configuration: computed value is %d. "+
+					"The maxUnavailable field must result in at least 1 node. "+
+					"Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")",
+				maxUnavailable)
+			r.Log.Error(node.InvalidMaxUnavailableError{}, "Invalid maxUnavailable configuration")
 			policyconditions.SetPolicyFailedToConfigure(&policy.Status.Conditions, errMsg)
 			updateErr := r.Client.Status().Update(ctx, policy)
 			if updateErr != nil {
 				return updateErr
 			}
-			return errors.New(errMsg)
+			return node.InvalidMaxUnavailableError{}
 		}
 
 		if policy.Status.UnavailableNodeCountMap == nil {
@@ -695,14 +710,18 @@ func (r *NodeNetworkConfigurationPolicyReconciler) shouldAbortReconcile(
 	}
 
 	if maxUnavailable < 1 {
-		errMsg := fmt.Sprintf("invalid maxUnavailable configuration: computed value is %d. The maxUnavailable field must result in at least 1 node. Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")", maxUnavailable)
-		logger.Error(errors.New(errMsg), "Invalid maxUnavailable configuration")
+		errMsg := fmt.Sprintf(
+			"invalid maxUnavailable configuration: computed value is %d. "+
+				"The maxUnavailable field must result in at least 1 node. "+
+				"Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")",
+			maxUnavailable)
+		logger.Error(node.InvalidMaxUnavailableError{}, "Invalid maxUnavailable configuration")
 		policyconditions.SetPolicyFailedToConfigure(&instance.Status.Conditions, errMsg)
 		updateErr := r.Client.Status().Update(ctx, instance)
 		if updateErr != nil {
 			return false, updateErr
 		}
-		return false, errors.New(errMsg)
+		return false, node.InvalidMaxUnavailableError{}
 	}
 
 	filter := enactmentconditions.LogicalConditionCountFilter{

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -591,6 +591,17 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 			)
 		}
 
+		if maxUnavailable < 1 {
+			errMsg := fmt.Sprintf("invalid maxUnavailable configuration: computed value is %d. The maxUnavailable field must result in at least 1 node. Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")", maxUnavailable)
+			r.Log.Error(errors.New(errMsg), "Invalid maxUnavailable configuration")
+			policyconditions.SetPolicyFailedToConfigure(&policy.Status.Conditions, errMsg)
+			updateErr := r.Client.Status().Update(ctx, policy)
+			if updateErr != nil {
+				return updateErr
+			}
+			return errors.New(errMsg)
+		}
+
 		if policy.Status.UnavailableNodeCountMap == nil {
 			policy.Status.UnavailableNodeCountMap = map[string]int{}
 		}
@@ -682,6 +693,18 @@ func (r *NodeNetworkConfigurationPolicyReconciler) shouldAbortReconcile(
 		logger.Info("Error getting max unavailable count")
 		return false, err
 	}
+
+	if maxUnavailable < 1 {
+		errMsg := fmt.Sprintf("invalid maxUnavailable configuration: computed value is %d. The maxUnavailable field must result in at least 1 node. Either increase the value (e.g., set to 1 or higher) or use a higher percentage (e.g., \"1%%\")", maxUnavailable)
+		logger.Error(errors.New(errMsg), "Invalid maxUnavailable configuration")
+		policyconditions.SetPolicyFailedToConfigure(&instance.Status.Conditions, errMsg)
+		updateErr := r.Client.Status().Update(ctx, instance)
+		if updateErr != nil {
+			return false, updateErr
+		}
+		return false, errors.New(errMsg)
+	}
+
 	filter := enactmentconditions.LogicalConditionCountFilter{
 		nmstateapi.NodeNetworkConfigurationEnactmentConditionFailing:     corev1.ConditionTrue,
 		nmstateapi.NodeNetworkConfigurationEnactmentConditionProgressing: corev1.ConditionFalse,

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -231,6 +231,14 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(ctx context.Context
 	if r.shouldIncrementUnavailableNodeCount(previousConditions) {
 		err = r.incrementUnavailableNodeCount(ctx, instance, generationKey)
 		if err != nil {
+			if errors.As(err, &node.InvalidMaxUnavailableError{}) {
+				log.Error(err, "policy has an invalid maxUnavailable value, failing enactment")
+				if r.Recorder != nil {
+					r.Recorder.Event(instance, corev1.EventTypeWarning, ReconcileFailed, err.Error())
+				}
+				enactmentConditions.NotifyFailedToConfigure(ctx, err)
+				return ctrl.Result{}, nil
+			}
 			if apierrors.IsConflict(err) || errors.Is(err, node.MaxUnavailableLimitReachedError{}) {
 				enactmentConditions.NotifyPending(ctx)
 				log.Info(err.Error())
@@ -579,13 +587,19 @@ func (r *NodeNetworkConfigurationPolicyReconciler) incrementUnavailableNodeCount
 	policy *nmstatev1.NodeNetworkConfigurationPolicy,
 	generationKey string) error {
 	policyKey := types.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}
-	return retry.OnError(retry.DefaultRetry, func(error) bool { return true }, func() error {
+	return retry.OnError(retry.DefaultRetry, func(err error) bool {
+		// An invalid maxUnavailable value is terminal: retrying cannot fix it.
+		return !errors.As(err, &node.InvalidMaxUnavailableError{})
+	}, func() error {
 		err := r.Get(ctx, policyKey, policy)
 		if err != nil {
 			return err
 		}
 		maxUnavailable, err := node.MaxUnavailableNodeCount(ctx, r.APIClient, policy)
 		if err != nil {
+			if errors.As(err, &node.InvalidMaxUnavailableError{}) {
+				return err
+			}
 			r.Log.Info(
 				fmt.Sprintf("failed calculating limit of max unavailable nodes, defaulting to %d, err: %s", maxUnavailable, err.Error()),
 			)

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -133,6 +133,9 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 			nnce := nmstatev1beta1.NodeNetworkConfigurationEnactment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: shared.EnactmentKey(nodeName, nncp.Name).Name,
+					Labels: map[string]string{
+						shared.EnactmentPolicyLabel: nncp.Name,
+					},
 				},
 				Status: shared.NodeNetworkConfigurationEnactmentStatus{},
 			}

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -203,6 +204,83 @@ var _ = Describe("NodeNetworkConfigurationPolicy controller predicates", func() 
 				expectedReconcileResult:     ctrl.Result{Requeue: true},
 			}),
 	)
+
+	Describe("when a policy has an invalid maxUnavailable value", func() {
+		// This exercises the defense-in-depth runtime guard: a policy whose
+		// maxUnavailable resolves to a non-positive node count (e.g. one persisted
+		// before the CRD CEL rule was in place) must terminally fail the enactment
+		// rather than requeue and hot-loop the rollout. The CEL rule blocks such a
+		// value at admission, so this path is only reachable via a unit test.
+		It("should fail the enactment terminally without requeuing", func() {
+			nmstatectlShowFn = func() (string, error) { return "", nil }
+			reconciler := NodeNetworkConfigurationPolicyReconciler{
+				RetriesUntilFail:   5,
+				MaximumTimeBackoff: 30 * time.Second,
+				InitialBackoff:     1 * time.Second,
+			}
+			s := scheme.Scheme
+			s.AddKnownTypes(nmstatev1beta1.GroupVersion,
+				&nmstatev1beta1.NodeNetworkState{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactment{},
+				&nmstatev1beta1.NodeNetworkConfigurationEnactmentList{},
+			)
+			s.AddKnownTypes(nmstatev1.GroupVersion,
+				&nmstatev1.NodeNetworkConfigurationPolicy{},
+			)
+
+			node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+			nns := nmstatev1beta1.NodeNetworkState{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+
+			invalidMaxUnavailable := intstr.FromInt(0)
+			nncp := nmstatev1.NodeNetworkConfigurationPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: shared.NodeNetworkConfigurationPolicySpec{
+					MaxUnavailable: &invalidMaxUnavailable,
+				},
+				Status: shared.NodeNetworkConfigurationPolicyStatus{
+					UnavailableNodeCountMap: map[string]int{},
+				},
+			}
+			// Empty enactment conditions so shouldIncrementUnavailableNodeCount runs
+			// the increment path, and the policy label so it is counted as a match.
+			nnce := nmstatev1beta1.NodeNetworkConfigurationEnactment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   shared.EnactmentKey(nodeName, nncp.Name).Name,
+					Labels: map[string]string{shared.EnactmentPolicyLabel: nncp.Name},
+				},
+			}
+
+			clb := fake.ClientBuilder{}
+			clb.WithScheme(s)
+			clb.WithRuntimeObjects(&nncp, &nnce, &nns, &node)
+			clb.WithStatusSubresource(&nncp)
+			clb.WithStatusSubresource(&nnce)
+			clb.WithStatusSubresource(&nns)
+			cl := clb.Build()
+
+			reconciler.Client = cl
+			reconciler.APIClient = cl
+			reconciler.Log = ctrl.Log.WithName("controllers").WithName("NodeNetworkConfigurationPolicy")
+
+			res, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: nncp.Name},
+			})
+
+			// The invalid value is terminal: no error returned to the manager and
+			// no requeue, so the reconcile does not hot-loop.
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+
+			// The enactment must be marked FailedToConfigure (Failing=True).
+			updatedNNCE := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
+			err = cl.Get(context.TODO(), shared.EnactmentKey(nodeName, nncp.Name), updatedNNCE)
+			Expect(err).To(BeNil())
+			failing := updatedNNCE.Status.Conditions.Find(shared.NodeNetworkConfigurationEnactmentConditionFailing)
+			Expect(failing).ToNot(BeNil(), "Failing condition should be set")
+			Expect(failing.Status).To(Equal(corev1.ConditionTrue))
+			Expect(failing.Reason).To(Equal(shared.NodeNetworkConfigurationEnactmentConditionFailedToConfigure))
+		})
+	})
 
 	Describe("allPolicies function", func() {
 		It("should return policies in alphanumerical order by name", func() {

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,6 +70,8 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  The computed value must result in at least 1 node being allowed to undergo updates at a time.
+                  If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 additionalProperties:
@@ -190,6 +192,8 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  The computed value must result in at least 1 node being allowed to undergo updates at a time.
+                  If set to 0 or a percentage that rounds to 0, the policy will fail with FailedToConfigure.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 additionalProperties:

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,7 +70,12 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: maxUnavailable must be greater than 0
+                  rule: (type(self) == int && self > 0) || (type(self) == string &&
+                    self != '0' && self != '0%')
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -190,7 +195,12 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
+                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: maxUnavailable must be greater than 0
+                  rule: (type(self) == int && self > 0) || (type(self) == string &&
+                    self != '0' && self != '0%')
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -70,12 +70,13 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
-                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
+                  Must be greater than 0. When set as a percentage, it must be between 1% and 100%.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:
-                - message: maxUnavailable must be greater than 0
+                - message: maxUnavailable must be a positive integer or a percentage
+                    between 1% and 100%
                   rule: (type(self) == int && self > 0) || (type(self) == string &&
-                    self != '0' && self != '0%')
+                    self.matches('^([1-9][0-9]*|([1-9]|[1-9][0-9]|100)%)$'))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -195,12 +196,13 @@ spec:
                 description: |-
                   MaxUnavailable specifies percentage or number
                   of machines that can be updating at a time. Default is "50%".
-                  Must be greater than 0. When set as a percentage, it must be a positive percentage.
+                  Must be greater than 0. When set as a percentage, it must be between 1% and 100%.
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:
-                - message: maxUnavailable must be greater than 0
+                - message: maxUnavailable must be a positive integer or a percentage
+                    between 1% and 100%
                   rule: (type(self) == int && self > 0) || (type(self) == string &&
-                    self != '0' && self != '0%')
+                    self.matches('^([1-9][0-9]*|([1-9]|[1-9][0-9]|100)%)$'))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -43,6 +43,12 @@ func (f MaxUnavailableLimitReachedError) Error() string {
 	return "maximal number of nodes are already processing policy configuration"
 }
 
+type InvalidMaxUnavailableError struct{}
+
+func (e InvalidMaxUnavailableError) Error() string {
+	return "invalid maxUnavailable configuration: computed value is 0"
+}
+
 func NodesRunningNmstate(ctx context.Context, cli client.Reader, nodeSelector map[string]string) ([]corev1.Node, error) {
 	nodes := corev1.NodeList{}
 	err := cli.List(ctx, &nodes, client.MatchingLabels(nodeSelector))

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -108,12 +108,6 @@ func MaxUnavailableNodeCount(ctx context.Context, cli client.Reader, policy *nms
 }
 
 func ScaledMaxUnavailableNodeCount(matchingNodes int, intOrPercent intstr.IntOrString) (int, error) {
-	correctMaxUnavailable := func(maxUnavailable int) int {
-		if maxUnavailable < 1 {
-			return MinMaxunavailable
-		}
-		return maxUnavailable
-	}
 	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&intOrPercent, matchingNodes, true)
 	if err != nil {
 		defaultMaxUnavailable := intstr.FromString(DefaultMaxunavailable)
@@ -122,9 +116,9 @@ func ScaledMaxUnavailableNodeCount(matchingNodes int, intOrPercent intstr.IntOrS
 			matchingNodes,
 			true,
 		)
-		return correctMaxUnavailable(maxUnavailable), err
+		return maxUnavailable, err
 	}
-	return correctMaxUnavailable(maxUnavailable), nil
+	return maxUnavailable, nil
 }
 
 // Return true if the event name is the name of

--- a/pkg/node/nodes.go
+++ b/pkg/node/nodes.go
@@ -19,6 +19,9 @@ package node
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
 	"github.com/nmstate/kubernetes-nmstate/pkg/enactment"
@@ -41,6 +44,19 @@ type MaxUnavailableLimitReachedError struct{}
 
 func (f MaxUnavailableLimitReachedError) Error() string {
 	return "maximal number of nodes are already processing policy configuration"
+}
+
+// InvalidMaxUnavailableError indicates that a policy's maxUnavailable resolves to a
+// non-positive number of nodes. This should normally be rejected at admission time by
+// the CRD CEL rule, but it can still be observed for policies persisted before the CRD
+// was upgraded. It is a terminal validation error: reconciliation must fail the
+// enactment rather than retry, since the value can only be fixed by editing the policy.
+type InvalidMaxUnavailableError struct {
+	value string
+}
+
+func (e InvalidMaxUnavailableError) Error() string {
+	return fmt.Sprintf("maxUnavailable must be a positive integer or a percentage between 1%% and 100%%, got %q", e.value)
 }
 
 func NodesRunningNmstate(ctx context.Context, cli client.Reader, nodeSelector map[string]string) ([]corev1.Node, error) {
@@ -107,16 +123,42 @@ func MaxUnavailableNodeCount(ctx context.Context, cli client.Reader, policy *nms
 	return ScaledMaxUnavailableNodeCount(enactmentsTotal, intOrPercent)
 }
 
+// scaledDefaultMaxUnavailableNodeCount returns the DefaultMaxunavailable percentage
+// scaled to the given number of matching nodes. Used as the fallback count when the
+// configured value cannot be resolved.
+func scaledDefaultMaxUnavailableNodeCount(matchingNodes int) int {
+	defaultMaxUnavailable := intstr.FromString(DefaultMaxunavailable)
+	maxUnavailable, _ := intstr.GetScaledValueFromIntOrPercent(&defaultMaxUnavailable, matchingNodes, true)
+	return maxUnavailable
+}
+
 func ScaledMaxUnavailableNodeCount(matchingNodes int, intOrPercent intstr.IntOrString) (int, error) {
+	// GetScaledValueFromIntOrPercent only accepts int values and strings ending in
+	// "%"; it rejects a string that holds a plain integer (e.g. "5"). Treat such a
+	// string as an absolute node count so both "5" and "5%" are accepted. The CRD
+	// CEL rule only admits [1-9][0-9]* for this form, so a parse failure means the
+	// value is either out of int range or bypassed admission (e.g. persisted before
+	// the CRD was upgraded); either way it is terminally invalid rather than a value
+	// that should silently fall back to the default.
+	if intOrPercent.Type == intstr.String && !strings.HasSuffix(intOrPercent.StrVal, "%") {
+		v, convErr := strconv.Atoi(intOrPercent.StrVal)
+		if convErr != nil {
+			return scaledDefaultMaxUnavailableNodeCount(matchingNodes), InvalidMaxUnavailableError{value: intOrPercent.String()}
+		}
+		intOrPercent = intstr.FromInt(v)
+	}
 	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&intOrPercent, matchingNodes, true)
 	if err != nil {
-		defaultMaxUnavailable := intstr.FromString(DefaultMaxunavailable)
-		maxUnavailable, _ = intstr.GetScaledValueFromIntOrPercent(
-			&defaultMaxUnavailable,
-			matchingNodes,
-			true,
-		)
-		return maxUnavailable, err
+		return scaledDefaultMaxUnavailableNodeCount(matchingNodes), err
+	}
+	// Defense-in-depth: the CRD CEL rule rejects non-positive maxUnavailable values on
+	// write, but it only runs on create/update and cannot catch policies persisted
+	// before the CRD was upgraded. A value below MinMaxunavailable would make
+	// incrementUnavailableNodeCount treat the limit as reached on the first node and
+	// deadlock the rollout, so fail validation instead. matchingNodes is guarded so a
+	// valid policy that simply matches no nodes is not reported as invalid.
+	if matchingNodes > 0 && maxUnavailable < MinMaxunavailable {
+		return maxUnavailable, InvalidMaxUnavailableError{value: intOrPercent.String()}
 	}
 	return maxUnavailable, nil
 }

--- a/pkg/node/nodes_test.go
+++ b/pkg/node/nodes_test.go
@@ -32,6 +32,8 @@ var _ = Describe("MaxUnavailable nodes", func() {
 		expectedScaledMaxUnavailable int
 		expectedError                types.GomegaMatcher
 	}
+	// Note: ValidateMaxUnavailable is tested at the controller integration test level
+	// since it requires a full client context with policies and enactments
 	DescribeTable("testing ScaledMaxUnavailableNodeCount",
 		func(c maxUnavailableCase) {
 			maxUnavailable, err := ScaledMaxUnavailableNodeCount(c.nmstateEnabledNodes, c.maxUnavailable)
@@ -84,14 +86,14 @@ var _ = Describe("MaxUnavailable nodes", func() {
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromString("0%"),
-				expectedScaledMaxUnavailable: 1,
+				expectedScaledMaxUnavailable: 0,
 				expectedError:                Not(HaveOccurred()),
 			}),
 		Entry("Zero value",
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromInt(0),
-				expectedScaledMaxUnavailable: 1,
+				expectedScaledMaxUnavailable: 0,
 				expectedError:                Not(HaveOccurred()),
 			}))
 })

--- a/pkg/node/nodes_test.go
+++ b/pkg/node/nodes_test.go
@@ -18,12 +18,20 @@ limitations under the License.
 package node
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func beInvalidMaxUnavailableError() types.GomegaMatcher {
+	return WithTransform(func(err error) bool {
+		return errors.As(err, &InvalidMaxUnavailableError{})
+	}, BeTrue())
+}
 
 var _ = Describe("MaxUnavailable nodes", func() {
 	type maxUnavailableCase struct {
@@ -32,8 +40,11 @@ var _ = Describe("MaxUnavailable nodes", func() {
 		expectedScaledMaxUnavailable int
 		expectedError                types.GomegaMatcher
 	}
-	// Note: ValidateMaxUnavailable is tested at the controller integration test level
-	// since it requires a full client context with policies and enactments
+	// Note: rejection of maxUnavailable values of 0 / "0%" is enforced by the CRD CEL
+	// rule and covered by the e2e tests in test/e2e/handler/nnce_conditions_test.go.
+	// As defense-in-depth ScaledMaxUnavailableNodeCount additionally returns an
+	// InvalidMaxUnavailableError for any non-positive computed value (e.g. for policies
+	// persisted before the CRD was upgraded), which the cases below assert.
 	DescribeTable("testing ScaledMaxUnavailableNodeCount",
 		func(c maxUnavailableCase) {
 			maxUnavailable, err := ScaledMaxUnavailableNodeCount(c.nmstateEnabledNodes, c.maxUnavailable)
@@ -68,32 +79,67 @@ var _ = Describe("MaxUnavailable nodes", func() {
 				expectedScaledMaxUnavailable: 3,
 				expectedError:                Not(HaveOccurred()),
 			}),
-		Entry("Wrong string value",
+		Entry("Wrong string value is terminally invalid",
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromString("asdf"),
 				expectedScaledMaxUnavailable: 3,
-				expectedError:                HaveOccurred(),
+				expectedError:                beInvalidMaxUnavailableError(),
 			}),
-		Entry("Absolute value in string",
+		Entry("Bare integer string above int range is terminally invalid",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("99999999999999999999"),
+				expectedScaledMaxUnavailable: 3,
+				expectedError:                beInvalidMaxUnavailableError(),
+			}),
+		Entry("Absolute value in string is treated as a node count",
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromString("42"),
-				expectedScaledMaxUnavailable: 3,
-				expectedError:                HaveOccurred(),
+				expectedScaledMaxUnavailable: 42,
+				expectedError:                Not(HaveOccurred()),
 			}),
 		Entry("Zero percent",
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromString("0%"),
 				expectedScaledMaxUnavailable: 0,
-				expectedError:                Not(HaveOccurred()),
+				expectedError:                beInvalidMaxUnavailableError(),
 			}),
 		Entry("Zero value",
 			maxUnavailableCase{
 				nmstateEnabledNodes:          5,
 				maxUnavailable:               intstr.FromInt(0),
 				expectedScaledMaxUnavailable: 0,
+				expectedError:                beInvalidMaxUnavailableError(),
+			}),
+		Entry("Zero-equivalent percentage that bypasses CEL validation",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("00%"),
+				expectedScaledMaxUnavailable: 0,
+				expectedError:                beInvalidMaxUnavailableError(),
+			}),
+		Entry("Negative percentage that bypasses CEL validation",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("-100%"),
+				expectedScaledMaxUnavailable: -5,
+				expectedError:                beInvalidMaxUnavailableError(),
+			}),
+		Entry("Valid policy that matches no nodes is not reported invalid",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          0,
+				maxUnavailable:               intstr.FromString("50%"),
+				expectedScaledMaxUnavailable: 0,
+				expectedError:                Not(HaveOccurred()),
+			}),
+		Entry("Upper-bound percentage of 100% is valid",
+			maxUnavailableCase{
+				nmstateEnabledNodes:          5,
+				maxUnavailable:               intstr.FromString("100%"),
+				expectedScaledMaxUnavailable: 5,
 				expectedError:                Not(HaveOccurred()),
 			}))
 })

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -225,7 +225,7 @@ var _ = Describe("EnactmentCondition", func() {
 				map[string]string{"node-role.kubernetes.io/worker": ""},
 			)
 			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: 0")
-			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be greater than 0"))
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be a positive integer or a percentage"))
 		})
 
 		It("should be rejected by API validation when maxUnavailable is 0%", func() {
@@ -237,7 +237,31 @@ var _ = Describe("EnactmentCondition", func() {
 				map[string]string{"node-role.kubernetes.io/worker": ""},
 			)
 			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: 0%")
-			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be greater than 0"))
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be a positive integer or a percentage"))
+		})
+
+		It("should be rejected by API validation for non-positive percentages that scale to zero", func() {
+			By("Attempt to apply policy with maxUnavailable: -5%")
+			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
+				TestPolicy,
+				linuxBrUp(bridge1),
+				intstr.FromString("-5%"),
+				map[string]string{"node-role.kubernetes.io/worker": ""},
+			)
+			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: -5%")
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be a positive integer or a percentage"))
+		})
+
+		It("should be rejected by API validation for percentages greater than 100%", func() {
+			By("Attempt to apply policy with maxUnavailable: 200%")
+			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
+				TestPolicy,
+				linuxBrUp(bridge1),
+				intstr.FromString("200%"),
+				map[string]string{"node-role.kubernetes.io/worker": ""},
+			)
+			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: 200%")
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be a positive integer or a percentage"))
 		})
 	})
 })

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -219,7 +219,6 @@ var _ = Describe("EnactmentCondition", func() {
 		It("should be rejected by API validation when maxUnavailable is 0", func() {
 			By("Attempt to apply policy with maxUnavailable: 0")
 			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
-				TestPolicy,
 				linuxBrUp(bridge1),
 				intstr.FromInt(0),
 				map[string]string{"node-role.kubernetes.io/worker": ""},
@@ -231,7 +230,6 @@ var _ = Describe("EnactmentCondition", func() {
 		It("should be rejected by API validation when maxUnavailable is 0%", func() {
 			By("Attempt to apply policy with maxUnavailable: 0%")
 			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
-				TestPolicy,
 				linuxBrUp(bridge1),
 				intstr.FromString("0%"),
 				map[string]string{"node-role.kubernetes.io/worker": ""},
@@ -243,7 +241,6 @@ var _ = Describe("EnactmentCondition", func() {
 		It("should be rejected by API validation for non-positive percentages that scale to zero", func() {
 			By("Attempt to apply policy with maxUnavailable: -5%")
 			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
-				TestPolicy,
 				linuxBrUp(bridge1),
 				intstr.FromString("-5%"),
 				map[string]string{"node-role.kubernetes.io/worker": ""},
@@ -255,7 +252,6 @@ var _ = Describe("EnactmentCondition", func() {
 		It("should be rejected by API validation for percentages greater than 100%", func() {
 			By("Attempt to apply policy with maxUnavailable: 200%")
 			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
-				TestPolicy,
 				linuxBrUp(bridge1),
 				intstr.FromString("200%"),
 				map[string]string{"node-role.kubernetes.io/worker": ""},

--- a/test/e2e/handler/nnce_conditions_test.go
+++ b/test/e2e/handler/nnce_conditions_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
 	enactmentconditions "github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus/conditions"
@@ -206,6 +207,37 @@ var _ = Describe("EnactmentCondition", func() {
 			Eventually(func() nmstate.ConditionList {
 				return policyconditions.Status(TestPolicy)
 			}, 2*time.Second, 100*time.Millisecond).Should(policyconditions.ContainPolicyDegraded(), "policy should be marked as Degraded")
+		})
+	})
+
+	Context("when maxUnavailable configuration is invalid", func() {
+		BeforeEach(func() {
+			By("Ensure policy doesn't exist")
+			deletePolicy(TestPolicy)
+		})
+
+		It("should be rejected by API validation when maxUnavailable is 0", func() {
+			By("Attempt to apply policy with maxUnavailable: 0")
+			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
+				TestPolicy,
+				linuxBrUp(bridge1),
+				intstr.FromInt(0),
+				map[string]string{"node-role.kubernetes.io/worker": ""},
+			)
+			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: 0")
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be greater than 0"))
+		})
+
+		It("should be rejected by API validation when maxUnavailable is 0%", func() {
+			By("Attempt to apply policy with maxUnavailable: 0%")
+			err := setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
+				TestPolicy,
+				linuxBrUp(bridge1),
+				intstr.FromString("0%"),
+				map[string]string{"node-role.kubernetes.io/worker": ""},
+			)
+			Expect(err).To(HaveOccurred(), "API should reject policy with maxUnavailable: 0%")
+			Expect(err.Error()).To(ContainSubstring("maxUnavailable must be greater than 0"))
 		})
 	})
 })

--- a/test/e2e/handler/nodes_test.go
+++ b/test/e2e/handler/nodes_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Nodes", func() {
 		})
 		Context("and node network state is deleted", func() {
 			BeforeEach(func() {
-				deleteNodeNeworkStates()
+				deleteNodeNetworkStates()
 			})
 			It("should recreate it with currentState", func() {
 				for _, node := range nodes {

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -165,6 +165,28 @@ func setDesiredStateWithPolicyAndCapture(name string, desiredState nmstate.State
 	setDesiredStateWithPolicyAndCaptureAndNodeSelectorEventually(name, desiredState, capture, runAtWorkers)
 }
 
+func setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
+	name string,
+	desiredState nmstate.State,
+	maxUnavailableValue intstr.IntOrString,
+	nodeSelector map[string]string,
+) error {
+	policy := nmstatev1.NodeNetworkConfigurationPolicy{}
+	policy.Name = name
+	key := types.NamespacedName{Name: name}
+	err := testenv.Client.Get(context.TODO(), key, &policy)
+	policy.Spec.DesiredState = desiredState
+	policy.Spec.NodeSelector = nodeSelector
+	policy.Spec.MaxUnavailable = &maxUnavailableValue
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return testenv.Client.Create(context.TODO(), &policy)
+		}
+		return err
+	}
+	return testenv.Client.Update(context.TODO(), &policy)
+}
+
 // nodeMatchesSelector checks if a node's labels match the given selector.
 // An empty selector matches all nodes.
 func nodeMatchesSelector(nodeName string, nodeSelector map[string]string) bool {
@@ -279,7 +301,7 @@ func nodeNetworkConfigurationPolicy(policyName string) nmstatev1.NodeNetworkConf
 	return policy
 }
 
-func deleteNodeNeworkStates() {
+func deleteNodeNetworkStates() {
 	nodeNetworkStateList := &nmstatev1beta1.NodeNetworkStateList{}
 	err := testenv.Client.List(context.TODO(), nodeNetworkStateList, &dynclient.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -166,14 +166,13 @@ func setDesiredStateWithPolicyAndCapture(name string, desiredState nmstate.State
 }
 
 func setDesiredStateWithPolicyMaxUnavailableAndNodeSelector(
-	name string,
 	desiredState nmstate.State,
 	maxUnavailableValue intstr.IntOrString,
 	nodeSelector map[string]string,
 ) error {
 	policy := nmstatev1.NodeNetworkConfigurationPolicy{}
-	policy.Name = name
-	key := types.NamespacedName{Name: name}
+	policy.Name = TestPolicy
+	key := types.NamespacedName{Name: TestPolicy}
 	err := testenv.Client.Get(context.TODO(), key, &policy)
 	policy.Spec.DesiredState = desiredState
 	policy.Spec.NodeSelector = nodeSelector


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

---
**What**

Move maxUnavailable validation from controller logic to a CRD-level CEL validation rule, so invalid values are rejected at admission time with a clear message instead of silently falling back to a default during reconciliation.

**Why**

Previously an invalid maxUnavailable (e.g. 0, 0%, or a value scaling to zero nodes) was only caught at reconcile time and quietly defaulted. A value that scales to zero makes the rollout treat its limit as reached on the first node and deadlock. Validating at the API boundary gives users immediate, actionable feedback and prevents the bad value from ever being persisted.

**Changes**

- CEL validation rule on NodeNetworkConfigurationPolicy.spec.maxUnavailable: accepts a positive integer or a percentage between 1% and 100%. Rejects 0, 0%, negative values, non-numeric strings, and percentages > 100%. Absolute counts remain uncapped by design.
- Runtime handling (ScaledMaxUnavailableNodeCount): accepts both percentage strings ("50%") and bare-integer strings ("5", treated as an absolute node count). Any value that still resolves to a non-positive count — only reachable for policies persisted before the CRD upgrade — returns a terminal InvalidMaxUnavailableError.
- Terminal failure path: an invalid value fails the enactment (Failing=True, reason FailedToConfigure) with a clear message and no requeue — the desired state is never applied and no fallback value is silently used.
- Regenerated CRDs and OLM bundle manifests.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Reject invalid maxUnavailable values (0, 0%, negatives, or percentages over 100%) at API admission with a clear error message.
```
