### PR TITLE
OPNET-795: ci: pin GitHub Actions by SHA and add top-level permissions

### DIFF
--- a/.github/workflows/nightly-job-slack-bot.yml
+++ b/.github/workflows/nightly-job-slack-bot.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 5 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: ./automation/nmstate-latest-reporter
@@ -15,10 +18,10 @@ jobs:
     if: github.repository == 'nmstate/kubernetes-nmstate'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./automation/nmstate-latest-reporter/go.mod
 

--- a/.github/workflows/publish-operatorhub.yml
+++ b/.github/workflows/publish-operatorhub.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   OPERATOR_NAME: kubernetes-nmstate-operator
   IMAGE_REGISTRY: quay.io
@@ -25,17 +29,14 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout kubernetes-nmstate
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -115,7 +116,7 @@ jobs:
 
       - name: Checkout OperatorHub repository
         if: ${{ github.event_name == 'release' || github.event.inputs.create_pr == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: k8s-operatorhub/community-operators
           path: operatorhub-repo
@@ -195,7 +196,7 @@ jobs:
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: operator-bundle-${{ env.VERSION }}
           path: |

--- a/.github/workflows/publish-operatorhub.yml
+++ b/.github/workflows/publish-operatorhub.yml
@@ -16,8 +16,7 @@ on:
         default: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   OPERATOR_NAME: kubernetes-nmstate-operator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,10 @@ jobs:
         fetch-depth: 0
     - name: Bump version and push tag
       run: |
-        # Find the latest stable semver tag reachable from HEAD
-        LATEST_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+        # Find the latest stable semver tag reachable from HEAD.
+        # Use '|| true' to prevent pipefail from aborting when grep
+        # finds no matches or head closes the pipe early.
+        LATEST_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
         if [ -z "$LATEST_TAG" ]; then
           echo "Error: no stable semver tag (vMAJOR.MINOR.PATCH) found on this branch"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,25 +21,41 @@ on:
         - release-0.64
         - release-0.52
         - release-0.47
+
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code from ${{ github.event.inputs.baseBranch }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ github.event.inputs.baseBranch }}
         fetch-depth: 0
-    - name: Retrieve last tag
-      uses: actions-ecosystem/action-get-latest-tag@v1
-      id: get-latest-tag
-    - name: Bump version with level ${{ github.event.inputs.baseBranch }}
-      uses: actions-ecosystem/action-bump-semver@v1
-      id: bump-semver
-      with:
-        current_version: ${{ steps.get-latest-tag.outputs.tag }}
-        level:  ${{ github.event.inputs.versionLevel }}
-    - name: Push the new version
-      uses: actions-ecosystem/action-push-tag@v1
-      with:
-        tag: ${{ steps.bump-semver.outputs.new_version }}
+    - name: Bump version and push tag
+      run: |
+        LATEST_TAG=$(git tag --sort=-v:refname | head -n1)
+        if [ -z "$LATEST_TAG" ]; then
+          echo "Error: no existing tags found"
+          exit 1
+        fi
+        echo "Latest tag: $LATEST_TAG"
+
+        VERSION="${LATEST_TAG#v}"
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+        LEVEL="${{ github.event.inputs.versionLevel }}"
+        case "$LEVEL" in
+          major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+          minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+          patch) PATCH=$((PATCH + 1)) ;;
+          *) echo "Unknown level: $LEVEL"; exit 1 ;;
+        esac
+
+        NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+        echo "Bumping $LATEST_TAG -> $NEW_TAG (level: $LEVEL)"
+
+        git tag "$NEW_TAG"
+        git push origin "$NEW_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,22 @@ jobs:
         fetch-depth: 0
     - name: Bump version and push tag
       run: |
-        LATEST_TAG=$(git tag --sort=-v:refname | head -n1)
+        # Find the latest stable semver tag reachable from HEAD
+        LATEST_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
         if [ -z "$LATEST_TAG" ]; then
-          echo "Error: no existing tags found"
+          echo "Error: no stable semver tag (vMAJOR.MINOR.PATCH) found on this branch"
           exit 1
         fi
         echo "Latest tag: $LATEST_TAG"
 
         VERSION="${LATEST_TAG#v}"
         IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+        # Validate parsed components are numeric
+        if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
+          echo "Error: failed to parse version components from $LATEST_TAG"
+          exit 1
+        fi
 
         LEVEL="${{ github.event.inputs.versionLevel }}"
         case "$LEVEL" in


### PR DESCRIPTION
## Summary

Pin all GitHub Actions by commit SHA and add top-level `permissions:` blocks to
all CI workflows, following [OpenSSF Scorecard](https://securityscorecards.dev/)
Pinned-Dependencies and Token-Permissions recommendations.

## Changes

### Actions pinned by SHA

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v2` (release.yml) / `@v4` | `@34e1148…` (v4.3.1) |
| `actions/setup-go` | `@v5` | `@40f1582…` (v5.6.0) |
| `actions/upload-artifact` | `@v4` | `@ea165f8…` (v4.6.2) |
| `actions-ecosystem/*` | `@v1` (3 actions) | **Removed** — replaced with inline shell |

### Third-party actions removed

The three `actions-ecosystem/*` actions (`action-get-latest-tag`,
`action-bump-semver`, `action-push-tag`) are replaced with inline shell in
`release.yml`. These actions are unmaintained (last release 2021) and performed
simple git tag + semver arithmetic operations.

### Top-level permissions

| Workflow | Permissions |
|----------|-------------|
| `release.yml` | `contents: write` |
| `publish-operatorhub.yml` | `contents: read` (OperatorHub PR uses `OPERATORHUB_TOKEN`, not `GITHUB_TOKEN`) |
| `nightly-job-slack-bot.yml` | `contents: read` |

## Why

This addresses `actions/checkout@v2` being deprecated (Node 12 EOL), eliminates
supply-chain risk from mutable tags and unmaintained third-party actions, and
restricts the default `GITHUB_TOKEN` scope.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*