### PR TITLE
operator: add startupProbe to nmstate-operator deployment

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -380,12 +380,18 @@ spec:
                   value: nmstate
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: IfNotPresent
+                startupProbe:
+                  httpGet:
+                    path: /readyz
+                    port: healthprobe
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 18
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:
                     path: /healthz
                     port: healthprobe
-                  initialDelaySeconds: 10
                   periodSeconds: 10
                   successThreshold: 1
                   timeoutSeconds: 1
@@ -398,7 +404,6 @@ spec:
                   httpGet:
                     path: /readyz
                     port: healthprobe
-                  initialDelaySeconds: 10
                   periodSeconds: 10
                   successThreshold: 1
                   timeoutSeconds: 1

--- a/charts/kubernetes-nmstate/templates/operator.yaml
+++ b/charts/kubernetes-nmstate/templates/operator.yaml
@@ -54,11 +54,17 @@ spec:
             capabilities:
               drop:
               - ALL
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /readyz
               port: healthprobe
             initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthprobe
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -67,7 +73,6 @@ spec:
             httpGet:
               path: /healthz
               port: healthprobe
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
## What this PR does

Adds a `startupProbe` to the `nmstate-operator` container (helm chart template + OLM bundle CSV) and removes `initialDelaySeconds` from its readiness/liveness probes, mirroring the pattern already applied to the webhook and metrics operands.

## Why

The operator container currently gets only ~40s to bind `:8081` (`initialDelaySeconds=10`, `periodSeconds=10`, `failureThreshold=3`) before the liveness probe kills it. In environments where startup is slow — observed in the field at 50–75s on clusters with restrictive network policies and a cluster-wide proxy delaying API/DNS access during initialization — the operator never survives long enough to become ready and enters a permanent CrashLoopBackOff. Because the deployment is OLM-managed, any manual probe adjustment is reverted by the CSV reconciliation, so there is no persistent user-side workaround.

The startupProbe (`failureThreshold=18`, `periodSeconds=10`) gives the container up to 3 minutes to initialize; once it passes, the regular probes take over without initial delay.

Downstream reference: https://issues.redhat.com/browse/OCPBUGS-94072 (the previous fix covered only the webhook/metrics operands, not the operator itself).

---
This PR was prepared with AI assistance. Please verify before acting on it.