### PR TITLE
ci: label PRs cleared by Copilot review

### DIFF
--- a/.github/workflows/copilot-review-check.yml
+++ b/.github/workflows/copilot-review-check.yml
@@ -1,0 +1,34 @@
+name: Copilot review check
+
+# Unprivileged detection workflow. Runs with a read-only token (including on
+# cross-repository/fork PRs) and only records whether Copilot's review came
+# back clean. The privileged "Copilot review label" workflow (workflow_run)
+# picks up the artifact and applies the label with write permissions.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  detect-clean-copilot-review:
+    name: Detect clean Copilot review
+    if: >-
+      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' &&
+      (contains(github.event.review.body, 'generated no comments') ||
+       contains(github.event.review.body, 'generated no new comments'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record PR information
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p ./pr
+          echo "${PR_NUMBER}" > ./pr/number
+          echo "${HEAD_SHA}" > ./pr/head_sha
+      - name: Upload PR information
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: copilot-clean-review-pr
+          path: pr/

--- a/.github/workflows/copilot-review-label.yml
+++ b/.github/workflows/copilot-review-label.yml
@@ -1,0 +1,102 @@
+name: Copilot review label
+
+# Privileged labeling workflow. Runs in the base repository context with
+# write permissions, so it also works for cross-repository (fork) PRs where
+# the "Copilot review check" workflow only gets a read-only token.
+#
+# Security: no PR code is checked out or executed here. The PR number and
+# head SHA come from an artifact uploaded by the unprivileged workflow, so
+# they are validated (numeric PR number, head SHA cross-checked against the
+# triggering workflow run) before being used.
+on:
+  workflow_run:
+    workflows: ["Copilot review check"]
+    types: [completed]
+  pull_request_target:
+    types: [review_requested]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  add-label:
+    name: Add good-for-human label
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR information
+        id: download
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # The check workflow concludes successfully with a skipped job (and
+          # no artifact) for non-clean or non-Copilot reviews; treat a missing
+          # artifact as a no-op instead of failing.
+          if gh run download "${RUN_ID}" \
+            --repo "${{ github.repository }}" \
+            --name copilot-clean-review-pr \
+            --dir pr; then
+            echo "found=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "No clean Copilot review artifact, nothing to do"
+            echo "found=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Add label
+        if: steps.download.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr_number="$(cat pr/number)"
+          head_sha="$(cat pr/head_sha)"
+          if ! [[ "${pr_number}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number in artifact" >&2
+            exit 1
+          fi
+          if [[ "${head_sha}" != "${RUN_HEAD_SHA}" ]]; then
+            echo "Artifact head SHA does not match workflow run head SHA" >&2
+            exit 1
+          fi
+          current_head="$(gh pr view "${pr_number}" \
+            --repo "${{ github.repository }}" \
+            --json headRefOid --jq .headRefOid)"
+          if [[ "${current_head}" != "${head_sha}" ]]; then
+            echo "PR head moved since the review, skipping label" >&2
+            exit 0
+          fi
+          # If a new Copilot review has been requested meanwhile, this clean
+          # verdict is already outdated; do not (re-)add the label.
+          if gh api "repos/${{ github.repository }}/pulls/${pr_number}" \
+            --jq '.requested_reviewers[].login' | \
+            grep -qx 'copilot-pull-request-reviewer\[bot\]'; then
+            echo "Copilot re-review is pending, skipping label" >&2
+            exit 0
+          fi
+          gh pr edit "${pr_number}" \
+            --repo "${{ github.repository }}" \
+            --add-label "good-for-human"
+
+  remove-label-on-copilot-review-request:
+    name: Remove good-for-human label on Copilot re-review request
+    # A new Copilot review has been requested, so the previous clean verdict
+    # no longer reflects the state under review. pull_request_target is used
+    # so the token has write permissions also for fork PRs; it is safe here
+    # since no PR code is checked out or executed.
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.requested_reviewer.login == 'copilot-pull-request-reviewer[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "good-for-human"
+


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind enhancement

**What this PR does / why we need it**:

Copilot code review cannot approve PRs — it always submits "Comment" reviews, even when it finds nothing to flag. This makes it hard to see at a glance which PRs have already been cleared by Copilot and are ready for human review.

This PR adds automation that:
- Adds the `good-for-human` label when Copilot submits a review that generated no comments.
- Removes the label when a new Copilot review is requested, so the label always reflects Copilot's latest verdict.

Cross-repository (fork) PRs are fully supported: because `pull_request_review` events from forks only get a read-only `GITHUB_TOKEN`, the automation is split into an unprivileged detection workflow (`copilot-review-check.yml`) that uploads the PR number/head SHA as an artifact, and a privileged `workflow_run` consumer (`copilot-review-label.yml`) that validates the artifact and applies the label with `issues: write`. Label removal is triggered by `pull_request_target: review_requested` filtered to Copilot as the requested reviewer, which also works for forks.

**Special notes for your reviewer**:

- Uses only the built-in `GITHUB_TOKEN` and SHA-pinned `actions/upload-artifact` (consistent with the Scorecard hardening in #1556).
- No PR code is checked out or executed in the privileged workflow; the artifact contents are validated (numeric PR number, head SHA cross-checked against the triggering run and the current PR head, so a stale review cannot label a PR whose head has moved).
- The label is intentionally not removed on plain pushes: Copilot does not re-review automatically, so the label sticks to its last verdict until a re-review is explicitly requested.
- The `workflow_run` trigger only activates once the check workflow exists on the default branch, so end-to-end verification is only possible after merge.
- The `good-for-human` label already exists in the repository.

**Release note**:

```release-note
NONE
```