### PR TITLE
OPNET-794: netpol: restrict metrics ingress to monitoring namespace

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -247,6 +247,7 @@ func (r *NMStateReconciler) applyNetworkPolicies(ctx context.Context, instance *
 	data.Data["HandlerNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
 	data.Data["OperatorNamespace"] = environment.GetEnvVar("OPERATOR_NAMESPACE", "")
 	data.Data["PluginNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "")
+	data.Data["MonitoringNamespace"] = environment.GetEnvVar("MONITORING_NAMESPACE", "")
 	data.Data["IsOpenShift"] = r.IsOpenShift
 
 	return r.renderAndApply(ctx, instance, data, "netpol", true)

--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -45,7 +45,11 @@ spec:
       app: kubernetes-nmstate
       component: kubernetes-nmstate-metrics
   ingress:
-  - ports:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .MonitoringNamespace }}
+    ports:
     - protocol: TCP
       port: 8443
   policyTypes:
@@ -62,12 +66,20 @@ spec:
       app: kubernetes-nmstate
       component: kubernetes-nmstate-metrics
   ingress:
-    - ports:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .MonitoringNamespace }}
+      ports:
         - protocol: TCP
           port: 443
   policyTypes:
     - Ingress
 ---
+# Webhook ingress: kube-apiserver calls webhooks from hostNetwork.
+# We cannot restrict by namespaceSelector because hostNetwork traffic
+# originates from the node IP, not from a pod within a namespace.
+# Restricting with a from: selector would break webhook functionality.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
## Summary

Add `from:` namespaceSelector to metrics NetworkPolicy ingress rules, restricting
scrape access to pods in the configured monitoring namespace only.

## Problem

All four NetworkPolicy ingress rules (metrics-8443, metrics-443, webhook-9443,
webhook-443) specified `ports:` without `from:` selectors, allowing any pod in
any namespace to reach the webhook and metrics endpoints. While a default-deny
policy is in place, the allow rules were over-broad.

## Fix

- **Metrics ingress** (ports 8443, 443): Add `from: namespaceSelector` matching
  `{{ .MonitoringNamespace }}` via the `kubernetes.io/metadata.name` label. Only
  Prometheus pods in the monitoring namespace can now reach the metrics endpoints.

- **Webhook ingress** (ports 9443, 443): Intentionally left without `from:`
  restriction. The kube-apiserver calls webhooks from `hostNetwork` and its
  traffic originates from the node IP, not from a pod within a selectable
  namespace. Adding a `namespaceSelector` would break webhook functionality. A
  comment documents this design decision.

## Testing

- Verified that Prometheus ServiceMonitor `prometheus-k8s` SA in
  `{{ .MonitoringNamespace }}` is the only legitimate metrics scraper (confirmed
  via the RoleBinding in `operator.yaml`).
- Webhook functionality is unaffected since the ingress rules are unchanged.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*