### PR TITLE
hack: fail early when chart push has no credentials

### DIFF
--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -20,14 +20,30 @@ if [[ -z "${chart_oci_repo}" ]]; then
     chart_oci_repo="oci://${IMAGE_REGISTRY:-quay.io}/${IMAGE_REPO:-nmstate}"
 fi
 
+# Both podman and docker may have performed the registry login, and each of
+# them stores the credentials at a different location, so look them up at the
+# usual places instead of assuming one of them.
 helm_registry_config=${HELM_REGISTRY_CONFIG:-}
 if [[ -z "${helm_registry_config}" ]]; then
-    if [[ -n "${XDG_RUNTIME_DIR:-}" && -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]]; then
-        helm_registry_config="${XDG_RUNTIME_DIR}/containers/auth.json"
-    else
-        helm_registry_config="${HOME}/.docker/config.json"
-    fi
+    for candidate in \
+        "${REGISTRY_AUTH_FILE:-}" \
+        "${XDG_RUNTIME_DIR:-}/containers/auth.json" \
+        "/run/containers/$(id -u)/auth.json" \
+        "${HOME}/.config/containers/auth.json" \
+        "${DOCKER_CONFIG:-${HOME}/.docker}/config.json"; do
+        if [[ -n "${candidate}" && -f "${candidate}" ]]; then
+            helm_registry_config="${candidate}"
+            break
+        fi
+    done
 fi
+
+if [[ -z "${helm_registry_config}" ]]; then
+    echo "Error: no registry credentials found, log in to ${chart_oci_repo#oci://} or set HELM_REGISTRY_CONFIG" >&2
+    exit 1
+fi
+
+echo "Using registry credentials from ${helm_registry_config}"
 
 "${helm_bin}" package charts/kubernetes-nmstate \
     --version "${chart_version}" \


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

`push-chart.sh` falls back to `~/.docker/config.json` unconditionally, even when that file does not exist. Helm is then handed a nonexistent registry config, pushes anonymously and reports an opaque `401 Unauthorized`. This looks the credentials up at the usual podman and docker locations, uses the first file that exists, and bails out with a clear message when there is none.

**Special notes for your reviewer**:

:warning: This does **not** fix the failing release job, and I had originally claimed it did. In the CI image `~/.docker/config.json` is a symlink to `/root/containers/auth.json`, which is exactly where podman writes on login, so the credentials were already being picked up correctly. This PR is a diagnostics improvement only.

The actual release failure looks like a quay permissions issue: `quay.io/nmstate/kubernetes-nmstate` does not exist yet, and the release robot account presumably cannot create it in the `nmstate` org, which quay reports as a 401 on the blob HEAD. That needs fixing on the quay side, not here.

Feel free to close this if the extra check is not considered worth it.

**Release note**:

```release-note
NONE
```