### PR TITLE
Makefile: add optional Makefile.overrides include hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,3 +343,9 @@ olm-push: bundle-push index-push
 	tools \
 	bundle \
 	bundle-build
+
+# Optional project-level overrides. Downstream distributions (for example
+# openshift/kubernetes-nmstate) ship a Makefile.overrides with extra targets
+# and variable overrides so they do not need to patch this file. A missing
+# file is silently ignored (same pattern as istio and cilium).
+-include Makefile.overrides


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE?**:

> /kind enhancement

**What this PR does / why we need it**:

Adds a trailing `-include Makefile.overrides` to the `Makefile`. Downstream distributions (openshift/kubernetes-nmstate) currently carry 8 patches against this file for extra targets (`ocp-*`, `check-ocp-bundle`) and variable overrides (`HANDLER_IMAGE_ENV_VAR`, `PLUGIN_IMAGE`). Those patches conflict on nearly every upstream sync and have clobbered upstream content in the past (#1335 had to be restored by hand). With this hook they move into a separate `Makefile.overrides` that upstream never touches.

The include is placed after all defaults and the `.PHONY` block so an override file can both reassign variables and reference upstream ones (`$(HELM)`, `$(OPERATOR_SDK)`, `$(MANIFESTS_DIR)`).

Same pattern as istio (`-include Makefile.overrides.mk`) and cilium (`-include Makefile.override`).

Context: openshift/kubernetes-nmstate#763.

**Special notes for your reviewer**:

- `-include` is silent when the file is missing; no `Makefile.overrides` is added upstream, so `make -n check` output is byte-identical before and after this change.
- Verified a throwaway `Makefile.overrides` can override a variable and add a target that uses `$(HELM)`.
- Intentionally **not** added to `.gitignore`: forks are expected to commit the file.

**Release note**:

```release-note
NONE
```