### PR TITLE
ci: disable Gemini code review

### DIFF
--- a/.gemini/config.yml
+++ b/.gemini/config.yml
@@ -2,7 +2,7 @@
 # as it's really noisy.
 have_fun: true
 code_review:
-  disable: false
+  disable: true
   comment_severity_threshold: MEDIUM
   max_review_comments: -1
   pull_request_opened:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind enhancement

**What this PR does / why we need it**:

Gemini Code Assist for GitHub is being sunset, so disable its automatic code review via `.gemini/config.yml`. Copilot is used as the AI reviewer for this repository instead.

**Special notes for your reviewer**:

Once the app is fully sunset, the `.gemini/` directory can be removed entirely and the GitHub App uninstalled from the org/repo.

**Release note**:

```release-note
NONE
```