### PR TITLE
hack: bump github-release to v0.11.0

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -7,7 +7,7 @@ old_version=$(hack/versions.sh -2)
 new_version=$(hack/versions.sh -1)
 gh_organization=nmstate
 gh_repo=kubernetes-nmstate
-github_release_cmd="go run github.com/github-release/github-release@v0.10.0"
+github_release_cmd="go run github.com/github-release/github-release@v0.11.0"
 
 MANIFESTS_DIR=${MANIFESTS_DIR:-build/_output/manifests}
 


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

/kind bug

**What this PR does / why we need it**:

The release job fails when creating the GitHub release, after the images and the chart have already been pushed:

```
go run github.com/github-release/github-release@v0.10.0 release ...
go: finding module for package github.com/kevinburke/rest/restclient
/home/prow/go/pkg/mod/github.com/github-release/github-release@v0.10.0/github/github.go:14:2: no matching versions for query "latest"
make: *** [Makefile:286: release] Error 1
```

github-release v0.10.0 ships a go.mod with no `require` directive at all, so every dependency is resolved with the `latest` query at build time. Together with `GOPROXY=direct` (Makefile:74) that resolution goes to the VCS, and since `github.com/kevinburke/rest` moved its module path to `/v2` there is no v1 version left to resolve.

Nothing changed on our side, this broke on its own when the dependency went v2. v0.86.0 released fine in March.

v0.11.0 pins all four dependencies, including `github.com/kevinburke/rest v0.0.0-20250718180114-1a15e4f2364f`, so no `latest` query is left and it cannot drift again.

Failing build: https://storage.googleapis.com/kubevirt-prow/logs/release-kubernetes-nmstate/2082399085196742656/build-log.txt

**Special notes for your reviewer**:

Reproduced and verified locally under the same conditions the job uses:

```
$ GOPROXY=direct GOFLAGS=-mod=mod go run github.com/github-release/github-release@v0.10.0 --version
no matching versions for query "latest"          # fails

$ GOPROXY=direct GOFLAGS=-mod=mod go run github.com/github-release/github-release@v0.11.0 --version
github-release v0.11.0                           # works
```

The command line flags used in `hack/release.sh` (`-u -r -R -t -n -f -d`) are identical between v0.10.0 and v0.11.0 for the `release`, `upload` and `download` subcommands, so no call site changes are needed. v0.10.1 was skipped, it still carries the bare go.mod.

The v0.87.0 GitHub release was created by hand, so this unblocks v0.88.0 rather than v0.87.0.

Note `hack/render-release-notes.sh` uses the same `go run <tool>@<version>` pattern for `k8s.io/release/cmd/release-notes@v0.13.0`. It resolves fine today, but it carries the same latent risk, worth keeping in mind.

**Release note**:

```release-note
NONE
```