### PR TITLE
charts: publish helm chart on Artifact Hub

### DIFF
--- a/charts/kubernetes-nmstate/Chart.yaml
+++ b/charts/kubernetes-nmstate/Chart.yaml
@@ -17,3 +17,12 @@ keywords:
   - networking
   - nmstate
   - NetworkManager
+annotations:
+  # Artifact Hub specific metadata, see
+  # https://artifacthub.io/docs/topics/annotations/helm/
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://nmstate.github.io/kubernetes-nmstate/
+    - name: Deployment with Helm
+      url: https://nmstate.github.io/kubernetes-nmstate/deployment/helm

--- a/charts/kubernetes-nmstate/README.md
+++ b/charts/kubernetes-nmstate/README.md
@@ -1,0 +1,104 @@
+# kubernetes-nmstate
+
+[kubernetes-nmstate](https://github.com/nmstate/kubernetes-nmstate) provides
+declarative node network configuration driven through the Kubernetes API. It
+uses [nmstate](https://nmstate.io) to configure networking on the cluster
+nodes and to report their current state.
+
+NetworkManager must be running on the nodes, it is the only external
+dependency.
+
+## Prerequisites
+
+- Helm >= 3.8 (OCI registry support)
+- NetworkManager running on the nodes
+
+## Install
+
+```shell
+helm install nmstate oci://quay.io/nmstate/kubernetes-nmstate \
+  --version <version> \
+  --namespace nmstate \
+  --create-namespace
+```
+
+This deploys the operator and, by default (`nmstate.enabled=true`), an
+`NMState` custom resource that makes the operator deploy the
+kubernetes-nmstate handler on all nodes.
+
+kubernetes-nmstate is a cluster singleton: only one release of this chart per
+cluster is supported. The chart creates cluster scoped resources with fixed
+names (such as the `nmstate-operator` ClusterRole and ClusterRoleBinding), so
+installing a second release would conflict with the first one.
+
+## Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `operator.image` | `""` | Operator image; empty means `quay.io/nmstate/kubernetes-nmstate-operator:<appVersion>` |
+| `operator.pullPolicy` | `IfNotPresent` | Operator image pull policy |
+| `handler.image` | `""` | Handler image; empty means `quay.io/nmstate/kubernetes-nmstate-handler:<appVersion>` |
+| `handler.pullPolicy` | `IfNotPresent` | Handler image pull policy |
+| `handler.namespace` | `nmstate` | Namespace the operator deploys the handler into |
+| `handler.prefix` | `""` | Optional name prefix for the handler resources deployed by the operator; when empty no `HANDLER_PREFIX` env is rendered |
+| `handler.imageEnvVar` | `RELATED_IMAGE_HANDLER_IMAGE` | Name of the operator env var carrying the handler image |
+| `plugin.image` | `""` | Console plugin image for downstream distributions; when empty no `PLUGIN_IMAGE` env is rendered |
+| `monitoring.namespace` | `monitoring` | Cluster monitoring namespace |
+| `createNamespace` | `false` | Emit a Namespace object for the release namespace (use `helm install --create-namespace` instead) |
+| `nmstate.enabled` | `true` | Create the `NMState` custom resource (named `nmstate`) at install time |
+| `nmstate.spec` | `{}` | Passthrough for `NMState` spec fields (`nodeSelector`, `tolerations`, ...) |
+
+## Usage
+
+Configure node networking by creating a `NodeNetworkConfigurationPolicy`:
+
+```yaml
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: linux-bridge
+spec:
+  desiredState:
+    interfaces:
+    - name: br1
+      description: Linux bridge with eth1 as a port
+      type: linux-bridge
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: eth1
+```
+
+The current state of each node is reported through `NodeNetworkState`
+objects, and the result of applying a policy through
+`NodeNetworkConfigurationEnactment` objects.
+
+## Upgrade
+
+Helm does not modify custom resource definitions shipped in the chart's
+`crds/` directory on upgrade, so apply the NMState CRD manually first:
+
+```shell
+kubectl apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/<version>/nmstate.io_nmstates.yaml
+helm upgrade nmstate oci://quay.io/nmstate/kubernetes-nmstate \
+  --version <version> \
+  --namespace nmstate
+```
+
+## Uninstall
+
+```shell
+helm uninstall nmstate --namespace nmstate --wait
+```
+
+## Documentation
+
+- [Deployment guide](https://nmstate.github.io/kubernetes-nmstate/deployment/helm)
+- [User guide](https://nmstate.github.io/kubernetes-nmstate/user-guide/)
+- [Examples](https://github.com/nmstate/kubernetes-nmstate/tree/main/docs/examples)

--- a/docs/content/developer-guide/105-advanced.md
+++ b/docs/content/developer-guide/105-advanced.md
@@ -34,6 +34,28 @@ The kubernetes-nmstate project uses the following CI infrastructure:
 - [Prow](https://prow.apps.ovirt.org/) - Main CI system
 - [Flakefinder](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/nmstate/kubernetes-nmstate/index.html) - Flaky test detection
 
+## Helm chart publishing
+
+The Helm chart is published to `quay.io/nmstate/kubernetes-nmstate` as an OCI
+artifact by `make push-chart`, which the release job runs for every tag.
+
+The chart is also listed on
+[Artifact Hub](https://artifacthub.io/packages/helm/kubernetes-nmstate/kubernetes-nmstate),
+which indexes new chart versions on its own. It reads the repository metadata
+from `hack/artifacthub-repo.yml`, published to the same chart repository under
+the special `artifacthub.io` tag. That file declares the repository owners, so
+it is kept under review here rather than only in the registry. It changes
+rarely and is pushed by hand, from the `hack` directory:
+
+```shell
+oras push quay.io/nmstate/kubernetes-nmstate:artifacthub.io \
+  --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+  artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+```
+
+The currently published copy can be retrieved with `oras pull` on the same
+reference, to check it still matches this repository.
+
 ## Code Structure Notes
 
 - Controllers use controller-runtime reconciliation pattern

--- a/hack/artifacthub-repo.yml
+++ b/hack/artifacthub-repo.yml
@@ -1,14 +1,11 @@
 # Artifact Hub repository metadata file.
 #
-# Artifact Hub reads it from the chart OCI repository under the special
-# "artifacthub.io" tag. It changes rarely, so it is pushed by hand, from this
-# directory, so that the layer is titled "artifacthub-repo.yml":
+# It declares who owns the Artifact Hub repository, so it is kept here under
+# review. Artifact Hub reads it from the chart OCI repository, under the
+# special "artifacthub.io" tag, where it is pushed by hand. See
+# docs/content/developer-guide/105-advanced.md for the publishing command.
 #
-#   oras push quay.io/nmstate/kubernetes-nmstate:artifacthub.io \
-#     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
-#     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
-#
-# See https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
+# https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
 #
 # The repositoryID is shown on the repository card in the Artifact Hub control
 # panel. Setting it enables the "Verified publisher" flag.

--- a/hack/artifacthub-repo.yml
+++ b/hack/artifacthub-repo.yml
@@ -1,0 +1,19 @@
+# Artifact Hub repository metadata file.
+#
+# Artifact Hub reads it from the chart OCI repository under the special
+# "artifacthub.io" tag. It changes rarely, so it is pushed by hand:
+#
+#   oras push quay.io/nmstate/kubernetes-nmstate:artifacthub.io \
+#     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+#     hack/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+#
+# See https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
+#
+# The repositoryID is shown on the repository card in the Artifact Hub control
+# panel once the repository has been added. Setting it enables the "Verified
+# publisher" flag. It can be left empty for an ownership claim, which only
+# needs the owners section.
+repositoryID: ""
+owners:
+  - name: Enrique Llorente
+    email: ellorent@redhat.com

--- a/hack/artifacthub-repo.yml
+++ b/hack/artifacthub-repo.yml
@@ -1,19 +1,18 @@
 # Artifact Hub repository metadata file.
 #
 # Artifact Hub reads it from the chart OCI repository under the special
-# "artifacthub.io" tag. It changes rarely, so it is pushed by hand:
+# "artifacthub.io" tag. It changes rarely, so it is pushed by hand, from this
+# directory, so that the layer is titled "artifacthub-repo.yml":
 #
 #   oras push quay.io/nmstate/kubernetes-nmstate:artifacthub.io \
 #     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
-#     hack/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+#     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 #
 # See https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
 #
 # The repositoryID is shown on the repository card in the Artifact Hub control
-# panel once the repository has been added. Setting it enables the "Verified
-# publisher" flag. It can be left empty for an ownership claim, which only
-# needs the owners section.
-repositoryID: ""
+# panel. Setting it enables the "Verified publisher" flag.
+repositoryID: 51e2f12f-cb13-4ba5-b91d-b4cfe63e49bb
 owners:
   - name: Enrique Llorente
     email: ellorent@redhat.com

--- a/hack/release-notes.tmpl
+++ b/hack/release-notes.tmpl
@@ -16,6 +16,24 @@
 
 # Installation
 
+## With Helm
+
+Install the operator and the handler with a single command, using
+[Helm](https://helm.sh) (>= 3.8):
+
+```
+helm install nmstate oci://quay.io/nmstate/kubernetes-nmstate \
+  --version {{ slice .CurrentRevision 1 }} \
+  --namespace nmstate \
+  --create-namespace
+```
+
+This deploys the operator and, by default (`nmstate.enabled=true`), an
+`NMState` custom resource that makes the operator deploy the
+kubernetes-nmstate handler on all nodes.
+
+## With manifests
+
 First, install kubernetes-nmstate operator:
 
 ```


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind enhancement

**What this PR does / why we need it**:

The chart is published to `quay.io/nmstate/kubernetes-nmstate` since v0.87.0, but nothing tells users about it and the chart is not discoverable. This adds the missing pieces:

1. **Helm instructions in the release notes** (`hack/release-notes.tmpl`). The generated notes only documented the manifest based installation. Rendered output:

    ```
    ## With Helm

    helm install nmstate oci://quay.io/nmstate/kubernetes-nmstate \
      --version 0.87.0 \
      --namespace nmstate \
      --create-namespace
    ```

    The helm path does not need the separate `NMState` CR step, since the chart creates it by default (`nmstate.enabled=true`).

2. **A chart README** (`charts/kubernetes-nmstate/README.md`). Artifact Hub renders the chart README as the package page body, and the chart did not ship one, so the page would be empty. It covers install, values, usage, upgrade and uninstall.

3. **Artifact Hub repository metadata** (`hack/artifacthub-repo.yml`), carrying the ownership information.

**Special notes for your reviewer**:

Listing the chart on Artifact Hub is a **manual step** that still has to be done: sign in at artifacthub.io, create an `nmstate` organization and add a repository of kind *Helm charts* with the url `oci://quay.io/nmstate/kubernetes-nmstate`. From then on new chart versions are indexed automatically. This PR only provides what the repository side has to contribute.

Two consequences worth knowing:

- `repositoryID` in `hack/artifacthub-repo.yml` is empty on purpose, the value only exists once the repository has been added. Filling it in later enables the `Verified publisher` flag. The `owners` section alone is enough for the ownership claim.
- The README will only show up on Artifact Hub from the next release on, since Artifact Hub reads it from the chart package and `0.87.0` is already published without it.

The metadata file is pushed by hand with `oras` (the command is in the file header). It changes rarely, so no release automation was added for it, and the chart push itself is unchanged.

For reference, MetalLB is set up the same way: registered manually, `artifacthub-repo.yml` with `repositoryID` plus `owners`, chart README, and no `artifacthub.io/*` annotations, which is why none were added here.

Verified with `make lint-helm` and `make whitespace-check`, and by packaging the chart to confirm `README.md` ends up inside the tarball. The rendered release notes were checked against the v0.87.0 ones produced by CI: same changelog body, only the Installation section differs.

**Release note**:

```release-note
NONE
```