### PR TITLE
netpol: allow DNS egress to openshift-dns on port 5353

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -147,6 +147,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -183,6 +194,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -201,6 +223,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---


### PR DESCRIPTION
## What this PR does

Adds an OpenShift-gated egress rule (UDP/TCP **5353** towards the `openshift-dns` namespace) to the three `allow-*-egress-dns` NetworkPolicies. The existing port-53 rule is kept for vanilla Kubernetes.

## Why

On OpenShift the `dns-default` service maps port 53 to CoreDNS pods listening on **5353**, and OVN-Kubernetes evaluates egress NetworkPolicy **after** service DNAT. The current port-53 rule therefore never matches real DNS traffic — DNS from the webhook, metrics and operator pods is silently dropped despite the allow policy. This is the documented OpenShift NetworkPolicy pattern for DNS access.

Field impact: blocked DNS caused 50–75s startup stalls of nmstate pods on a proxied cluster, which combined with tight liveness probes resulted in permanent CrashLoopBackOff (downstream https://issues.redhat.com/browse/OCPBUGS-94072).

The `IsOpenShift` render flag is already passed to this template (`nmstate_controller.go`), and is already used in the same file for the cert-manager policy.

Related: #1569

---
This PR was prepared with AI assistance. Please verify before acting on it.