### PR TITLE
tls: strict cluster TLS profile adherence and curve preferences support

### DIFF
--- a/api/shared/nmstate_types.go
+++ b/api/shared/nmstate_types.go
@@ -22,7 +22,8 @@ const (
 	NmstateConditionDegraded    ConditionType = "Degraded"
 	NmstateConditionProgressing ConditionType = "Progressing"
 
-	NmstateInternalError        ConditionReason = "InternalError"
-	NmstateDeploying            ConditionReason = "Deploying"
-	NmstateSuccessfullyDeployed ConditionReason = "SuccessfullyDeployed"
+	NmstateInternalError             ConditionReason = "InternalError"
+	NmstateDeploying                 ConditionReason = "Deploying"
+	NmstateSuccessfullyDeployed      ConditionReason = "SuccessfullyDeployed"
+	NmstateTLSProfileNotFullyHonored ConditionReason = "TLSProfileNotFullyHonored"
 )

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -151,6 +151,9 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	r.deployments = []client.ObjectKey{}
 	r.daemonSets = []client.ObjectKey{}
+	// Request-scoped state, reset together with deployments/daemonSets so a
+	// failed reconcile cannot leak a stale warning into the next run.
+	r.tlsProfileWarning = ""
 
 	if err := r.applyManifests(instance, ctx); err != nil {
 		r.setDegradedCondition(ctx, instance, shared.NmstateInternalError, err.Error())

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -69,6 +69,10 @@ type NMStateReconciler struct {
 	IsOpenShift bool
 	deployments []client.ObjectKey
 	daemonSets  []client.ObjectKey
+	// tlsProfileWarning holds a human-readable description of cluster TLS
+	// profile entries that cannot be honored and were dropped. Empty when
+	// the profile is fully honored. Reported as a Degraded condition.
+	tlsProfileWarning string
 }
 
 // Core resources: services, endpoints, events, configmaps need full CRUD for handler deployment manifests.
@@ -412,6 +416,13 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		if err != nil {
 			return fmt.Errorf("failed fetching TLS profile for ConfigMap: %w", err)
 		}
+		// Strict adherence: refuse to roll out a profile the components
+		// cannot honor; it would crash-loop the TLS-serving pods.
+		_, unsupported, err := nmstatetls.NewTLSConfigFromProfile(tlsProfileSpec)
+		if err != nil {
+			return fmt.Errorf("cluster TLS profile cannot be honored: %w", err)
+		}
+		r.tlsProfileWarning = unsupported.Message()
 		tlsJSON, err := json.Marshal(tlsProfileSpec)
 		if err != nil {
 			return fmt.Errorf("failed serializing TLS profile: %w", err)
@@ -625,13 +636,24 @@ func (r *NMStateReconciler) reconcileStatus(ctx context.Context, instance *nmsta
 			shared.NmstateSuccessfullyDeployed,
 			"All components are available and ready",
 		)
-		// Clear any previous degraded condition when available
-		instance.Status.Conditions.Set(
-			shared.NmstateConditionDegraded,
-			corev1.ConditionFalse,
-			shared.NmstateSuccessfullyDeployed,
-			"All components are available and ready",
-		)
+		if r.tlsProfileWarning != "" {
+			// The cluster TLS profile contains entries the components
+			// cannot honor; the served config is a strict subset.
+			instance.Status.Conditions.Set(
+				shared.NmstateConditionDegraded,
+				corev1.ConditionTrue,
+				shared.NmstateTLSProfileNotFullyHonored,
+				r.tlsProfileWarning,
+			)
+		} else {
+			// Clear any previous degraded condition when available
+			instance.Status.Conditions.Set(
+				shared.NmstateConditionDegraded,
+				corev1.ConditionFalse,
+				shared.NmstateSuccessfullyDeployed,
+				"All components are available and ready",
+			)
+		}
 	}
 
 	// Clear managed fields before applying server-side apply to status subresource

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -69,9 +69,8 @@ type NMStateReconciler struct {
 	IsOpenShift bool
 	deployments []client.ObjectKey
 	daemonSets  []client.ObjectKey
-	// tlsProfileWarning holds a human-readable description of cluster TLS
-	// profile entries that cannot be honored and were dropped. Empty when
-	// the profile is fully honored. Reported as a Degraded condition.
+	// tlsProfileWarning describes cluster TLS profile entries that cannot be
+	// honored; reported as a Degraded condition. Request-scoped.
 	tlsProfileWarning string
 }
 
@@ -151,8 +150,6 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	r.deployments = []client.ObjectKey{}
 	r.daemonSets = []client.ObjectKey{}
-	// Request-scoped state, reset together with deployments/daemonSets so a
-	// failed reconcile cannot leak a stale warning into the next run.
 	r.tlsProfileWarning = ""
 
 	if err := r.applyManifests(instance, ctx); err != nil {
@@ -419,8 +416,8 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 		if err != nil {
 			return fmt.Errorf("failed fetching TLS profile for ConfigMap: %w", err)
 		}
-		// Strict adherence: refuse to roll out a profile the components
-		// cannot honor; it would crash-loop the TLS-serving pods.
+		// Refuse to roll out a profile the components cannot honor; it
+		// would crash-loop the TLS-serving pods.
 		_, unsupported, err := nmstatetls.NewTLSConfigFromProfile(tlsProfileSpec)
 		if err != nil {
 			return fmt.Errorf("cluster TLS profile cannot be honored: %w", err)
@@ -640,8 +637,6 @@ func (r *NMStateReconciler) reconcileStatus(ctx context.Context, instance *nmsta
 			"All components are available and ready",
 		)
 		if r.tlsProfileWarning != "" {
-			// The cluster TLS profile contains entries the components
-			// cannot honor; the served config is a strict subset.
 			instance.Status.Conditions.Set(
 				shared.NmstateConditionDegraded,
 				corev1.ConditionTrue,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -71,10 +71,14 @@ func FetchTLSProfileFromFile(path string) (func(*tls.Config), nmstatetls.TLSProf
 		return nil, nmstatetls.TLSProfileSpec{}, fmt.Errorf("failed parsing TLS profile from %s: %w", path, err)
 	}
 
-	tlsOpts, unsupportedCiphers := nmstatetls.NewTLSConfigFromProfile(spec)
-	if len(unsupportedCiphers) > 0 {
-		log.Info("TLS configuration contains unsupported ciphers that will be ignored",
-			"unsupportedCiphers", unsupportedCiphers)
+	tlsOpts, unsupported, err := nmstatetls.NewTLSConfigFromProfile(spec)
+	if err != nil {
+		// Fail closed: serving with Go defaults could exceed the profile.
+		return nil, nmstatetls.TLSProfileSpec{}, fmt.Errorf("TLS profile from %s cannot be honored: %w", path, err)
+	}
+	if !unsupported.IsEmpty() {
+		log.Info("TLS profile contains unsupported entries that will be ignored",
+			"details", unsupported.Message())
 	}
 
 	return tlsOpts, spec, nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -73,7 +73,6 @@ func FetchTLSProfileFromFile(path string) (func(*tls.Config), nmstatetls.TLSProf
 
 	tlsOpts, unsupported, err := nmstatetls.NewTLSConfigFromProfile(spec)
 	if err != nil {
-		// Fail closed: serving with Go defaults could exceed the profile.
 		return nil, nmstatetls.TLSProfileSpec{}, fmt.Errorf("TLS profile from %s cannot be honored: %w", path, err)
 	}
 	if !unsupported.IsEmpty() {

--- a/pkg/tls/ciphers.go
+++ b/pkg/tls/ciphers.go
@@ -101,14 +101,6 @@ func tlsVersion(versionName string) (uint16, error) {
 	return 0, fmt.Errorf("unknown tls version %q", versionName)
 }
 
-func tlsVersionOrDie(versionName string) uint16 {
-	version, err := tlsVersion(versionName)
-	if err != nil {
-		panic(err)
-	}
-	return version
-}
-
 func cipherSuite(cipherName string) (uint16, error) {
 	if cipher, ok := ianaCiphers[cipherName]; ok {
 		return cipher, nil

--- a/pkg/tls/ciphers.go
+++ b/pkg/tls/ciphers.go
@@ -147,3 +147,22 @@ func cipherCodes(ciphers []string) (codes []uint16, unsupportedCiphers []string)
 	}
 	return codes, unsupportedCiphers
 }
+
+// tls13CipherSuiteIDs are the codes of the cipher suites in tls13CipherSuiteNames.
+var tls13CipherSuiteIDs = map[uint16]bool{
+	tls.TLS_AES_128_GCM_SHA256:       true,
+	tls.TLS_AES_256_GCM_SHA384:       true,
+	tls.TLS_CHACHA20_POLY1305_SHA256: true,
+}
+
+// tls12CipherCodes returns only the codes applicable to TLS 1.2 and older;
+// tls.Config.CipherSuites must not contain TLS 1.3 suite IDs.
+func tls12CipherCodes(codes []uint16) []uint16 {
+	tls12Codes := []uint16{}
+	for _, code := range codes {
+		if !tls13CipherSuiteIDs[code] {
+			tls12Codes = append(tls12Codes, code)
+		}
+	}
+	return tls12Codes
+}

--- a/pkg/tls/curves.go
+++ b/pkg/tls/curves.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import "crypto/tls"
+
+// curveIDs maps TLS group (curve) names to Go tls.CurveID constants.
+// IANA names plus common OpenSSL/NIST aliases are accepted.
+var curveIDs = map[string]tls.CurveID{
+	"X25519MLKEM768": tls.X25519MLKEM768,
+	"X25519":         tls.X25519,
+	"x25519":         tls.X25519,
+	"secp256r1":      tls.CurveP256,
+	"prime256v1":     tls.CurveP256,
+	"P-256":          tls.CurveP256,
+	"secp384r1":      tls.CurveP384,
+	"P-384":          tls.CurveP384,
+	"secp521r1":      tls.CurveP521,
+	"P-521":          tls.CurveP521,
+}
+
+// curveCodes converts a list of curve names to tls.CurveID values,
+// preserving order. Unknown names are returned in unsupported.
+func curveCodes(curves []string) (codes []tls.CurveID, unsupported []string) {
+	for _, name := range curves {
+		if id, ok := curveIDs[name]; ok {
+			codes = append(codes, id)
+			continue
+		}
+		unsupported = append(unsupported, name)
+	}
+	return codes, unsupported
+}

--- a/pkg/tls/curves_test.go
+++ b/pkg/tls/curves_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("curveCodes", func() {
+	It("maps IANA names to tls.CurveID", func() {
+		codes, unsupported := curveCodes([]string{"X25519MLKEM768", "X25519", "secp256r1", "secp384r1", "secp521r1"})
+		Expect(unsupported).To(BeEmpty())
+		Expect(codes).To(Equal([]tls.CurveID{
+			tls.X25519MLKEM768, tls.X25519, tls.CurveP256, tls.CurveP384, tls.CurveP521,
+		}))
+	})
+
+	It("maps common aliases", func() {
+		codes, unsupported := curveCodes([]string{"x25519", "prime256v1", "P-256", "P-384", "P-521"})
+		Expect(unsupported).To(BeEmpty())
+		Expect(codes).To(Equal([]tls.CurveID{
+			tls.X25519, tls.CurveP256, tls.CurveP256, tls.CurveP384, tls.CurveP521,
+		}))
+	})
+
+	It("reports unsupported names and keeps supported ones", func() {
+		codes, unsupported := curveCodes([]string{"X25519", "brainpoolP256r1", "ffdhe2048"})
+		Expect(codes).To(Equal([]tls.CurveID{tls.X25519}))
+		Expect(unsupported).To(Equal([]string{"brainpoolP256r1", "ffdhe2048"}))
+	})
+
+	It("returns empty results for empty input", func() {
+		codes, unsupported := curveCodes(nil)
+		Expect(codes).To(BeEmpty())
+		Expect(unsupported).To(BeEmpty())
+	})
+})

--- a/pkg/tls/mlkem_test.go
+++ b/pkg/tls/mlkem_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	cryptotls "crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// selfSignedCert generates an in-memory ECDSA certificate for 127.0.0.1.
+func selfSignedCert() cryptotls.Certificate {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	Expect(err).NotTo(HaveOccurred())
+	return cryptotls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// handshake starts a TLS server configured through NewTLSConfigFromProfile
+// and connects with a default Go client. It returns the negotiated
+// connection state observed by the client.
+func handshake(profile TLSProfileSpec) cryptotls.ConnectionState {
+	opts, _, err := NewTLSConfigFromProfile(profile)
+	Expect(err).NotTo(HaveOccurred())
+
+	serverConf := &cryptotls.Config{Certificates: []cryptotls.Certificate{selfSignedCert()}}
+	opts(serverConf)
+
+	listener, err := cryptotls.Listen("tcp", "127.0.0.1:0", serverConf)
+	Expect(err).NotTo(HaveOccurred())
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer GinkgoRecover()
+		defer close(done)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		// Drive the handshake from the server side.
+		_ = conn.(*cryptotls.Conn).Handshake()
+	}()
+
+	clientConf := &cryptotls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only client
+	conn, err := cryptotls.Dial("tcp", listener.Addr().String(), clientConf)
+	Expect(err).NotTo(HaveOccurred())
+	defer conn.Close()
+	Expect(conn.Handshake()).To(Succeed())
+	state := conn.ConnectionState()
+	<-done
+	return state
+}
+
+var _ = Describe("ML-KEM key exchange", func() {
+	It("is negotiated under the Intermediate profile", func() {
+		state := handshake(*TLSProfiles[TLSProfileIntermediateType])
+		Expect(state.Version).To(Equal(uint16(cryptotls.VersionTLS13)))
+		Expect(state.CurveID).To(Equal(cryptotls.X25519MLKEM768))
+	})
+
+	It("is negotiated under the Modern profile", func() {
+		state := handshake(*TLSProfiles[TLSProfileModernType])
+		Expect(state.Version).To(Equal(uint16(cryptotls.VersionTLS13)))
+		Expect(state.CurveID).To(Equal(cryptotls.X25519MLKEM768))
+	})
+
+	It("is negotiated when the profile explicitly allows it", func() {
+		state := handshake(TLSProfileSpec{
+			MinTLSVersion: VersionTLS13,
+			Curves:        []string{"X25519MLKEM768", "X25519"},
+		})
+		Expect(state.CurveID).To(Equal(cryptotls.X25519MLKEM768))
+	})
+
+	It("is NOT negotiated when the profile restricts curves", func() {
+		state := handshake(TLSProfileSpec{
+			MinTLSVersion: VersionTLS13,
+			Curves:        []string{"secp256r1"},
+		})
+		Expect(state.CurveID).To(Equal(cryptotls.CurveP256))
+	})
+})

--- a/pkg/tls/mlkem_test.go
+++ b/pkg/tls/mlkem_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package tls
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -74,14 +75,15 @@ func handshake(profile TLSProfileSpec) cryptotls.ConnectionState {
 		}
 		defer conn.Close()
 		// Drive the handshake from the server side.
-		_ = conn.(*cryptotls.Conn).Handshake()
+		_ = conn.(*cryptotls.Conn).HandshakeContext(context.Background())
 	}()
 
 	clientConf := &cryptotls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only client
-	conn, err := cryptotls.Dial("tcp", listener.Addr().String(), clientConf)
+	dialer := &cryptotls.Dialer{Config: clientConf}
+	rawConn, err := dialer.DialContext(context.Background(), "tcp", listener.Addr().String())
 	Expect(err).NotTo(HaveOccurred())
+	conn := rawConn.(*cryptotls.Conn)
 	defer conn.Close()
-	Expect(conn.Handshake()).To(Succeed())
 	state := conn.ConnectionState()
 	<-done
 	return state

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -38,15 +38,12 @@ var (
 	ErrCustomProfileNil = errors.New("custom TLS profile specified but Custom field is nil")
 
 	// ErrUnknownProfileType is returned when the profile type is not recognized.
-	// Strict adherence forbids guessing a fallback profile.
 	ErrUnknownProfileType = errors.New("unknown TLS profile type")
 
-	// ErrNoSupportedCiphers is returned when the profile names ciphers but none
-	// are supported; falling back to Go defaults could exceed the profile.
+	// ErrNoSupportedCiphers is returned when none of the profile ciphers is supported.
 	ErrNoSupportedCiphers = errors.New("TLS profile specifies ciphers but none are supported")
 
-	// ErrNoSupportedCurves is returned when the profile names curves but none
-	// are supported; falling back to Go defaults could exceed the profile.
+	// ErrNoSupportedCurves is returned when none of the profile curves is supported.
 	ErrNoSupportedCurves = errors.New("TLS profile specifies curves but none are supported")
 
 	apiServerGVK = schema.GroupVersionKind{
@@ -124,9 +121,8 @@ type tlsSecurityProfile struct {
 }
 
 // GetTLSProfileSpec returns a TLSProfileSpec for the given profile.
-// If no profile is configured, the default Intermediate profile is returned.
-// Unknown profile types are an error: strict adherence forbids silently
-// serving a different profile than the one configured.
+// If no profile is configured, the default Intermediate profile is returned;
+// unknown profile types are an error.
 func GetTLSProfileSpec(profile *tlsSecurityProfile) (TLSProfileSpec, error) {
 	if profile == nil || profile.profileType == "" {
 		return *TLSProfiles[TLSProfileIntermediateType], nil
@@ -146,26 +142,21 @@ func GetTLSProfileSpec(profile *tlsSecurityProfile) (TLSProfileSpec, error) {
 	return *profile.customSpec, nil
 }
 
-// tls13CipherSuiteNames are the TLS 1.3 cipher suites Go always enables.
-// They cannot be restricted via tls.Config.CipherSuites.
+// tls13CipherSuiteNames are the TLS 1.3 cipher suites Go always enables;
+// they cannot be restricted via tls.Config.CipherSuites.
 var tls13CipherSuiteNames = []string{
 	"TLS_AES_128_GCM_SHA256",
 	"TLS_AES_256_GCM_SHA384",
 	"TLS_CHACHA20_POLY1305_SHA256",
 }
 
-// UnsupportedEntries lists profile entries that Go cannot honor and that
-// were dropped, as well as restrictions that Go cannot enforce. Dropping
-// entries keeps the served configuration a strict subset of the profile,
-// which is still adherent, but must be reported. Unenforceable
-// restrictions mean the served configuration exceeds the profile and must
-// be reported too.
+// UnsupportedEntries lists profile entries that were dropped because Go does
+// not support them, and restrictions that Go cannot enforce.
 type UnsupportedEntries struct {
 	Ciphers []string
 	Curves  []string
 	// UnenforceableCiphers lists TLS 1.3 cipher suites that Go always
-	// offers even though the profile excludes them: Go does not allow
-	// restricting TLS 1.3 cipher suites.
+	// offers even though the profile excludes them.
 	UnenforceableCiphers []string
 }
 
@@ -174,8 +165,7 @@ func (u UnsupportedEntries) IsEmpty() bool {
 	return len(u.Ciphers) == 0 && len(u.Curves) == 0 && len(u.UnenforceableCiphers) == 0
 }
 
-// Message returns a human-readable description of the dropped entries and
-// unenforceable restrictions.
+// Message returns a human-readable description of the entries.
 func (u UnsupportedEntries) Message() string {
 	parts := []string{}
 	if len(u.Ciphers) > 0 {
@@ -196,7 +186,6 @@ func (u UnsupportedEntries) Message() string {
 // offer even though the profile's cipher list excludes them.
 func unenforceableTLS13Ciphers(profileCiphers []string) []string {
 	if len(profileCiphers) == 0 {
-		// No cipher restriction requested; Go defaults are within profile.
 		return nil
 	}
 	allowed := map[string]bool{}
@@ -214,13 +203,8 @@ func unenforceableTLS13Ciphers(profileCiphers []string) []string {
 
 // NewTLSConfigFromProfile returns a function that configures a tls.Config
 // based on the provided TLSProfileSpec, along with any profile entries that
-// are not supported and were dropped.
-//
-// It fails closed (returns an error) when the profile cannot be honored at
-// all: unknown minimum TLS version, no supported cipher while the minimum
-// version is below TLS 1.3, or no supported curve while curves are
-// specified. In those cases serving would silently fall back to Go defaults
-// that may exceed the profile.
+// could not be honored. It returns an error when the profile cannot be
+// honored at all, instead of falling back to Go defaults that may exceed it.
 func NewTLSConfigFromProfile(profile TLSProfileSpec) (func(*tls.Config), UnsupportedEntries, error) {
 	minVersion, err := tlsVersion(string(profile.MinTLSVersion))
 	if err != nil {

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -146,32 +146,70 @@ func GetTLSProfileSpec(profile *tlsSecurityProfile) (TLSProfileSpec, error) {
 	return *profile.customSpec, nil
 }
 
+// tls13CipherSuiteNames are the TLS 1.3 cipher suites Go always enables.
+// They cannot be restricted via tls.Config.CipherSuites.
+var tls13CipherSuiteNames = []string{
+	"TLS_AES_128_GCM_SHA256",
+	"TLS_AES_256_GCM_SHA384",
+	"TLS_CHACHA20_POLY1305_SHA256",
+}
+
 // UnsupportedEntries lists profile entries that Go cannot honor and that
-// were dropped. Dropping entries keeps the served configuration a strict
-// subset of the profile, which is still adherent, but must be reported.
+// were dropped, as well as restrictions that Go cannot enforce. Dropping
+// entries keeps the served configuration a strict subset of the profile,
+// which is still adherent, but must be reported. Unenforceable
+// restrictions mean the served configuration exceeds the profile and must
+// be reported too.
 type UnsupportedEntries struct {
 	Ciphers []string
 	Curves  []string
+	// UnenforceableCiphers lists TLS 1.3 cipher suites that Go always
+	// offers even though the profile excludes them: Go does not allow
+	// restricting TLS 1.3 cipher suites.
+	UnenforceableCiphers []string
 }
 
-// IsEmpty returns true when every profile entry is supported.
+// IsEmpty returns true when every profile entry is supported and enforceable.
 func (u UnsupportedEntries) IsEmpty() bool {
-	return len(u.Ciphers) == 0 && len(u.Curves) == 0
+	return len(u.Ciphers) == 0 && len(u.Curves) == 0 && len(u.UnenforceableCiphers) == 0
 }
 
-// Message returns a human-readable description of the dropped entries.
+// Message returns a human-readable description of the dropped entries and
+// unenforceable restrictions.
 func (u UnsupportedEntries) Message() string {
-	msg := ""
+	parts := []string{}
 	if len(u.Ciphers) > 0 {
-		msg += fmt.Sprintf("unsupported ciphers ignored: %s", strings.Join(u.Ciphers, ", "))
+		parts = append(parts, fmt.Sprintf("unsupported ciphers ignored: %s", strings.Join(u.Ciphers, ", ")))
 	}
 	if len(u.Curves) > 0 {
-		if msg != "" {
-			msg += "; "
-		}
-		msg += fmt.Sprintf("unsupported curves ignored: %s", strings.Join(u.Curves, ", "))
+		parts = append(parts, fmt.Sprintf("unsupported curves ignored: %s", strings.Join(u.Curves, ", ")))
 	}
-	return msg
+	if len(u.UnenforceableCiphers) > 0 {
+		parts = append(parts, fmt.Sprintf(
+			"Go cannot restrict TLS 1.3 cipher suites, these are offered beyond the profile: %s",
+			strings.Join(u.UnenforceableCiphers, ", ")))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// unenforceableTLS13Ciphers returns the TLS 1.3 cipher suites that Go will
+// offer even though the profile's cipher list excludes them.
+func unenforceableTLS13Ciphers(profileCiphers []string) []string {
+	if len(profileCiphers) == 0 {
+		// No cipher restriction requested; Go defaults are within profile.
+		return nil
+	}
+	allowed := map[string]bool{}
+	for _, c := range profileCiphers {
+		allowed[c] = true
+	}
+	unenforceable := []string{}
+	for _, c := range tls13CipherSuiteNames {
+		if !allowed[c] {
+			unenforceable = append(unenforceable, c)
+		}
+	}
+	return unenforceable
 }
 
 // NewTLSConfigFromProfile returns a function that configures a tls.Config
@@ -190,7 +228,11 @@ func NewTLSConfigFromProfile(profile TLSProfileSpec) (func(*tls.Config), Unsuppo
 	}
 	cipherSuites, unsupportedCiphers := cipherCodes(profile.Ciphers)
 	curves, unsupportedCurves := curveCodes(profile.Curves)
-	unsupported := UnsupportedEntries{Ciphers: unsupportedCiphers, Curves: unsupportedCurves}
+	unsupported := UnsupportedEntries{
+		Ciphers:              unsupportedCiphers,
+		Curves:               unsupportedCurves,
+		UnenforceableCiphers: unenforceableTLS13Ciphers(profile.Ciphers),
+	}
 
 	if len(profile.Ciphers) > 0 && len(cipherSuites) == 0 && minVersion < tls.VersionTLS13 {
 		return nil, unsupported, ErrNoSupportedCiphers

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,6 +36,18 @@ const (
 var (
 	// ErrCustomProfileNil is returned when a custom TLS profile is specified but the Custom field is nil.
 	ErrCustomProfileNil = errors.New("custom TLS profile specified but Custom field is nil")
+
+	// ErrUnknownProfileType is returned when the profile type is not recognized.
+	// Strict adherence forbids guessing a fallback profile.
+	ErrUnknownProfileType = errors.New("unknown TLS profile type")
+
+	// ErrNoSupportedCiphers is returned when the profile names ciphers but none
+	// are supported; falling back to Go defaults could exceed the profile.
+	ErrNoSupportedCiphers = errors.New("TLS profile specifies ciphers but none are supported")
+
+	// ErrNoSupportedCurves is returned when the profile names curves but none
+	// are supported; falling back to Go defaults could exceed the profile.
+	ErrNoSupportedCurves = errors.New("TLS profile specifies curves but none are supported")
 
 	apiServerGVK = schema.GroupVersionKind{
 		Group:   "config.openshift.io",
@@ -112,18 +125,18 @@ type tlsSecurityProfile struct {
 
 // GetTLSProfileSpec returns a TLSProfileSpec for the given profile.
 // If no profile is configured, the default Intermediate profile is returned.
+// Unknown profile types are an error: strict adherence forbids silently
+// serving a different profile than the one configured.
 func GetTLSProfileSpec(profile *tlsSecurityProfile) (TLSProfileSpec, error) {
-	defaultProfile := *TLSProfiles[TLSProfileIntermediateType]
-
 	if profile == nil || profile.profileType == "" {
-		return defaultProfile, nil
+		return *TLSProfiles[TLSProfileIntermediateType], nil
 	}
 
 	if profile.profileType != TLSProfileCustomType {
 		if tlsConfig, ok := TLSProfiles[profile.profileType]; ok {
 			return *tlsConfig, nil
 		}
-		return defaultProfile, nil
+		return TLSProfileSpec{}, fmt.Errorf("%w: %q", ErrUnknownProfileType, profile.profileType)
 	}
 
 	if profile.customSpec == nil {
@@ -133,11 +146,58 @@ func GetTLSProfileSpec(profile *tlsSecurityProfile) (TLSProfileSpec, error) {
 	return *profile.customSpec, nil
 }
 
-// NewTLSConfigFromProfile returns a function that configures a tls.Config based on the provided TLSProfileSpec,
-// along with any cipher names from the profile that are not supported.
-func NewTLSConfigFromProfile(profile TLSProfileSpec) (tlsConfig func(*tls.Config), unsupportedCiphers []string) {
-	minVersion := tlsVersionOrDie(string(profile.MinTLSVersion))
-	cipherSuites, unsupported := cipherCodes(profile.Ciphers)
+// UnsupportedEntries lists profile entries that Go cannot honor and that
+// were dropped. Dropping entries keeps the served configuration a strict
+// subset of the profile, which is still adherent, but must be reported.
+type UnsupportedEntries struct {
+	Ciphers []string
+	Curves  []string
+}
+
+// IsEmpty returns true when every profile entry is supported.
+func (u UnsupportedEntries) IsEmpty() bool {
+	return len(u.Ciphers) == 0 && len(u.Curves) == 0
+}
+
+// Message returns a human-readable description of the dropped entries.
+func (u UnsupportedEntries) Message() string {
+	msg := ""
+	if len(u.Ciphers) > 0 {
+		msg += fmt.Sprintf("unsupported ciphers ignored: %s", strings.Join(u.Ciphers, ", "))
+	}
+	if len(u.Curves) > 0 {
+		if msg != "" {
+			msg += "; "
+		}
+		msg += fmt.Sprintf("unsupported curves ignored: %s", strings.Join(u.Curves, ", "))
+	}
+	return msg
+}
+
+// NewTLSConfigFromProfile returns a function that configures a tls.Config
+// based on the provided TLSProfileSpec, along with any profile entries that
+// are not supported and were dropped.
+//
+// It fails closed (returns an error) when the profile cannot be honored at
+// all: unknown minimum TLS version, no supported cipher while the minimum
+// version is below TLS 1.3, or no supported curve while curves are
+// specified. In those cases serving would silently fall back to Go defaults
+// that may exceed the profile.
+func NewTLSConfigFromProfile(profile TLSProfileSpec) (func(*tls.Config), UnsupportedEntries, error) {
+	minVersion, err := tlsVersion(string(profile.MinTLSVersion))
+	if err != nil {
+		return nil, UnsupportedEntries{}, err
+	}
+	cipherSuites, unsupportedCiphers := cipherCodes(profile.Ciphers)
+	curves, unsupportedCurves := curveCodes(profile.Curves)
+	unsupported := UnsupportedEntries{Ciphers: unsupportedCiphers, Curves: unsupportedCurves}
+
+	if len(profile.Ciphers) > 0 && len(cipherSuites) == 0 && minVersion < tls.VersionTLS13 {
+		return nil, unsupported, ErrNoSupportedCiphers
+	}
+	if len(profile.Curves) > 0 && len(curves) == 0 {
+		return nil, unsupported, ErrNoSupportedCurves
+	}
 
 	return func(tlsConf *tls.Config) {
 		tlsConf.MinVersion = minVersion
@@ -145,5 +205,8 @@ func NewTLSConfigFromProfile(profile TLSProfileSpec) (tlsConfig func(*tls.Config
 		if minVersion != tls.VersionTLS13 {
 			tlsConf.CipherSuites = cipherSuites
 		}
-	}, unsupported
+		if len(curves) > 0 {
+			tlsConf.CurvePreferences = curves
+		}
+	}, unsupported, nil
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -92,9 +92,12 @@ func parseTLSSecurityProfile(obj map[string]any) (*tlsSecurityProfile, error) {
 
 		ciphersRaw, _, _ := unstructured.NestedStringSlice(customMap, "ciphers")
 
+		curvesRaw, _, _ := unstructured.NestedStringSlice(customMap, "curves")
+
 		profile.customSpec = &TLSProfileSpec{
 			Ciphers:       ciphersRaw,
 			MinTLSVersion: TLSProtocolVersion(minVersion),
+			Curves:        curvesRaw,
 		}
 	}
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -225,11 +225,19 @@ func NewTLSConfigFromProfile(profile TLSProfileSpec) (func(*tls.Config), Unsuppo
 		return nil, unsupported, ErrNoSupportedCurves
 	}
 
+	// tls.Config.CipherSuites only applies to TLS 1.2 and older. When the
+	// profile permits no TLS 1.2 cipher, serve TLS 1.3 only: leaving
+	// CipherSuites nil would fall back to Go's default TLS 1.2 ciphers.
+	tls12CipherSuites := tls12CipherCodes(cipherSuites)
+	if len(profile.Ciphers) > 0 && len(tls12CipherSuites) == 0 && minVersion < tls.VersionTLS13 {
+		minVersion = tls.VersionTLS13
+	}
+
 	return func(tlsConf *tls.Config) {
 		tlsConf.MinVersion = minVersion
 		// TLS 1.3 cipher suites are not configurable in Go.
 		if minVersion != tls.VersionTLS13 {
-			tlsConf.CipherSuites = cipherSuites
+			tlsConf.CipherSuites = tls12CipherSuites
 		}
 		if len(curves) > 0 {
 			tlsConf.CurvePreferences = curves

--- a/pkg/tls/tls_suite_test.go
+++ b/pkg/tls/tls_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Profile Test Suite")
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package tls
 
 import (
+	cryptotls "crypto/tls"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -74,5 +76,86 @@ var _ = Describe("GetTLSProfileSpec", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(spec.MinTLSVersion).To(Equal(VersionTLS13))
 		Expect(spec.Curves).To(BeEmpty())
+	})
+})
+
+var _ = Describe("GetTLSProfileSpec strictness", func() {
+	It("errors on unknown profile type instead of falling back", func() {
+		_, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: TLSProfileType("Bogus")})
+		Expect(err).To(MatchError(ErrUnknownProfileType))
+	})
+
+	It("errors on Custom profile with nil spec", func() {
+		_, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: TLSProfileCustomType})
+		Expect(err).To(MatchError(ErrCustomProfileNil))
+	})
+})
+
+var _ = Describe("NewTLSConfigFromProfile", func() {
+	It("applies min version, ciphers and curves", func() {
+		opts, unsupported, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS12,
+			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+			Curves:        []string{"X25519MLKEM768", "X25519"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unsupported.IsEmpty()).To(BeTrue())
+		conf := &cryptotls.Config{}
+		opts(conf)
+		Expect(conf.MinVersion).To(Equal(uint16(cryptotls.VersionTLS12)))
+		Expect(conf.CipherSuites).To(Equal([]uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}))
+		Expect(conf.CurvePreferences).To(Equal([]cryptotls.CurveID{cryptotls.X25519MLKEM768, cryptotls.X25519}))
+	})
+
+	It("leaves CurvePreferences nil when profile has no curves", func() {
+		opts, _, err := NewTLSConfigFromProfile(*TLSProfiles[TLSProfileIntermediateType])
+		Expect(err).NotTo(HaveOccurred())
+		conf := &cryptotls.Config{}
+		opts(conf)
+		Expect(conf.CurvePreferences).To(BeNil())
+	})
+
+	It("reports partially unsupported entries but still succeeds", func() {
+		_, unsupported, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS12,
+			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "NOT-A-CIPHER"},
+			Curves:        []string{"X25519", "brainpoolP256r1"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unsupported.Ciphers).To(Equal([]string{"NOT-A-CIPHER"}))
+		Expect(unsupported.Curves).To(Equal([]string{"brainpoolP256r1"}))
+		Expect(unsupported.Message()).To(ContainSubstring("NOT-A-CIPHER"))
+		Expect(unsupported.Message()).To(ContainSubstring("brainpoolP256r1"))
+	})
+
+	It("fails closed when no cipher is supported below TLS 1.3", func() {
+		_, _, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS12,
+			Ciphers:       []string{"NOT-A-CIPHER"},
+		})
+		Expect(err).To(MatchError(ErrNoSupportedCiphers))
+	})
+
+	It("does not fail on unsupported ciphers with TLS 1.3 minimum", func() {
+		_, _, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS13,
+			Ciphers:       []string{"NOT-A-CIPHER"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("fails closed when no curve is supported", func() {
+		_, _, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS13,
+			Curves:        []string{"brainpoolP256r1"},
+		})
+		Expect(err).To(MatchError(ErrNoSupportedCurves))
+	})
+
+	It("fails closed on unknown minimum TLS version", func() {
+		_, _, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: TLSProtocolVersion("VersionTLS99"),
+		})
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func apiServerObj(tlsSecurityProfile map[string]any) map[string]any {
+	spec := map[string]any{}
+	if tlsSecurityProfile != nil {
+		spec["tlsSecurityProfile"] = tlsSecurityProfile
+	}
+	return map[string]any{
+		"apiVersion": "config.openshift.io/v1",
+		"kind":       "APIServer",
+		"metadata":   map[string]any{"name": "cluster"},
+		"spec":       spec,
+	}
+}
+
+var _ = Describe("parseTLSSecurityProfile", func() {
+	It("parses custom profile curves", func() {
+		profile, err := parseTLSSecurityProfile(apiServerObj(map[string]any{
+			"type": "Custom",
+			"custom": map[string]any{
+				"minTLSVersion": "VersionTLS12",
+				"ciphers":       []any{"TLS_AES_128_GCM_SHA256"},
+				"curves":        []any{"X25519MLKEM768", "X25519"},
+			},
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile.customSpec.Curves).To(Equal([]string{"X25519MLKEM768", "X25519"}))
+	})
+
+	It("leaves curves nil when absent", func() {
+		profile, err := parseTLSSecurityProfile(apiServerObj(map[string]any{
+			"type": "Custom",
+			"custom": map[string]any{
+				"minTLSVersion": "VersionTLS12",
+				"ciphers":       []any{"TLS_AES_128_GCM_SHA256"},
+			},
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(profile.customSpec.Curves).To(BeNil())
+	})
+})
+
+var _ = Describe("GetTLSProfileSpec", func() {
+	It("defaults to Intermediate when no profile is set", func() {
+		spec, err := GetTLSProfileSpec(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).To(Equal(*TLSProfiles[TLSProfileIntermediateType]))
+	})
+
+	It("returns named profiles without curves", func() {
+		spec, err := GetTLSProfileSpec(&tlsSecurityProfile{profileType: TLSProfileModernType})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.MinTLSVersion).To(Equal(VersionTLS13))
+		Expect(spec.Curves).To(BeEmpty())
+	})
+})

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -109,12 +109,26 @@ var _ = Describe("NewTLSConfigFromProfile", func() {
 		opts(conf)
 		Expect(conf.MinVersion).To(Equal(uint16(cryptotls.VersionTLS12)))
 		Expect(conf.CipherSuites).To(Equal([]uint16{
-			cryptotls.TLS_AES_128_GCM_SHA256,
-			cryptotls.TLS_AES_256_GCM_SHA384,
-			cryptotls.TLS_CHACHA20_POLY1305_SHA256,
 			cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		}))
+		}), "CipherSuites must only carry TLS 1.2 and older suite IDs")
 		Expect(conf.CurvePreferences).To(Equal([]cryptotls.CurveID{cryptotls.X25519MLKEM768, cryptotls.X25519}))
+	})
+
+	It("serves TLS 1.3 only when the profile permits no TLS 1.2 ciphers", func() {
+		opts, unsupported, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS12,
+			Ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unsupported.IsEmpty()).To(BeTrue())
+		conf := &cryptotls.Config{}
+		opts(conf)
+		Expect(conf.MinVersion).To(Equal(uint16(cryptotls.VersionTLS13)))
+		Expect(conf.CipherSuites).To(BeNil())
 	})
 
 	It("reports TLS 1.3 cipher restrictions Go cannot enforce", func() {

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -95,16 +95,49 @@ var _ = Describe("NewTLSConfigFromProfile", func() {
 	It("applies min version, ciphers and curves", func() {
 		opts, unsupported, err := NewTLSConfigFromProfile(TLSProfileSpec{
 			MinTLSVersion: VersionTLS12,
-			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
-			Curves:        []string{"X25519MLKEM768", "X25519"},
+			Ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+			},
+			Curves: []string{"X25519MLKEM768", "X25519"},
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(unsupported.IsEmpty()).To(BeTrue())
 		conf := &cryptotls.Config{}
 		opts(conf)
 		Expect(conf.MinVersion).To(Equal(uint16(cryptotls.VersionTLS12)))
-		Expect(conf.CipherSuites).To(Equal([]uint16{cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}))
+		Expect(conf.CipherSuites).To(Equal([]uint16{
+			cryptotls.TLS_AES_128_GCM_SHA256,
+			cryptotls.TLS_AES_256_GCM_SHA384,
+			cryptotls.TLS_CHACHA20_POLY1305_SHA256,
+			cryptotls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		}))
 		Expect(conf.CurvePreferences).To(Equal([]cryptotls.CurveID{cryptotls.X25519MLKEM768, cryptotls.X25519}))
+	})
+
+	It("reports TLS 1.3 cipher restrictions Go cannot enforce", func() {
+		_, unsupported, err := NewTLSConfigFromProfile(TLSProfileSpec{
+			MinTLSVersion: VersionTLS12,
+			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "TLS_AES_128_GCM_SHA256"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unsupported.IsEmpty()).To(BeFalse())
+		Expect(unsupported.UnenforceableCiphers).To(Equal([]string{
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+		}))
+		Expect(unsupported.Message()).To(ContainSubstring("TLS_AES_256_GCM_SHA384"))
+		Expect(unsupported.Message()).To(ContainSubstring("cannot restrict TLS 1.3"))
+	})
+
+	It("does not flag unenforceable ciphers for the predefined profiles", func() {
+		for _, profileType := range []TLSProfileType{TLSProfileOldType, TLSProfileIntermediateType, TLSProfileModernType} {
+			_, unsupported, err := NewTLSConfigFromProfile(*TLSProfiles[profileType])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unsupported.IsEmpty()).To(BeTrue(), "profile %s should be fully enforceable", profileType)
+		}
 	})
 
 	It("leaves CurvePreferences nil when profile has no curves", func() {

--- a/pkg/tls/types.go
+++ b/pkg/tls/types.go
@@ -41,9 +41,8 @@ const (
 type TLSProfileSpec struct {
 	Ciphers       []string           `json:"ciphers"`
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion"`
-	// Curves lists the TLS key exchange groups (curves) allowed by the
-	// profile. Empty means Go defaults, which keep the post-quantum
-	// X25519MLKEM768 group enabled.
+	// Curves lists the allowed TLS key exchange groups; empty means Go
+	// defaults (post-quantum X25519MLKEM768 included).
 	Curves []string `json:"curves,omitempty"`
 }
 

--- a/pkg/tls/types.go
+++ b/pkg/tls/types.go
@@ -41,6 +41,10 @@ const (
 type TLSProfileSpec struct {
 	Ciphers       []string           `json:"ciphers"`
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion"`
+	// Curves lists the TLS key exchange groups (curves) allowed by the
+	// profile. Empty means Go defaults, which keep the post-quantum
+	// X25519MLKEM768 group enabled.
+	Curves []string `json:"curves,omitempty"`
 }
 
 // TLSProfiles contains the predefined TLS profile specifications.

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nmstate_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nmstate_types.go
@@ -22,7 +22,8 @@ const (
 	NmstateConditionDegraded    ConditionType = "Degraded"
 	NmstateConditionProgressing ConditionType = "Progressing"
 
-	NmstateInternalError        ConditionReason = "InternalError"
-	NmstateDeploying            ConditionReason = "Deploying"
-	NmstateSuccessfullyDeployed ConditionReason = "SuccessfullyDeployed"
+	NmstateInternalError             ConditionReason = "InternalError"
+	NmstateDeploying                 ConditionReason = "Deploying"
+	NmstateSuccessfullyDeployed      ConditionReason = "SuccessfullyDeployed"
+	NmstateTLSProfileNotFullyHonored ConditionReason = "TLSProfileNotFullyHonored"
 )


### PR DESCRIPTION
## What this PR does

Prepares kubernetes-nmstate for strict cluster-wide TLS configuration
adherence and post-quantum readiness:

- Adds `curves` support to the TLS security profile handling: the
  `custom.curves` list from the `APIServer/cluster` resource is parsed,
  propagated through the existing ConfigMap + hash rollout, and applied
  as `tls.Config.CurvePreferences` on the webhook and metrics servers.
  When the profile specifies no curves, Go defaults apply, keeping the
  post-quantum `X25519MLKEM768` key exchange enabled.
- Strict adherence semantics: unknown profile types and profiles whose
  entries are entirely unsupported are now hard errors (fail closed)
  instead of silently falling back to defaults that may exceed the
  profile. Individually unsupported cipher/curve names are dropped
  (still a strict subset of the profile) and reported via a
  `Degraded` condition (`TLSProfileNotFullyHonored`) on the NMState CR.
- Adds unit tests including TLS handshake tests asserting that
  `X25519MLKEM768` is negotiated under the Intermediate/Modern profiles
  and that profile curves are honored.

Vanilla Kubernetes behavior is unchanged (no profile, Go defaults).

```release-note
TLS security profile handling now strictly adheres to the cluster-wide configuration: custom profile `curves` (TLS key exchange groups, including post-quantum X25519MLKEM768) are honored, unknown or unhonorable profiles fail closed instead of falling back to defaults, and partially unsupported profile entries are reported through a new `TLSProfileNotFullyHonored` Degraded condition on the NMState CR.
```
